### PR TITLE
Removed version check from fix directory-no-deref on sbcl

### DIFF
--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -276,16 +276,8 @@ they should be windows. So use this function to make a window out of them."
   #+clisp (mapcar #'car (directory pathspec :full t))
   #+lispworks (directory pathspec :link-transparency nil)
   #+openmcl (directory pathspec :follow-links nil)
-  ;; FIXME: seems like there ought to be a less cumbersome way to run
-  ;; different code based on the version.
-  #+sbcl (macrolet ((dir (p)
-                      (if (>= (parse-integer (third (split-seq (lisp-implementation-version) '(#\.))) :junk-allowed t)
-                              24)
-                          `(directory ,p :resolve-symlinks nil)
-                          `(directory ,p))))
-           (dir pathspec))
-  #-(or clisp cmu lispworks openmcl sbcl scl) (directory pathspec)
-  )
+  #+sbcl (directory pathspec :resolve-symlinks nil)
+  #-(or clisp cmu lispworks openmcl sbcl scl) (directory pathspec))
 
 ;;; CLISP does not include features to distinguish different Unix
 ;;; flavours (at least until version 2.46). Until this is fixed, use a


### PR DESCRIPTION
As per #190, the logic of version check is wrong as it only checks for the patch number, and it wasn't working as intended since version 1.1.0, the successor for 1.0.58. The keyword argument is available since [1.0.24](http://sbcl.sourceforge.net/all-news.html#1.0.24), so IMHO we can safely assume the keyword argument :resolve-symlinks is supported.

