### PR TITLE
Remove obsolete workaround.

### DIFF
--- a/workarounds.lisp
+++ b/workarounds.lisp
@@ -2,26 +2,8 @@
 
 (in-package :xlib)
 
-;;; Both clisp and SBCL can't handle incompliant (and in clisp's case,
-;;; even compliant) wm-class strings. See test-wm-class in test-wm.lisp.
-
-#+sbcl
-(defun get-wm-class (window)
-  (declare (type window window))
-  (declare (clx-values (or null name-string) (or null class-string)))
-  (let ((value (get-property window :WM_CLASS :type :STRING :result-type '(vector card8))))
-    (declare (type (or null (vector card8)) value))
-    (when value
-      ;; Buggy clients may not comply with the format, so deal with
-      ;; the unexpected.
-      (let* ((first-zero (position 0 (the (vector card8) value)))
-             (second-zero (and first-zero
-                               (position 0 (the (vector card8) value) :start (1+ first-zero))))
-	     (name (subseq (the (vector card8) value) 0 first-zero))
-	     (class (and first-zero
-                         (subseq (the (vector card8) value) (1+ first-zero) second-zero))))
-	(values (and (plusp (length name)) (map 'string #'card8->char name))
-		(and (plusp (length class)) (map 'string #'card8->char class)))))))
+;;; CLISP can't handle non-compliant (and even compliant) wm-class strings. See
+;;; test-wm-class in test-wm.lisp.
 
 ;; This redefines decod-wm-size-hints in clisp because "It seems clisp
 ;; tries to be sneaky and represent the min and max aspect ratios as a


### PR DESCRIPTION
The bug was fixed ~15 days after the 172f13e144268e51a87f314cb771dc4513943c78 commit, as you can see from: https://github.com/sharplispers/clx/commit/c928dccb561b2df6f5e5b4d09eab22cf67e8ff03