### PR TITLE
Allow non ascii chars to be typed in window-send-string.

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -1102,7 +1102,7 @@ formatting. This is a simple wrapper around the command @command{windowlist}."
                                  (stumpwm-name->keysym "TAB"))
                                 ((char= ch #\Newline)
                                  (stumpwm-name->keysym "RET"))
-                                (t nil))))
+                                (t (first (xlib:character->keysyms ch *display*))))))
                  (when sym
                    (send-fake-key window
                                   (make-key :keysym sym)))))


### PR DESCRIPTION
This simple change allows me to type German Umlauts with `window-send-string`, after doing `setxkbmap de`.