### PR TITLE
Guess removed head by frame number. Fixes #71

### DIFF
--- a/head.lisp
+++ b/head.lisp
@@ -144,9 +144,8 @@
       ;; Some heads were removed (or cloned), try to guess which.
       (dolist (oh oheads)
         (dolist (nh heads)
-          (when (and (= (head-x nh) (head-x oh))
-                     (= (head-y nh) (head-y oh)))
-          ;; Same screen position; probably the same head.
+          (when (= (head-number oh) (head-number nh))
+            ;; Same frame number, probably the same head
             (setf (head-number nh) (head-number oh))))))
     (dolist (h (set-difference oheads heads :test '= :key 'head-number))
       (remove-head screen h))


### PR DESCRIPTION
SCALE-SCREEN tried to guess what head was removed by comparing their
screen position. If the removed head was positioned left or above other
heads, the other heads were moved to the left or up before SCALE-SCREEN
is ever called. This resulted in SCALE-SCREEN guessing wrong at what
head was removed.

Frame numbers of heads haven't (yet) been reassigned when SCALE-SCREEN
is called, so compare those instead.
