### PR TITLE
Allow insertion of TAB character when editing Makefiles

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,2 @@
-((nil . ((indent-tabs-mode . nil))))
+((nil . ((indent-tabs-mode . nil)))
+ (makefile-mode . ((indent-tabs-mode . t))))


### PR DESCRIPTION
Fixed `.dir-locals.el` to allow insertion of TAB character when
editing makefiles.
