### PR TITLE
Decouple mouse focus policy from clicking root

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1097,7 +1097,7 @@ input focus is transfered to the window you click on.")
 
 (defvar *root-click-focuses-frame* t
   "Set to NIL if you don't want clicking the root window to focus the frame
-  containing the pointer when *mouse-focus-policy* is :click.")
+  containing the pointer.")
 
 (defvar *banish-pointer-to* :head
   "Where to put the pointer when no argument is given to (banish-pointer) or the banish

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -119,8 +119,7 @@
   (frame-raise-window group (window-frame win) win))
 
 (defmethod group-button-press ((group tile-group) x y (where (eql :root)))
-  (when (and (eq *mouse-focus-policy* :click)
-             *root-click-focuses-frame*)
+  (when *root-click-focuses-frame*
     (let* ((frame (find-frame group x y)))
       (when frame
         (focus-frame group frame)


### PR DESCRIPTION
When *MOUSE-FOCUS-POLICY* was :SLOPPY it was impossible to focus an
empty frame using the mouse. There doesn't seem to be a real reason for
coupling the root click behavior and the mouse focus policy.
