### PR TITLE
Add configuring of the grabbed pointer

### DIFF
--- a/core.lisp
+++ b/core.lisp
@@ -101,15 +101,13 @@
 (defun grab-pointer (screen)
   "Grab the pointer and set the pointer shape."
   (incf *grab-pointer-count*)
-  (let* ((white (xlib:make-color :red 1.0 :green 1.0 :blue 1.0))
-         (black (xlib:make-color :red 0.0 :green 0.0 :blue 0.0))
-         (cursor-font (xlib:open-font *display* "cursor"))
+  (let* ((cursor-font (xlib:open-font *display* *grab-pointer-font*))
          (cursor (xlib:create-glyph-cursor :source-font cursor-font
-                                           :source-char 64
+                                           :source-char *grab-pointer-character*
                                            :mask-font cursor-font
-                                           :mask-char 65
-                                           :foreground black
-                                           :background white)))
+                                           :mask-char *grab-pointer-character-mask*
+                                           :foreground *grab-pointer-foreground*
+                                           :background *grab-pointer-background*)))
     (xlib:grab-pointer (screen-root screen) nil :owner-p nil
                        :cursor cursor)))
 

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -150,8 +150,27 @@ be an integer.")
 (defvar *message-window-timer* nil
   "Keep track of the timer that hides the message window.")
 
+;;; Grabbed pointer
+
 (defvar *grab-pointer-count* 0
-  "The number of times the pointer has been grabbed")
+  "The number of times the pointer has been grabbed.")
+
+(defvar *grab-pointer-font* "cursor"
+  "The font used for the grabbed pointer.")
+
+(defvar *grab-pointer-character* 64
+  "ID of a character used for the grabbed pointer.")
+
+(defvar *grab-pointer-character-mask* 65
+  "ID of a character mask used for the grabbed pointer.")
+
+(defvar *grab-pointer-foreground*
+  (xlib:make-color :red 0.0 :green 0.0 :blue 0.0)
+  "The foreground color of the grabbed pointer.")
+
+(defvar *grab-pointer-background*
+  (xlib:make-color :red 1.0 :green 1.0 :blue 1.0)
+  "The background color of the grabbed pointer.")
 
 ;;; Hooks
 


### PR DESCRIPTION
I put variables in `primitives.lisp` because `*grab-pointer-count*` was already there.  If it's not a suitable place, i can move them.
