### PR TITLE
Floating group: base current head on window

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -135,7 +135,7 @@
   (screen-focus (group-screen group)))
 
 (defmethod group-current-head ((group float-group))
-  (first (screen-heads (group-screen group))))
+  (window-head (group-current-window group)))
 
 (defun float-window-align (window)
   (with-slots (parent xwin width height) window


### PR DESCRIPTION
Instead of always returning the first head on the screen as the current
one, it makes more sense to instead return the head on which the current
window resides.
