### PR TITLE
Fix #188: Missing arguments in manual when built with CCL.

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -47,8 +47,9 @@
                                         name
                                         #+sbcl (sb-introspect:function-lambda-list fn)
                                         #+clisp (ext:arglist fn)
+                                        #+ccl (ccl:arglist fn)
                                         #+lispworks (lw:function-lambda-list fn)
-                                        #- (or sbcl clisp lispworks) '("(Check the code for args list)")
+                                        #- (or sbcl clisp ccl lispworks) '("(Check the code for args list)")
                                         (documentation fn 'function))
                                 t)))
 
@@ -61,8 +62,9 @@
                                         name
                                         #+sbcl (sb-introspect:function-lambda-list (macro-function symbol))
                                         #+clisp (ext:arglist symbol)
+                                        #+ccl (ccl:arglist symbol)
                                         #+lispworks (lw:function-lambda-list symbol)
-                                        #- (or sbcl clisp lispworks) '("(Check the code for args list)")
+                                        #- (or sbcl clisp ccl lispworks) '("(Check the code for args list)")
                                         ;;; FIXME: when clisp compiles
                                         ;;; a macro it discards the
                                         ;;; documentation string! So
@@ -99,8 +101,9 @@
                                         name
                                         #+sbcl (sb-introspect:function-lambda-list cmd)
                                         #+clisp (ext:arglist cmd)
+                                        #+ccl (ccl:arglist cmd)
                                         #+lispworks (lw:function-lambda-list cmd)
-                                        #- (or sbcl clisp lispworks) '("(Check the code for args list)")
+                                        #- (or sbcl clisp ccl lispworks) '("(Check the code for args list)")
                                         (documentation cmd 'function))
                                 t)))
 


### PR DESCRIPTION
Adds complete support for Clozure CL (CCL) to manual.lisp. Specifically, CCL wasn't extracting arglists from StumpWM source to fill out the manual references. It will now. ;) 