### PR TITLE
Only issue a warning if makeinfo isn't present.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_MSG_NOTICE([Using $LISP at $LISP_PROGRAM])
 AC_CHECK_PROG(MAKEINFO,makeinfo,yes,no)
 
 if test "$MAKEINFO" = "no"; then
-   AC_MSG_ERROR([Please install makeinfo for the manual.])
+   AC_MSG_WARN([Please install makeinfo for the manual.])
 fi
 
 AC_CHECK_PROG(XDPYINFO,xdpyinfo,yes,no)


### PR DESCRIPTION
Doesn't really seem right for configure to bail out entirely if makeinfo isn't present, people can still build stumpwm itself which is all the majority of people want to do.
