### PR TITLE
Added travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: lisp
+
+env:
+  matrix:
+    # - LISP=abcl
+    - LISP=sbcl
+    # - LISP=sbcl32
+    - LISP=ccl
+    # - LISP=ccl32
+    - LISP=clisp
+    # - LISP=clisp32
+    # - LISP=cmucl
+    # - LISP=ecl
+
+matrix:
+ allow_failures:
+   - env: LISP=clisp
+
+install:
+  - sudo apt-get install texinfo
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^#cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw2.github.com/luismbo/cl-travis/master/install.sh | sh;
+    fi
+  - cl-launch -i '(ql:quickload "clx")' -i '(ql:quickload "cl-ppcre")'
+
+before_script:
+  - ./autogen.sh
+  - ./configure
+
+script:
+  - make


### PR DESCRIPTION
Simple initial travis-ci setup.  Tests building only.  related to #60

CLisp is currently failing, but sbcl and ccl both build fine.  https://travis-ci.org/russell/stumpwm

I'll add test running shortly, using xvfb-run and the test-wm.lisp file.
