### PR TITLE
db/cleanup module.lisp

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -32,7 +32,7 @@
           find-module
           add-to-load-path))
 
-(defvar contrib-dir
+(defvar *contrib-dir*
   #.(asdf:system-relative-pathname (asdf:find-system :stumpwm)
                                    (make-pathname :directory
                                                   '(:relative "contrib")))
@@ -48,22 +48,23 @@
   (flatten 
    (mapcar (lambda (dir) 
              (let ((asd-file (car (directory 
-                                   (make-pathname :directory 
-                                                  (directory-namestring dir) 
+                                   (make-pathname :directory (directory-namestring dir) 
                                                   :name :wild 
                                                   :type "asd")))))
                (when asd-file
                  (directory (directory-namestring asd-file))))) 
            ;; TODO, make this truely recursive
            (directory (concat (if (stringp path) path
-                                  (directory-namestring path)) "*/*")))))
+                                  (directory-namestring path))
+                              "*/*")))))
+
 (defvar *load-path* nil
-  "A list of paths in which modules can be found, by default it is
-  populated by any asdf systems found in the first two levels of
-  contrib-dir set from the configure script when StumpWM was built, or
-  later by the user using `set-contrib-dir'")
+  "A list of paths in which modules can be found, by default it is populated by any asdf
+  systems found in the first two levels of `*CONTRIB-DIR*' set from the configure script
+  when StumpWM was built, or later by the user using `set-contrib-dir'")
+
 (defun sync-asdf-central-registry (load-path)
-  "Sync `load-path' with `asdf:*central-registry*'"
+  "Sync `LOAD-PATH' with `ASDF:*CENTRAL-REGISTRY*'"
   (setf asdf:*central-registry*
         (union load-path asdf:*central-registry*)))
 
@@ -73,14 +74,14 @@
     ;(format t "~{~a ~%~}" *load-path*)
     (sync-asdf-central-registry load-path)))
 
-(init-load-path contrib-dir)
+(init-load-path *contrib-dir*)
 
 (defcommand set-contrib-dir (dir) ((:string "Directory: "))
   "Sets the location of the contrib modules"
   (when (stringp dir)
     (setf dir (pathname (concat dir "/"))))
-  (setf contrib-dir dir)
-  (init-load-path contrib-dir))
+  (setf *contrib-dir* dir)
+  (init-load-path *contrib-dir*))
 
 (define-stumpwm-type :module (input prompt)
   (or (argument-pop-rest input)
@@ -99,9 +100,11 @@
   (if name
       (find name (list-modules) :test #'string=)
       nil))
+
 (defun ensure-pathname (path)
   (if (stringp path) (first (directory path))
       path))
+
 (defun add-to-load-path (path)
   "If `PATH' is not in `*LOAD-PATH*' add it, check if `PATH' contains
 an asdf system, and if so add it to the central registry"


### PR DESCRIPTION
SET-CONTRIB-DIR does not allow pathnames as arguments.  The first commit fixes this issue, and simplifies the code.  The second commit adds some cosmetic changes to module.lisp, the most important of them being the earmuffs around contrib-dir.
