### PR TITLE
Fix finding current head on empty floating group

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -135,7 +135,9 @@
   (screen-focus (group-screen group)))
 
 (defmethod group-current-head ((group float-group))
-  (window-head (group-current-window group)))
+  (if (group-current-window group)
+      (window-head (group-current-window group))
+      (first (screen-heads (group-screen group)))))
 
 (defun float-window-align (window)
   (with-slots (parent xwin width height) window


### PR DESCRIPTION
If there was no current window on a floating group the group crashed because GROUP-CURRENT-WINDOW returned NIL.
