### PR TITLE
Surfraw fails when there are local elvi.

### DIFF
--- a/contrib/surfraw.lisp
+++ b/contrib/surfraw.lisp
@@ -82,7 +82,7 @@
   "Use SURFRAW to surf the net; reclaim heathen lands."
   (check-type engine string)
   (check-type search string)
-  (run-shell-command (concat "exec surfraw -g " engine " " search)))
+  (run-shell-command (concat "exec surfraw -g " engine " '" search "'")))
 
 ;;; Bookmarks
 


### PR DESCRIPTION
Surfraw introduces global and local headers for elvi:

   GLOBAL ELVI:
  acronym         -- Look for acronyms
  definitions (www.acronymfinder.com)
  ...
   LOCAL ELVI:
  oed     -- Search OED (www.oed.com)

Surfraw.lisp isn't prepared for the local header and fails.
