### PR TITLE
Enable RUN-OR-RAISE to focus floating group

### DIFF
--- a/user.lisp
+++ b/user.lisp
@@ -257,7 +257,8 @@ number, with group being more significant (think radix sort)."
     (stable-sort (sort matches #'< :key #'window-number)
                  #'< :key (lambda (w) (group-number (window-group w))))))
 
-(defun run-or-raise (cmd props &optional (all-groups *run-or-raise-all-groups*) (all-screens *run-or-raise-all-screens*))
+(defun run-or-raise (cmd props &optional (all-groups *run-or-raise-all-groups*)
+                                 (all-screens *run-or-raise-all-screens*))
   "Run the shell command, @var{cmd}, unless an existing window
 matches @var{props}. @var{props} is a property list with the following keys:
 
@@ -296,7 +297,7 @@ instance. @var{all-groups} overrides this default. Similarily for
                     (first matches))))
       (if win
           (if (eq (type-of (window-group win)) 'float-group)
-              (group-focus-window (window-group win) win)
+              (focus-all win)
               (goto-win win))
           (run-shell-command cmd)))))
 


### PR DESCRIPTION
When raising a window on a floating group while on another group, the
group wasn't actually focused. It did when switching to a tiling group.
