### PR TITLE
Fixed 'STUMPWM' not foun when trying to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ stumpwm
 stumpwm.info
 TAGS
 make-image.lisp
+load-stumpwm.lisp
 version.lisp
 stumpwm-*.tgz
 stumpwm-*.tgz.sig

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,10 +6,10 @@ ccl_BUILDOPTS=--load ./make-image.lisp
 ecl_BUILDOPTS=-shell ./make-image.lisp
 lw_BUILDOPTS=-build ./make-image.lisp
 
-clisp_INFOOPTS=-K full -on-error exit -x "(require 'asdf) (asdf:oos 'asdf:load-op :stumpwm) (load (compile-file \"manual.lisp\")) (stumpwm::generate-manual) (ext:exit)"
-sbcl_INFOOPTS=--eval "(progn (require 'asdf) (require 'stumpwm) (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
-ccl_INFOOPTS=--eval "(progn (require 'asdf) (require 'stumpwm))" --load manual.lisp --eval "(progn (stumpwm::generate-manual) (quit))"
-ecl_INFOOPTS=-eval "(progn (require 'asdf) (require 'stumpwm) (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (ext:quit))"
+clisp_INFOOPTS=-K full -on-error exit -x "(load (compile-file \"load-stumpwm.lisp\")) (load (compile-file \"manual.lisp\")) (stumpwm::generate-manual) (ext:exit)"
+sbcl_INFOOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
+ccl_INFOOPTS=--eval "(load \"load-stumpwm.lisp\")" --load manual.lisp --eval "(progn (stumpwm::generate-manual) (quit))"
+ecl_INFOOPTS=-eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (ext:quit))"
 lw_INFOOPTS=-eval "(progn (require 'asdf) (load \"manual.lisp\"))" -eval "(progn (stumpwm::generate-manual) (lw:quit))"
 
 datarootdir = @datarootdir@

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_INIT(Stump Window Manager, esyscmd(grep :version stumpwm.asd | cut -d\" -f2 |
 AC_SUBST(CONTRIB_DIR)
 AC_SUBST(LISP_PROGRAM)
 AC_SUBST(LISP)
+AC_SUBST(STUMPWM_ASDF_DIR)
 
 # Checks for programs.
 AC_ARG_WITH(lisp,    [  --with-lisp=IMPL        use the specified lisp (sbcl, clisp, ccl or ecl)], LISP=$withval, LISP="any")
@@ -19,6 +20,8 @@ AC_ARG_WITH(lw,      [  --with-lw=PATH          specify location of lispworks], 
 AC_ARG_WITH(contrib-dir,
                      [  --with-contrib-dir=PATH specify location of contrib modules],
                      CONTRIB_DIR=$withval, CONTRIB_DIR="`pwd`/contrib")
+
+STUMPWM_ASDF_DIR="`pwd`"
 
 if test -x "$SBCL_PATH"; then
    SBCL=$SBCL_PATH
@@ -114,3 +117,4 @@ fi
 # Checks for library functions.
 AC_OUTPUT(Makefile)
 AC_OUTPUT(make-image.lisp)
+AC_OUTPUT(load-stumpwm.lisp)

--- a/load-stumpwm.lisp.in
+++ b/load-stumpwm.lisp.in
@@ -1,0 +1,8 @@
+(require 'asdf)
+
+(asdf:initialize-source-registry
+ '(:source-registry
+   (:directory "@STUMPWM_ASDF_DIR@")
+   :inherit-configuration))
+
+(asdf:oos 'asdf:load-op 'stumpwm)

--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -20,8 +20,7 @@
     (error "Quicklisp must be installed in order to build StumpWM with ~S."
            (lisp-implementation-type))))
 
-(require 'asdf)
-(asdf:oos 'asdf:load-op 'stumpwm)
+(load "load-stumpwm.lisp")
 #-ecl (stumpwm:set-contrib-dir "@CONTRIB_DIR@")
 
 #+sbcl


### PR DESCRIPTION
Added STUMPWM_ASDF_DIR in configure.ac to store the current directory
where stumpwm is being configured. This variable is used on
`load-stumpwm.lisp.in`, a new file created with the sole purpose of
bootstrap the loading of `stumpwm.asd`, using ASDF3 config API.

Both `Makefile.in` and `make-image.lisp.in` were modified to
accommodate this change.
