### PR TITLE
Menu filter predicate

### DIFF
--- a/menu.lisp
+++ b/menu.lisp
@@ -177,9 +177,7 @@ backspace or F9), return it otherwise return nil"
 predicate, an item is visible when it matches all of the regular
 expressions in USER-INPUT (multiple regexps are separated by one or
 more spaces; ARGUMENT-POP is used to split the string)."
-  (loop for pattern in (split-string user-input " ")
-     always (let ((scanner (ppcre:create-scanner pattern :case-insensitive-mode t)))
-              (ppcre:scan pattern item-string))))
+  (match-all-regexps user-input item-string))
 
 (defun select-from-menu (screen table &optional (prompt "Search:")
                                         (initial-selection 0)

--- a/menu.lisp
+++ b/menu.lisp
@@ -173,24 +173,13 @@ backspace or F9), return it otherwise return nil"
       (cl-ppcre:ppcre-syntax-error ()))))
 
 (defun menu-item-matches-regexp (item-string item-object user-input)
-  "This is a menu item filter predicate: returns T when the menu item
-corresponding to the object ITEM-OBJECT, shown to the user as
-ITEM-STRING, should be visible to the user when the current user input
-is USER-INPUT (a string).
-
-In particular, the item is visible when it matches all of the regular
+  "The default filter predicate for SELECT-FROM-MENU. When using this
+predicate, an item is visible when it matches all of the regular
 expressions in USER-INPUT (multiple regexps are separated by one or
-more spaces; ARGUMENT-POP is used to split the string).
-
- This function is the default behavior (the default value of the
-FILTER-PRED argument to SELECT-FROM-MENU)"
-  (let* ((arg-line (make-argument-line :string user-input
-                                       :start 0))
-         (match-regexes (loop for arg = (argument-pop arg-line)
-                           while arg
-                           collect (ppcre:create-scanner arg :case-insensitive-mode t))))
-    (loop for re in match-regexes
-       always (ppcre:scan re item-string))))
+more spaces; ARGUMENT-POP is used to split the string)."
+  (loop for pattern in (split-string user-input " ")
+     always (let ((scanner (ppcre:create-scanner pattern :case-insensitive-mode t)))
+              (ppcre:scan pattern item-string))))
 
 (defun select-from-menu (screen table &optional (prompt "Search:")
                                         (initial-selection 0)
@@ -202,6 +191,11 @@ element is displayed in the menu. What is displayed as menu items
 must be strings.
 EXTRA-KEYMAP can be a keymap whose bindings will take precedence
 over the default bindings.
+FILTER-PRED should be a a function returning T when a certain menu
+item should be visible to the user.  It should accept arguments
+ITEM-STRING (the string shown to the user), ITEM-OBJECT (the object
+corresponding to the menu item), and USER-INPUT (the current user
+input). The default is MENU-ITEM-MATCHES-REGEXP.
 Returns the selected element in TABLE or nil if aborted. "
   (check-type screen screen)
   (check-type table list)

--- a/menu.lisp
+++ b/menu.lisp
@@ -54,7 +54,7 @@
           m)))
 
 (defstruct menu-state
-  unfiltered-table table prompt selected view-start view-end
+  unfiltered-table table filter-pred prompt selected view-start view-end
   (current-input (make-array 10 :element-type 'character :adjustable t :fill-pointer 0)))
 
 (defun menu-scrolling-required (menu)
@@ -162,22 +162,40 @@ backspace or F9), return it otherwise return nil"
       (vector-push-extend input-char (menu-state-current-input menu)))
     (handler-case
         (when (or input-char (not key-seq))
-          (let* ((arg-line (make-argument-line :string (menu-state-current-input menu)
-                                               :start 0))
-                 (match-regexes (loop for arg = (argument-pop arg-line)
-                                   while arg
-                                   collect (ppcre:create-scanner arg :case-insensitive-mode t)))
-                 (match-p (lambda (item)
-                            (loop for re in match-regexes
-                               always (ppcre:scan re (menu-element-name item))))))
-            (setf (menu-state-table menu) (remove-if-not match-p (menu-state-unfiltered-table menu))
+          (labels ((match-p (table-item)
+                     (funcall (menu-state-filter-pred menu)
+                              (car table-item)
+                              (cdr table-item)
+                              (menu-state-current-input menu))))
+            (setf (menu-state-table menu) (remove-if-not #'match-p (menu-state-unfiltered-table menu))
                   (menu-state-selected menu) 0)
             (bound-check-menu menu)))
       (cl-ppcre:ppcre-syntax-error ()))))
 
+(defun menu-item-matches-regexp (item-string item-object user-input)
+  "This is a menu item filter predicate: returns T when the menu item
+corresponding to the object ITEM-OBJECT, shown to the user as
+ITEM-STRING, should be visible to the user when the current user input
+is USER-INPUT (a string).
+
+In particular, the item is visible when it matches all of the regular
+expressions in USER-INPUT (multiple regexps are separated by one or
+more spaces; ARGUMENT-POP is used to split the string).
+
+ This function is the default behavior (the default value of the
+FILTER-PRED argument to SELECT-FROM-MENU)"
+  (let* ((arg-line (make-argument-line :string user-input
+                                       :start 0))
+         (match-regexes (loop for arg = (argument-pop arg-line)
+                           while arg
+                           collect (ppcre:create-scanner arg :case-insensitive-mode t))))
+    (loop for re in match-regexes
+       always (ppcre:scan re item-string))))
+
 (defun select-from-menu (screen table &optional (prompt "Search:")
                                         (initial-selection 0)
-                                        extra-keymap)
+                                        extra-keymap
+                                        (filter-pred #'menu-item-matches-regexp))
   "Prompt the user to select from a menu on SCREEN. TABLE can be
 a list of values or an alist. If it's an alist, the CAR of each
 element is displayed in the menu. What is displayed as menu items
@@ -196,6 +214,7 @@ Returns the selected element in TABLE or nil if aborted. "
            (menu (make-menu-state
                   :unfiltered-table table
                   :table table
+                  :filter-pred filter-pred
                   :prompt prompt
                   :view-start 0
                   :view-end 0
@@ -212,7 +231,7 @@ Returns the selected element in TABLE or nil if aborted. "
                          (start (menu-state-view-start menu))
                          (end (menu-state-view-end menu))
                          (len (length (menu-state-table menu)))
-                         (prompt-line (format nil "~@[~A ~] ~A"
+                         (prompt-line (format nil "~@[~A ~]~A"
                                               prompt (menu-state-current-input menu)))
                          (strings (mapcar #'menu-element-name
                                           (subseq (menu-state-table menu)

--- a/menu.lisp
+++ b/menu.lisp
@@ -165,7 +165,7 @@ backspace or F9), return it otherwise return nil"
           (labels ((match-p (table-item)
                      (funcall (menu-state-filter-pred menu)
                               (car table-item)
-                              (cdr table-item)
+                              (second table-item)
                               (menu-state-current-input menu))))
             (setf (menu-state-table menu) (remove-if-not #'match-p (menu-state-unfiltered-table menu))
                   (menu-state-selected menu) 0)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -783,6 +783,17 @@ at the end of STRING, we don't include a null substring for that.
 Modifies the match data; use `save-match-data' if necessary."
   (split-seq string separators :test #'char= :default-value '("")))
 
+(defun match-all-regexps (regexps target-string &key (case-insensitive t))
+  "Return T if TARGET-STRING matches all regexps in REGEXPS.
+REGEXPS can be a list of strings (one regexp per element) or a single
+string which is split to obtain the individual regexps. "
+  (let* ((regexps (if (listp regexps)
+                      regexps
+                      (split-string regexps " "))))
+    (loop for pattern in regexps
+       always (let ((scanner (ppcre:create-scanner pattern
+                                                   :case-insensitive-mode case-insensitive)))
+                (ppcre:scan scanner target-string)))))
 
 (defun insert-before (list item nth)
   "Insert ITEM before the NTH element of LIST."

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -320,19 +320,14 @@ current frame and raise it."
     (pull-other-hidden-window group)))
 
 (defcommand (pull-from-windowlist tile-group) () ()
-"Pulls a window selected from the list of windows.
+  "Pulls a window selected from the list of windows.
 This allows a behavior similar to Emacs' switch-to-buffer
 when selecting another window."
-  (let ((pulled-window (select-from-menu
-                        (current-screen)
-                        (mapcar #'(lambda (w)
-                                    (list (format-expand *window-formatters*
-                                                         *window-format*
-                                                         w)
-                                          w))
-                                (group-windows (current-group))))))
+  (let ((pulled-window (select-window-from-menu
+                        (group-windows (current-group))
+                        *window-format*)))
     (when pulled-window
-      (pull-window (second pulled-window)))))
+      (pull-window pulled-window))))
 
 (defun exchange-windows (win1 win2)
   "Exchange the windows in their respective frames."

--- a/window.lisp
+++ b/window.lisp
@@ -950,7 +950,19 @@ needed."
   (dformat 3 "Kill client~%")
   (xlib:kill-client *display* (xlib:window-id window)))
 
-(defun select-window-from-menu (windows fmt &optional prompt)
+(defun default-window-menu-filter (item-string item-object user-input)
+  "The default filter predicate for window menus."
+  (or (menu-item-matches-regexp item-string item-object user-input)
+      (loop for pattern in (split-string user-input " ")
+         always (ppcre:scan pattern (window-title item-object)))))
+
+(defvar *window-menu-filter* #'default-window-menu-filter
+  "The filter predicate used to filter menu items in window menus
+  created by SELECT-WINDOW-FROM-MENU. The interface for filter
+  predicates is described in the docstring for SELECT-FROM-ITEM.")
+
+(defun select-window-from-menu (windows fmt &optional prompt
+                                              (filter-pred *window-menu-filter*))
   "Allow the user to select a window from the list passed in @var{windows}.  The
 @var{fmt} argument specifies the window formatting used.  Returns the window
 selected."
@@ -959,7 +971,9 @@ selected."
 				      (list (format-expand *window-formatters* fmt w) w))
                                     windows)
                             prompt
-                            (or (position (current-window) windows) 0))))
+                            (or (position (current-window) windows) 0)  ; Initial selection
+                            nil  ; Extra keymap
+                            filter-pred)))
 
 ;;; Window commands
 

--- a/window.lisp
+++ b/window.lisp
@@ -953,8 +953,8 @@ needed."
 (defun default-window-menu-filter (item-string item-object user-input)
   "The default filter predicate for window menus."
   (or (menu-item-matches-regexp item-string item-object user-input)
-      (loop for pattern in (split-string user-input " ")
-         always (ppcre:scan pattern (window-title item-object)))))
+      (match-all-regexps user-input (window-title item-object)
+                         :case-insensitive t)))
 
 (defvar *window-menu-filter* #'default-window-menu-filter
   "The filter predicate used to filter menu items in window menus


### PR DESCRIPTION
This aims to solve #220.

The changes are, basically:

1. an additional argument to `select-from-menu` specifies a filter predicate, which is a function that says whether a given menu item should be visible or not, based on the user-visible string, the object corresponding to the item, and user input;

2. `select-window-from-menu` specifies a filter predicate that also checks the user-input regexp against the full window title (not just the portion shown in the menu).

It's also possible to override `select-window-from-menu`'s default by setting the `*window-menu-filter*` variable.

(I still consider myself a CL beginner; any criticism/opinion on the code or the general design is appreciated. Also: should I squash some commits?)