### PR TITLE
Add support for ARGB visual when reparent window.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ Josh Elsasser       josh at elsasser org
 Matt Spear          batman900 at gmail com
 David Bjergaard     dbjergaard at gmail com
 Joram Schrijver     i at joram io
+Yu Changyuan        reivzy at gmail com


### PR DESCRIPTION
When reparent window, check whether the window to reparent has the depth
of 32. When that is true, we should create a parent window with the same
32bit depth. So the window with alpha channel will show as translucency,
or it will have a opaque background.
