### PR TITLE
Represent Newline using the character.

### DIFF
--- a/message-window.lisp
+++ b/message-window.lisp
@@ -248,7 +248,7 @@ function expects to be wrapped in a with-state for win."
 
 (defun echo-string (screen msg)
   "Display @var{string} in the message bar on @var{screen}. You almost always want to use @command{message}."
-  (echo-string-list screen (split-string msg (string #\Newline))))
+  (echo-string-list screen (split-string msg)))
 
 (defun message (fmt &rest args)
   "run FMT and ARGS through `format' and echo the result to the current screen."

--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -319,8 +319,7 @@ critical."
     ;; This is a StumpWM mode-line
     (setf (xlib:drawable-height (mode-line-window ml)) 
           (+ (* 2 *mode-line-pad-y*)
-             (nth-value 1 (rendered-size (split-string (mode-line-contents ml)
-                                                       (string #\Newline))
+             (nth-value 1 (rendered-size (split-string (mode-line-contents ml))
                                          (mode-line-cc ml))))))
   (setf (xlib:drawable-width (mode-line-window ml)) (- (frame-width (mode-line-head ml))
                                                        (* 2 (xlib:drawable-border-width (mode-line-window ml))))
@@ -414,7 +413,7 @@ critical."
         (resize-mode-line ml)
         (render-strings (mode-line-screen ml) (mode-line-cc ml)
                         *mode-line-pad-x*     *mode-line-pad-y*
-                        (split-string string (string #\Newline)) '())))))
+                        (split-string string) '())))))
 
 (defun find-mode-line-window (xwin)
   (dolist (s *screen-list*)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -754,8 +754,7 @@ Useful for re-using the &REST arg after removing some options."
           ;; it out a little.
           default-value))))
 
-(defun split-string (string &optional (separators "
-"))
+(defun split-string (string &optional (separators (string #\Newline)))
   "Splits STRING into substrings where there are matches for SEPARATORS.
 Each match for SEPARATORS is a splitting point.
 The substrings between the splitting points are made into a list


### PR DESCRIPTION
A small style fix. Use (string #\Newline) instead of using a literal newline inside a string

and use the default value when the default matches what was passed to `#'split-string`