### PR TITLE
Load rc from XDG_CONFIG_HOME instead of ~/.config

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -35,8 +35,15 @@
 doesn't exist. Returns a values list: whether the file loaded (t if no
 rc files exist), the error if it didn't, and the rc file that was
 loaded. When CATCH-ERRORS is nil, errors are left to be handled further up. "
-  (let* ((user-rc (probe-file (merge-pathnames  #p".stumpwmrc" (user-homedir-pathname))))
-         (conf-rc (probe-file (merge-pathnames  #p".config/stumpwm/config" (user-homedir-pathname))))
+  (let* ((xdg-config-dir
+           (let ((dir (getenv "XDG_CONFIG_HOME")))
+             (if (or (not dir) (string= dir ""))
+                 (merge-pathnames  #p".config/" (user-homedir-pathname))
+                 dir)))
+         (user-rc
+           (probe-file (merge-pathnames #p".stumpwmrc" (user-homedir-pathname))))
+         (conf-rc
+           (probe-file (merge-pathnames #p"stumpwm/config" xdg-config-dir)))
          (etc-rc (probe-file #p"/etc/stumpwmrc"))
          (rc (or user-rc conf-rc etc-rc)))
     (if rc


### PR DESCRIPTION
According to the XDG Base Directory Specification:

$XDG_CONFIG_HOME defines the base directory relative to which user
specific configuration files should be stored. If $XDG_CONFIG_HOME is
either not set or empty, a default equal to $HOME/.config should be
used.

This was also noted by Github user lipidity at
https://github.com/stumpwm/stumpwm/pull/117#issuecomment-52278942
