### PR TITLE
time.lisp: *time-format-string-default*: Include the year

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -114,6 +114,7 @@ from most specific groups to most general groups.")
   (kbd "C-u") "next-urgent"
   (kbd "w")   "windows"
   (kbd "C-w") "windows"
+  (kbd "DEL") "repack-window-numbers"
   (kbd "k")   "delete"
   (kbd "C-k") "delete"
   (kbd "K")   "kill"
@@ -133,7 +134,8 @@ from most specific groups to most general groups.")
   (kbd "#")   "mark"
   (kbd "F11") "fullscreen"
   (kbd "A")   "title"
-  (kbd "i")   "info")
+  (kbd "i")   "info"
+  (kbd "I")   "show-window-properties")
 
 (fill-keymap *tile-group-top-map*
   *escape-key* '*tile-group-root-map*)

--- a/time.lisp
+++ b/time.lisp
@@ -42,8 +42,8 @@
 	  echo-date
 	  time))
 
-(defvar *time-format-string-default* "%a %b %e %k:%M:%S"
-  "The default value for `echo-date', (e.g, Thu Mar  3 23:05:25 2005).")
+(defvar *time-format-string-default* "%a %b %e %Y %k:%M:%S"
+  "The default value for `echo-date', (e.g, Thu Mar  3 2005 23:05:25).")
 
 (defvar *time-modeline-string* "%a %b %e %k:%M:%S"
   "The default time value to pass to the modeline.")


### PR DESCRIPTION
*time-format-string-default* is used for the version command.
Up to now the year was not included.