### PR TITLE
Add ~/.stumpwm.d/init.lisp as an init file.

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -43,10 +43,12 @@ further up. "
                  dir)))
          (user-rc
            (probe-file (merge-pathnames #p".stumpwmrc" (user-homedir-pathname))))
+         (dir-rc
+           (probe-file (merge-pathnames #p".stumpwm.d/init.lisp" (user-homedir-pathname))))
          (conf-rc
            (probe-file (merge-pathnames #p"stumpwm/config" xdg-config-dir)))
          (etc-rc (probe-file #p"/etc/stumpwmrc"))
-         (rc (or user-rc conf-rc etc-rc)))
+         (rc (or user-rc dir-rc conf-rc etc-rc)))
     (if rc
         (if catch-errors
             (handler-case (load rc)


### PR DESCRIPTION
Now that we're using ~/.stumpwm.d for modules and data, I'd like the option to put StmpWM's init file in that directory. I've added "~/.stumpwm.d/init.lisp" as an init file StumpWM will search for. The traditional ~/.stumpwmrc continues to have the highest priority, followed by this init.lisp, then the xdg and system-wide versions.