### PR TITLE
Fix java windows not changing focus border color

### DIFF
--- a/screen.lisp
+++ b/screen.lisp
@@ -155,7 +155,9 @@ identity with a range check."
     ;;(format t "FOCUS TO: ~a ~a~%" window (window-xwin window))
     ;;(format t "FOCUS BEFORE: ~a~%" (multiple-value-list (xlib:input-focus *display*)))
     ;;(format t "FOCUS RET: ~a~%" (xlib:set-input-focus *display* (window-xwin window) :POINTER-ROOT))
-    (xlib:set-input-focus *display* (window-xwin window) :POINTER-ROOT)
+    (let ((hints (xlib:wm-hints (window-xwin window))))
+         (when (or (null hints) (eq (xlib:wm-hints-input hints) :on))
+           (xlib:set-input-focus *display* (window-xwin window) :POINTER-ROOT)))
     ;;(xlib:display-finish-output *display*)
     ;;(format t "FOCUS IS: ~a~%" (multiple-value-list (xlib:input-focus *display*)))
     (xlib:change-property (screen-root screen) :_NET_ACTIVE_WINDOW

--- a/window.lisp
+++ b/window.lisp
@@ -842,12 +842,10 @@ needed."
       ((and *current-event-time* 
             (member :WM_TAKE_FOCUS (xlib:wm-protocols xwin) :test #'eq))
        (raise-window window)
-       (let ((hints (xlib:wm-hints xwin)))
-         (when (or (null hints) (eq (xlib:wm-hints-input hints) :on))
-           (screen-set-focus screen window)
-           (update-decoration window)
-           (when cw
-             (update-decoration cw))))
+       (screen-set-focus screen window)
+       (update-decoration window)
+       (when cw
+         (update-decoration cw))
        (move-window-to-head group window)
        (send-client-message window :WM_PROTOCOLS
                             (xlib:intern-atom *display* :WM_TAKE_FOCUS)


### PR DESCRIPTION
The border for java windows such as IntelliJ IDEA weren't being set to
focus and unfocus color.
