### PR TITLE
Fix (gmove-and-follow "<float>") exception

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -120,6 +120,9 @@
                                     :width last-width
                                     :height last-height)))))
 
+(defmethod really-raise-window ((window float-window))
+  (raise-window window))
+
 ;;; floating group
 
 (defclass float-group (group)

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -55,7 +55,7 @@ like xterm and emacs.")
 
 ;;;;
 
-(defun really-raise-window (window)
+(defmethod really-raise-window ((window tile-window))
   (frame-raise-window (window-group window) (window-frame window) window))
 
 (defun raise-modals-of (window)

--- a/window.lisp
+++ b/window.lisp
@@ -41,7 +41,7 @@
     update-configuration no-focus
     ;; Window management API
     update-decoration focus-window raise-window window-visible-p window-sync
-    window-head))
+    window-head really-raise-window))
 
 (defvar *default-window-name* "Unnamed"
   "The name given to a window that does not supply its own name.")
@@ -88,6 +88,8 @@
 may need to sync itself. WHAT-CHANGED is a hint at what changed."))
 (defgeneric window-head (window)
   (:documentation "Report what window the head is currently on."))
+(defgeneric really-raise-window (window)
+  (:documentation "Really bring the window to the top of the window stack in group"))
 
 ;; Urgency / demands attention
 


### PR DESCRIPTION
When invoke gmove-and-follow to a float group, an exception will
raised.  Because really-raise-window is defined for tile-window only.
Fix this via make it a generic function and provide method for
float-window too.