### PR TITLE
Add variable to disable messages indicating window placement

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -27,6 +27,7 @@
 
 (export '(*suppress-abort-messages*
           *suppress-frame-indicator*
+          *suppress-window-placement-indicator*
           *timeout-wait*
           *timeout-frame-indicator-wait*
           *frame-indicator-text*
@@ -147,6 +148,10 @@ be an integer.")
 
 (defvar *suppress-frame-indicator* nil
   "Set this to T if you never want to see the frame indicator.")
+
+(defvar *suppress-window-placement-indicator* nil
+  "Set to T if you never want to see messages that windows were placed
+  according to rules.")
 
 (defvar *message-window-timer* nil
   "Keep track of the timer that hides the message window.")

--- a/window.lisp
+++ b/window.lisp
@@ -706,7 +706,8 @@ needed."
       (when placement-data
         (if (getf placement-data :raise)
           (switch-to-group (window-group window))
-          (message "Placing window ~a in group ~a" (window-name window) (group-name (window-group window))))
+          (unless *suppress-window-placement-indicator*
+            (message "Placing window ~a in group ~a" (window-name window) (group-name (window-group window)))))
         (apply 'run-hook-with-args *place-window-hook* window (window-group window) placement-data)))
     ;; must call this after the group slot is set for the window.
     (grab-keys-on-window window)


### PR DESCRIPTION
When a window is placed by a rule that had :raise nil, a message is
displayed. This patch introduces the
variable _suppress-window-placement-indicator_ that if set to t will
never display these messages.
