### PR TITLE
bugfix for shift modifier setting in xwin-grab-keys.

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -613,30 +613,36 @@ and bottom_end_x."
     (xwin-hide w)))
 
 (defun xwin-grab-keys (win screen)
-  (labels ((grabit (w key)
+  (labels ((add-shift-modifier (key)
+             ;; don't butcher the caller's structure
+             (let ((key (copy-structure key)))
+               (setf (key-shift key) t)
+               key))
+           (grabit (w key)
              (loop for code in (multiple-value-list (xlib:keysym->keycodes *display* (key-keysym key))) do
-               ;; some keysyms aren't mapped to keycodes so just ignore them.
-               (when code
-                 ;; Some keysyms, such as upper case letters, need the
-                 ;; shift modifier to be set in order to grab properly.
-                 (when (and (not (eql (key-keysym key) (xlib:keycode->keysym *display* code 0)))
-                            (eql (key-keysym key) (xlib:keycode->keysym *display* code 1)))
-                   ;; don't butcher the caller's structure
-                   (setf key (copy-structure key)
-                         (key-shift key) t))
-                 (xlib:grab-key w code
-                                :modifiers (x11-mods key) :owner-p t
-                                :sync-pointer-p nil :sync-keyboard-p nil)
-                 ;; Ignore capslock and numlock by also grabbing the
-                 ;; keycombos with them on.
-                 (xlib:grab-key w code :modifiers (x11-mods key nil t) :owner-p t
-                                :sync-keyboard-p nil :sync-keyboard-p nil)
-                 (when (modifiers-numlock *modifiers*)
-                   (xlib:grab-key w code
-                                  :modifiers (x11-mods key t nil) :owner-p t
-                                  :sync-pointer-p nil :sync-keyboard-p nil)
-                   (xlib:grab-key w code :modifiers (x11-mods key t t) :owner-p t
-                                  :sync-keyboard-p nil :sync-keyboard-p nil))))))
+                ;; some keysyms aren't mapped to keycodes so just ignore them.
+                  (when code
+                    ;; Some keysyms, such as upper case letters, need the
+                    ;; shift modifier to be set in order to grab properly.
+                    (let ((key
+                           (if (and (not (eql (key-keysym key) (xlib:keycode->keysym *display* code 0)))
+                                    (eql (key-keysym key) (xlib:keycode->keysym *display* code 1)))
+                               (add-shift-modifier key)
+                               key)))
+                      
+                      (xlib:grab-key w code
+                                     :modifiers (x11-mods key) :owner-p t
+                                     :sync-pointer-p nil :sync-keyboard-p nil)
+                      ;; Ignore capslock and numlock by also grabbing the
+                      ;; keycombos with them on.
+                      (xlib:grab-key w code :modifiers (x11-mods key nil t) :owner-p t
+                                     :sync-keyboard-p nil :sync-keyboard-p nil)
+                      (when (modifiers-numlock *modifiers*)
+                        (xlib:grab-key w code
+                                       :modifiers (x11-mods key t nil) :owner-p t
+                                       :sync-pointer-p nil :sync-keyboard-p nil)
+                        (xlib:grab-key w code :modifiers (x11-mods key t t) :owner-p t
+                                       :sync-keyboard-p nil :sync-keyboard-p nil)))))))
     (dolist (map (dereference-kmaps (top-maps screen)))
       (dolist (i (kmap-bindings map))
         (grabit win (binding-key i))))))


### PR DESCRIPTION
The code responsible for adding the shift modifier to the keys that need it in the xwin-grab-keys function setfs key, causing it to change for all codes looped over.
This was preventing me from being able to set the super key as the prefix key, as Super_L has two associated codes, the first of which (206) causes the shift modifier to be added to key, which is then still present for the second code (133) which should not have the shift modifier added.

This change alters the code so that key is rebound with a let rather than changed with setf, preventing the above scenario.
