### PR TITLE
Added the command "windowlist-by-class".

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -874,6 +874,9 @@ characters.")
 (defvar *window-info-format* "%wx%h %n (%t)"
   "The format used in the info command. @xref{*window-format*} for formatting details.")
 
+(defparameter *window-format-by-class* "%m%n %c %s%50t"
+  "The format used in the info winlist-by-classe command. @xref{*window-format*} for formatting details.")
+
 (defvar *group-formatters* '((#\n group-map-number)
                              (#\s fmt-group-status)
                              (#\t group-name))

--- a/window.lisp
+++ b/window.lisp
@@ -408,9 +408,39 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
       (defun (setf ,(intern1 (format nil "WINDOW-~a" attr))) (,val ,win)
         (setf (gethash ,attr (window-plist ,win)) ,val)))))
 
-(defun sort-windows (group)
+(defgeneric sort-windows-by-number (window-list-spec)
+  (:documentation "Return a copy of the provided window list sorted by number."))
+
+(defmethod sort-windows-by-number ((window-list list))
+  "Return a copy of the screen's window list sorted by number."
+  (sort1 window-list '< :key 'window-number))
+
+(defmethod sort-windows-by-number ((group group))
   "Return a copy of the screen's window list sorted by number."
   (sort1 (group-windows group) '< :key 'window-number))
+
+
+(defgeneric sort-windows-by-class (window-list-spec)
+  (:documentation "Return a copy of the provided window list sortes by class
+ then by numer."))
+
+(defmethod sort-windows-by-class ((window-list list))
+  "Return a copy of the provided window list sorted by class then by number."
+  (sort1 window-list (lambda (w1 w2)
+		       (let ((class1 (window-class w1))
+			     (class2 (window-class w2)))
+			 (if (string= class1 class2)
+			     (< (window-number w1) (window-number w2))
+			     (string< class1 class2))))))
+
+(defmethod sort-windows-by-class (group)
+  "Return a copy of the provided window list sorted by class then by number."
+  (sort-windows-by-class (group-windows group)))
+
+
+(defun sort-windows (group)
+  "Return a copy of the screen's window list sorted by number."
+    (sort-windows-by-number group))
 
 (defun marked-windows (group)
   "Return the marked windows in the specified group."
@@ -897,7 +927,7 @@ needed."
   (dformat 3 "Kill client~%")
   (xlib:kill-client *display* (xlib:window-id window)))
 
-(defun select-window-from-menu (windows fmt)
+(defun select-window-from-menu (windows fmt &optional prompt)
   "Allow the user to select a window from the list passed in @var{windows}.  The
 @var{fmt} argument specifies the window formatting used.  Returns the window
 selected."
@@ -905,7 +935,7 @@ selected."
 			    (mapcar (lambda (w)
 				      (list (format-expand *window-formatters* fmt w) w))
                                     windows)
-                            nil
+                            prompt
                             (or (position (current-window) windows) 0))))
 
 ;;; Window commands
@@ -1009,19 +1039,24 @@ is using the number, then the windows swap numbers. Defaults to current group."
 		     (mapcar 'window-number windows))
 		   0))))))
 
-(defcommand windowlist (&optional (fmt *window-format*)) (:rest)
-"Allow the user to Select a window from the list of windows and focus
+(defcommand windowlist (&optional (fmt *window-format*)
+                                  (window-list (sort-windows-by-number (group-windows (current-group)))))
+    (:rest)
+  "Allow the user to Select a window from the list of windows and focus
 the selected window. For information of menu bindings
 @xref{Menus}. The optional argument @var{fmt} can be specified to
 override the default window formatting."
-  (if (null (group-windows (current-group)))
+  (if (null window-list)
       (message "No Managed Windows")
       (let* ((group (current-group))
-             (window (select-window-from-menu (sort-windows group) fmt)))
+             (window (select-window-from-menu window-list fmt)))
         (if window
             (group-focus-window group window)
             (throw 'error :abort)))))
 
+(defcommand windowlist-by-class (&optional (fmt *window-format-by-class*)) (:rest)
+  "Same as @xref{windowlist} but sorts the windows by their classes."
+  (windowlist fmt (sort-windows-by-class (group-windows (current-group)))))
 
 (defcommand window-send-string (string &optional (window (current-window))) ((:rest "Insert: "))
   "Send the string of characters to the current window as if they'd been typed."


### PR DESCRIPTION
I started working on something to "switch between all windows of the same class", in other words, I wanted to use the command `windowlist`, but listing only the windows of the class "Firefox" for example.

For that I did:
- Added `prompt` parameter to the `select-window-from-menu` function.
- Created generic function `sort-windows-by-number` and `sort-windows-by-class`.
- For each generic function, I implemented two method: one taking a `group` and the other taking a list of `window` (named window-list).
- The "old" function `sort-windows` (which took a group as parameter) is now implement in term of these methods.
- Added the ability to specify a list of window for the command windowlist
- I then added the command `windowlist-by-class` because I could :smile: 

Now, it's really easy to do what I wanted in the first place, but my code for that part is "tighly" coupled with my stumpwm's config, so I didn't added it in the stumpwm's code.

What do you think?
