### PR TITLE
Fix bug in enabling the mode-line

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -527,7 +527,7 @@ critical."
       (if (head-mode-line head)
           (when format
             (setf (mode-line-format (head-mode-line head)) format))
-          (toggle-mode-line screen head (or format *screen-mode-line-format*)))
+          (toggle-mode-line screen head (or format '*screen-mode-line-format*)))
       (when (head-mode-line head)
         (toggle-mode-line screen head))))
 


### PR DESCRIPTION
I beleive it's a (tiny but still) bug.  For details, see http://lists.gnu.org/archive/html/stumpwm-devel/2013-08/msg00004.html
