### PR TITLE
Helm-like menu

### DIFF
--- a/menu.lisp
+++ b/menu.lisp
@@ -66,12 +66,6 @@
   (let ((len (length (menu-state-table menu))))
     (min (or *menu-maximum-height* len) len)))
 
-(defun menu-view-valid (start end)
-  (assert (>= start 0))
-  (assert (<= start (- len menu-height)))
-  (assert (>= end (1- menu-height)))
-  (assert (< end len)))
-
 (defun bound-check-menu (menu)
   "Adjust the menu view and selected item based
 on current view and new selection."
@@ -94,10 +88,8 @@ on current view and new selection."
                          (start (- sel (floor (/ menu-height 2))))
                          (end (+ sel menu-height -1)))
                     (labels ((validate-view (start end)
-                               (assert (>= start 0))
-                               (assert (<= start (- len menu-height)))
-                               (assert (>= end (1- menu-height)))
-                               (assert (< end len))
+                               (assert (<= 0 start (- len menu-height)) (start))
+                               (assert (< menu-height end len) (end))
                                (values start end)))
                       (apply #'validate-view
                              ;; Scrolling required
@@ -144,7 +136,7 @@ on current view and new selection."
 (defun menu-finish (menu)
   (throw :menu-quit (nth (menu-state-selected menu) (menu-state-table menu))))
 
-(defun menu-abort (mpenu)
+(defun menu-abort (menu)
   (declare (ignore menu))
   (throw :menu-quit nil))
 
@@ -235,7 +227,7 @@ Returns the selected element in TABLE or nil if aborted. "
                          (highlight (- (menu-state-selected menu)
                                        (menu-state-view-start menu)
                                        -1)))
-                    (unless (= 0 (menu-state-view-start menu))
+                    (unless (zerop (menu-state-view-start menu))
                       (setf strings (cons "..." strings))
                       (incf highlight))
                     (unless (= (1- num-items) (menu-state-view-end menu))


### PR DESCRIPTION
I've made a few modifications to `menu.lisp`, so that the menu shows only the items matching all the regular expressions typed by the user (previously, the first matching item in the menu was highlighted, and that was it). Now it behaves a bit more like helm-mode for Emacs. It's been pretty useful, in particular with `pull-from-windowlist`.
The interface is exactly the same, so all other commands can take advantage of the new behavior with no further modifications. I've been using this stuff for a while now, and it hasn't shown any bug in the last few days.
Care to take a look?
(btw, this is the first time I've ever written anything in Common Lisp, any criticism/opinion is appreciated . Also, first time ever sending a PR, so, sorry if I'm not following quite the right procedure)