### PR TITLE
Fixed 'STUMPWM not found' when building

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,11 +6,12 @@ ccl_BUILDOPTS=--load ./make-image.lisp
 ecl_BUILDOPTS=-shell ./make-image.lisp
 lw_BUILDOPTS=-build ./make-image.lisp
 
-clisp_INFOOPTS=-K full -on-error exit -x "(require 'asdf) (asdf:oos 'asdf:load-op :stumpwm) (load (compile-file \"manual.lisp\")) (stumpwm::generate-manual) (ext:exit)"
-sbcl_INFOOPTS=--eval "(progn (require 'asdf) (require 'stumpwm) (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
-ccl_INFOOPTS=--eval "(progn (require 'asdf) (require 'stumpwm))" --load manual.lisp --eval "(progn (stumpwm::generate-manual) (quit))"
-ecl_INFOOPTS=-eval "(progn (require 'asdf) (require 'stumpwm) (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (ext:quit))"
-lw_INFOOPTS=-eval "(progn (require 'asdf) (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (lw:quit))"
+asdf_registry_add=(push \#P\"@STUMPWM_ASDF_DIR@\" asdf:*central-registry*)
+clisp_INFOOPTS=-K full -on-error exit -x "(require 'asdf) ${asdf_registry_add} (asdf:oos 'asdf:load-op :stumpwm) (load (compile-file \"manual.lisp\")) (stumpwm::generate-manual) (ext:exit)"
+sbcl_INFOOPTS=--eval "(progn (require 'asdf) ${asdf_registry_add} (require 'stumpwm) (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
+ccl_INFOOPTS=--eval "(progn (require 'asdf) ${asdf_registry_add} (require 'stumpwm))" --load manual.lisp --eval "(progn (stumpwm::generate-manual) (quit))"
+ecl_INFOOPTS=-eval "(progn (require 'asdf) ${asdf_registry_add} (require 'stumpwm) (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (ext:quit))"
+lw_INFOOPTS=-eval "(progn (require 'asdf) ${asdf_registry_add} (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (lw:quit))"
 
 datarootdir = @datarootdir@
 prefix=@prefix@

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_INIT(Stump Window Manager, esyscmd(grep :version stumpwm.asd | cut -d\" -f2 |
 AC_SUBST(CONTRIB_DIR)
 AC_SUBST(LISP_PROGRAM)
 AC_SUBST(LISP)
+AC_SUBST(STUMPWM_ASDF_DIR)
 
 # Checks for programs.
 AC_ARG_WITH(lisp,    [  --with-lisp=IMPL        use the specified lisp (sbcl, clisp, ccl or ecl)], LISP=$withval, LISP="any")
@@ -19,6 +20,8 @@ AC_ARG_WITH(lw,      [  --with-lw=PATH          specify location of lispworks], 
 AC_ARG_WITH(contrib-dir,
                      [  --with-contrib-dir=PATH specify location of contrib modules],
                      CONTRIB_DIR=$withval, CONTRIB_DIR="`pwd`/contrib")
+
+STUMPWM_ASDF_DIR="`pwd`/"
 
 if test -x "$SBCL_PATH"; then
    SBCL=$SBCL_PATH

--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -21,6 +21,7 @@
            (lisp-implementation-type))))
 
 (require 'asdf)
+(push #P"@STUMPWM_ASDF_DIR@" asdf:*central-registry*)
 (asdf:oos 'asdf:load-op 'stumpwm)
 #-ecl (stumpwm:set-contrib-dir "@CONTRIB_DIR@")
 


### PR DESCRIPTION
Added `STUMPWM_ASDF_DIR` in `configure.ac` to store the current directory
where stumpwm is being configured. This variable is used on both `Makefile.in`
and `make-image.lisp.in` to push the directory to `asdf:*central-registry*`
before trying to load the stumpwm package.
