### PR TITLE
fixed sbcl setup problems

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -22,9 +22,7 @@
 
 (require 'asdf)
 (asdf:oos 'asdf:load-op 'stumpwm)
-
-#-ecl
-(stumpwm:set-contrib-dir "@CONTRIB_DIR@")
+#-ecl (stumpwm:set-contrib-dir "@CONTRIB_DIR@")
 
 #+sbcl
 (sb-ext:save-lisp-and-die "stumpwm" :toplevel (lambda ()


### PR DESCRIPTION
I am working on a Ubuntu 13.04 64 Bit system with SBCL 1.1.10 (compiled from source) and I couldn't setup stumpwm. The main problem was, that it could't find `stumpwm` in the `make-image.lisp` phase.

The important change, to make it build the `stumpwm` file, was to add `--load ./stumpwm.asd` to the `Makefile`.

Thie patch worked on my system... I am not sure if this will help others, but still, here is my pull request.
