### PR TITLE
Use >= 24 functions for sbcl version of "-dirty"

### DIFF
--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -279,8 +279,8 @@ they should be windows. So use this function to make a window out of them."
   ;; FIXME: seems like there ought to be a less cumbersome way to run
   ;; different code based on the version.
   #+sbcl (macrolet ((dir (p)
-                      (if (>= (parse-integer (third (split-seq (lisp-implementation-version) '(#\.))) :junk-allowed t)
-                              24)
+                      (if (or (equal (lisp-implementation-version) "-dirty") (>= (parse-integer (third (split-seq (lisp-implementation-version) '(#\.))) :junk-allowed t)
+                              24))
                           `(directory ,p :resolve-symlinks nil)
                           `(directory ,p))))
            (dir pathspec))

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -279,10 +279,13 @@ they should be windows. So use this function to make a window out of them."
   ;; FIXME: seems like there ought to be a less cumbersome way to run
   ;; different code based on the version.
   #+sbcl (macrolet ((dir (p)
-                      (if (or (equal (lisp-implementation-version) "-dirty") (>= (parse-integer (third (split-seq (lisp-implementation-version) '(#\.))) :junk-allowed t)
+                      (if
+                        (or
+                          (equal (lisp-implementation-version) "-dirty")
+                          (>= (parse-integer (third (split-seq (lisp-implementation-version) '(#\.))) :junk-allowed t)
                               24))
-                          `(directory ,p :resolve-symlinks nil)
-                          `(directory ,p))))
+                        `(directory ,p :resolve-symlinks nil)
+                        `(directory ,p))))
            (dir pathspec))
   #-(or clisp cmu lispworks openmcl sbcl scl) (directory pathspec)
   )


### PR DESCRIPTION
Current sbcl-1.2.8, packaged in voidlinux returns the string "-dirty" for lisp-implementation-version. 