### PR TITLE
Fixed ccl build process

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1524,7 +1524,7 @@ current group:
 @code{(act-on-matching-windows (w) (titled-p w "XTerm") (pull-w w))}
 
 !!! move-windows-to-group
-!!! act-on-matching-windows
+%%% act-on-matching-windows
 !!! pull-w
 !!! titled-p
 !!! title-re-p


### PR DESCRIPTION
act-on-matching-windows was flagged, in stumpwm.texi.in, as a command
when it should have been flagged as a macro. This caused the manual
creation phase to fail, killing the whole build and stopping travis
tests. This patch fixes that.