### PR TITLE
Export stumpwm-error

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -161,7 +161,10 @@
           modifiers-super
           modifiers-meta
           modifiers-hyper
-          modifiers-numlock))
+          modifiers-numlock
+
+          ;; Conditions
+          stumpwm-error))
 
 
 ;;; Message Timer


### PR DESCRIPTION
So that modules can register their error as a stumpwm related one.