### PR TITLE
Send :CONFIGURE-NOTIFY to client after moving

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -191,7 +191,8 @@ than the root window's width and height."
                             (list wx wy
                                   (- (xlib:drawable-width (window-parent win)) width wx)
                                   (- (xlib:drawable-height (window-parent win)) height wy))
-                            :cardinal 32))))
+                            :cardinal 32))
+    (update-configuration win)))
 
 ;;;
 


### PR DESCRIPTION
This fixes an issue with Java windows not really noticing when they're
moved. When a window was moved to a different frame and a dropdown menu
opened, it then expected the mouse to be at the previous coordinates.

The floating group already does this when moving.
