### PR TITLE
Sane behavior of the sloppy mouse focus policy in floating groups.

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -186,7 +186,7 @@
   )
 
 (defmethod group-focus-window ((group float-group) window)
-  (focus-window window))
+  (focus-window window nil))
 
 (defmethod group-root-exposure ((group float-group))
   )
@@ -211,7 +211,7 @@
   (let ((screen (group-screen group))
         (initial-width (xlib:drawable-width (window-parent window)))
         (initial-height (xlib:drawable-height (window-parent window))))
-    (when (eq *mouse-focus-policy* :click)
+    (when (or (eq *mouse-focus-policy* :click) (eq *mouse-focus-policy* :sloppy))
       (focus-window window))
 
     ;; When in border

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -211,7 +211,7 @@
   (let ((screen (group-screen group))
         (initial-width (xlib:drawable-width (window-parent window)))
         (initial-height (xlib:drawable-height (window-parent window))))
-    (when (or (eq *mouse-focus-policy* :click) (eq *mouse-focus-policy* :sloppy))
+    (when (member *mouse-focus-policy* '(:click :sloppy))
       (focus-window window))
 
     ;; When in border


### PR DESCRIPTION
The behavior of *mouse-focus-policy* = :sloppy in floating groups is:
any window that gets the focus (e.g. by hovering over it with the
mouse) automatically raises. This is annoying and makes using floating
groups very difficult. This patch makes floating group windows grab
the focus but stay in the background.  Windows raise only when
clicked.