### PR TITLE
Workaround for Muse sequencer

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -214,7 +214,9 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
        (window-gang window))
       (t
        (let ((w (window-by-id tr)))
-         (append (list w) (transients-of w)))))))
+         (if w
+             (append (list w) (transients-of w))
+           '()))))))
 
 (defun only-transients (windows)
   "Out of WINDOWS, return a list of those which are transient."


### PR DESCRIPTION
[Muse sequencer](http://muse-sequencer.org/) has some strange kind of subwindows, for those window-by-id sometimes (e.g. after switching to other desktop and back) returns false.

I don't know if it is the best way to workaround, but works well for me.