### PR TITLE
Split the floating group into off into its own package

### DIFF
--- a/core.lisp
+++ b/core.lisp
@@ -25,6 +25,8 @@
 
 (in-package :stumpwm)
 
+(export '(grab-pointer ungrab-pointer))
+
 ;; Wow, is there an easier way to do this?
 (defmacro def-thing-attr-macro (thing hash-slot)
   (let ((attr (gensym "ATTR"))

--- a/events.lisp
+++ b/events.lisp
@@ -73,14 +73,6 @@
       (when (has-bw value-mask)
         (setf (xlib:drawable-border-width xwin) border-width)))))
 
-(defun update-configuration (win)
-  ;; Send a synthetic configure-notify event so that the window
-  ;; knows where it is onscreen.
-  (xwin-send-configuration-notify (window-xwin win)
-                                  (xlib:drawable-x (window-parent win))
-                                  (xlib:drawable-y (window-parent win))
-                                  (window-width win) (window-height win) 0))
-
 (define-stump-event-handler :configure-request (stack-mode #|parent|# window #|above-sibling|# x y width height border-width value-mask)
   (labels ((has-x () (= 1 (logand value-mask 1)))
            (has-y () (= 2 (logand value-mask 2)))

--- a/group.lisp
+++ b/group.lisp
@@ -24,7 +24,7 @@
 
 (in-package #:stumpwm)
 
-(export '(current-group group-windows move-window-to-group
+(export '(current-group group-windows move-window-to-group add-group
           ;; Group accessors
           group group-screen group-windows group-number group-name
           ;; Group API

--- a/group.lisp
+++ b/group.lisp
@@ -24,7 +24,17 @@
 
 (in-package #:stumpwm)
 
-(export '(current-group group-windows move-window-to-group))
+(export '(current-group group-windows move-window-to-group
+          ;; Group accessors
+          group group-screen group-windows group-number group-name
+          ;; Group API
+          group-startup group-add-window group-delete-window group-wake-up
+          group-suspend group-current-window group-current-head
+          group-resize-request group-move-request group-raise-request
+          group-lost-focus group-indicate-focus group-focus-window
+          group-button-press group-root-exposure group-add-head
+          group-remove-head group-resize-head group-sync-all-heads
+          group-sync-head))
 
 (defvar *default-group-type* 'tile-group
   "The type of group that should be created by default.")

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -132,7 +132,13 @@
           with-restarts-menu
           with-data-file
           move-to-head
-          format-expand))
+          format-expand
+
+          ;; Frame accessors
+          frame-x
+          frame-y
+          frame-width
+          frame-height))
 
 
 ;;; Message Timer

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -146,7 +146,11 @@
           screen-focus
           screen-float-focus-color
           screen-float-unfocus-color
-))
+
+          ;; Window states
+          +withdrawn-state+
+          +normal-state+
+          +iconic-state+))
 
 
 ;;; Message Timer

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -150,7 +150,17 @@
           ;; Window states
           +withdrawn-state+
           +normal-state+
-          +iconic-state+))
+          +iconic-state+
+
+          ;; Modifiers
+          modifiers
+          modifiers-p
+          modifiers-alt
+          modifiers-altgr
+          modifiers-super
+          modifiers-meta
+          modifiers-hyper
+          modifiers-numlock))
 
 
 ;;; Message Timer

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -138,7 +138,15 @@
           frame-x
           frame-y
           frame-width
-          frame-height))
+          frame-height
+
+          ;; Screen accessors
+          screen-heads
+          screen-root
+          screen-focus
+          screen-float-focus-color
+          screen-float-unfocus-color
+))
 
 
 ;;; Message Timer

--- a/window.lisp
+++ b/window.lisp
@@ -32,12 +32,14 @@
           set-window-geometry))
 
 (export
-  '(
-    window-xwin window-width window-height window-x window-y window-gravity
-    window-group window-number window-parent window-title window-user-title
-    window-class window-type window-res window-role window-unmap-ignores
-    window-state window-normal-hints window-marked window-plist
-    window-fullscreen))
+  '(window window-xwin window-width window-height window-x window-y
+    window-gravity window-group window-number window-parent window-title
+    window-user-title window-class window-type window-res window-role
+    window-unmap-ignores window-state window-normal-hints window-marked
+    window-plist window-fullscreen window-screen update-configuration
+    ;; Window management API
+    update-decoration focus-window raise-window window-visible-p window-sync
+    window-head))
 
 (defvar *default-window-name* "Unnamed"
   "The name given to a window that does not supply its own name.")
@@ -331,6 +333,14 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
   (escape-caret (or
                  (xwin-net-wm-name win)
                  (xlib:wm-name win))))
+
+(defun update-configuration (win)
+  ;; Send a synthetic configure-notify event so that the window
+  ;; knows where it is onscreen.
+  (xwin-send-configuration-notify (window-xwin win)
+                                  (xlib:drawable-x (window-parent win))
+                                  (xlib:drawable-y (window-parent win))
+                                  (window-width win) (window-height win) 0))
 
 (defun window-fullscreen-locked-p (win)
   (let* ((xwin (window-xwin win))

--- a/window.lisp
+++ b/window.lisp
@@ -36,7 +36,9 @@
     window-gravity window-group window-number window-parent window-title
     window-user-title window-class window-type window-res window-role
     window-unmap-ignores window-state window-normal-hints window-marked
-    window-plist window-fullscreen window-screen update-configuration
+    window-plist window-fullscreen window-screen
+    ;; Window utilities
+    update-configuration no-focus
     ;; Window management API
     update-decoration focus-window raise-window window-visible-p window-sync
     window-head))


### PR DESCRIPTION
This is an attempt to commence organizing StumpWM into smaller parts, as discussed in #125.

I'm not sure if this should be merged as-is, but I'm curious to hear your thoughts. Splitting some parts off into their own package might be a good way to organize things a bit better. Maybe this will also involve finding some higher level abstractions in some places.

I chose to start with the floating group because it's a relatively uninvolved element of the system. Other things, like the tiling group, spread out a lot farther through different parts.