### PR TITLE
Include keysym for XF86AudioMicMute.

### DIFF
--- a/keysyms.lisp
+++ b/keysyms.lisp
@@ -2067,6 +2067,7 @@
 (define-keysym #x1008FFA9 "XF86TouchpadToggle")
 (define-keysym #x1008FFB0 "XF86TouchpadOn")
 (define-keysym #x1008FFB1 "XF86TouchpadOff")
+(define-keysym #x1008FFB2 "XF86AudioMicMute")
 (define-keysym #x1008FE01 "XF86_Switch_VT_1")
 (define-keysym #x1008FE02 "XF86_Switch_VT_2")
 (define-keysym #x1008FE03 "XF86_Switch_VT_3")


### PR DESCRIPTION
Fixes Issue #89
- keysyms.lisp: XF86AudioMicMute is #x1008FFB2
