### PR TITLE
Add event processing hook for using stumptray (clx-xembed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.o
 *.*fsl
 *~
+*.swp
+\#*#
 configure
 config.log
 config.status

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -41,6 +41,7 @@
           *place-window-hook*
           *start-hook*
           *internal-loop-hook*
+          *event-processing-hook*
           *focus-frame-hook*
           *new-frame-hook*
           *split-frame-hook*
@@ -192,6 +193,10 @@ window group and frame")
 
 (defvar *internal-loop-hook* '()
   "A hook called inside stumpwm's inner loop.")
+
+(defvar *event-processing-hook* '()
+  "A hook called inside stumpwm's inner loop, before the default event
+  processing takes place. This hook is run inside (with-event-queue ...).")
 
 (defvar *focus-frame-hook* '()
   "A hook called when a frame is given focus. The hook functions are

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1373,6 +1373,7 @@ $$$ *key-press-hook*
 $$$ *root-click-hook*
 $$$ *mode-line-click-hook*
 $$$ *urgent-window-hook*
+$$$ *event-processing-hook*
 
 @node Modules, Hacking, Hooks, Top
 @chapter Modules


### PR DESCRIPTION
clx-xembed provides X11 xembed extension, which makes it possible pure lisp tray window (notification area). Some programs (e.g. skype) require that tray.
