### PR TITLE
Fix fullscreen mode with floating windows

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -18,20 +18,16 @@
 
 ;; some book keeping functions
 (defmethod (setf window-x) :before (val (window float-window))
-  (unless (eql (window-x window) val)
-    (setf (float-window-last-x window) (window-x window))))
+  (setf (float-window-last-x window) (window-x window)))
 
 (defmethod (setf window-y) :before (val (window float-window))
-  (unless (eql (window-y window) val)
-    (setf (float-window-last-y window) (window-y window))))
+  (setf (float-window-last-y window) (window-y window)))
 
 (defmethod (setf window-width) :before (val (window float-window))
-  (unless (eql (window-width window) val)
-    (setf (float-window-last-width window) (window-width window))))
+  (setf (float-window-last-width window) (window-width window)))
 
 (defmethod (setf window-height) :before (val (window float-window))
-  (unless (eql (window-height window) val)
-    (setf (float-window-last-height window) (window-height window))))
+  (setf (float-window-last-height window) (window-height window)))
 
 (defun float-window-move-resize (win &key x y width height (border *float-window-border*))
   ;; x and y position the parent window while width, height resize the


### PR DESCRIPTION
When a float-window has width or height equal to width or height of the screen, its last-width or last-height slot is not being properly updated when you go to the fullscreen mode.

So If you have, for example, a window with sizes 1280x720 on the screen with sizes 1280x1024, you will never return the window to normal size (and get BadValue error from x server).

Solution: remove unnecessary (as they seem to be) 'unless' conditions in accessor methods for window geometry slots.