### PR TITLE
Replace the fullscreen-SDL skip-raise heuristic with grabbing the server

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -147,8 +147,9 @@
          ;; anyway.
          t)
         (t
-         (let ((window (process-mapped-window screen window)))
-           (group-raise-request (window-group window) window :map)))))))
+         (xlib:with-server-grabbed (*display*)
+           (let ((window (process-mapped-window screen window)))
+             (group-raise-request (window-group window) window :map))))))))
 
 (define-stump-event-handler :unmap-notify (send-event-p event-window window #|configure-p|#)
   ;; There are two kinds of unmap notify events: the straight up

--- a/window.lisp
+++ b/window.lisp
@@ -348,38 +348,16 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
                                   (xlib:drawable-y (window-parent win))
                                   (window-width win) (window-height win) 0))
 
-(defun window-fullscreen-locked-p (win)
-  (let* ((xwin (window-xwin win))
-         (hints (xlib:wm-normal-hints xwin)))
-    (with-accessors
-     ((min-width xlib:wm-size-hints-min-width)
-      (max-width xlib:wm-size-hints-max-width)
-      (min-height xlib:wm-size-hints-min-height)
-      (max-height xlib:wm-size-hints-max-height)
-      (x xlib:wm-size-hints-x)
-      (y xlib:wm-size-hints-y))
-        hints
-      (and
-       hints
-       x y
-       max-height min-height
-       max-width min-width
-       (= x 0) (= y 0)
-       (= min-height max-height)
-       (= min-width max-width)))))
-
 ;; FIXME: should we raise the window or its parent?
 (defmethod raise-window (win)
   "Map the window if needed and bring it to the top of the stack. Does not affect focus."
-  (let ((maxmin-notequal (not (window-fullscreen-locked-p win))))
-    (when (window-urgent-p win)
-      (window-clear-urgency win))
-    (when (window-hidden-p win)
-      (unhide-window win)
-      (if maxmin-notequal
-          (update-configuration win)))
-    (when (and maxmin-notequal (window-in-current-group-p win))
-      (setf (xlib:window-priority (window-parent win)) :top-if))))
+  (when (window-urgent-p win)
+    (window-clear-urgency win))
+  (when (window-hidden-p win)
+    (unhide-window win)
+    (update-configuration win))
+  (when (window-in-current-group-p win)
+    (setf (xlib:window-priority (window-parent win)) :top-if)))
 ;; some handy wrappers
 
 (defun xwin-border-width (win)
@@ -646,32 +624,31 @@ and bottom_end_x."
   ;; apparently we need to grab the server so the client doesn't get
   ;; the mapnotify event before the reparent event. that's what fvwm
   ;; says.
-  (xlib:with-server-grabbed (*display*)
-    (let* ((xwin (window-xwin window))
-           (master-window (xlib:create-window
-                           :parent (screen-root screen)
-                           :x (xlib:drawable-x (window-xwin window))
-                           :y (xlib:drawable-y (window-xwin window))
-                           :width (window-width window)
-                           :height (window-height window)
-                           :background (if (eq (window-type window) :normal)
-                                           (screen-win-bg-color screen)
-                                           :none)
-                           :border (screen-unfocus-color screen)
-                           :border-width (default-border-width-for-type window)
-                           :event-mask *window-parent-events*
-                           :depth (xlib:drawable-depth xwin)
-                           :visual (xlib:window-visual-info xwin)
-                           :colormap (xlib:window-colormap xwin))))
-      (unless (eq (xlib:window-map-state (window-xwin window)) :unmapped)
-        (incf (window-unmap-ignores window)))
-      (xlib:reparent-window (window-xwin window) master-window 0 0)
-      (xwin-grab-buttons master-window)
-      ;;     ;; we need to update these values since they get set to 0,0 on reparent
-      ;;     (setf (window-x window) 0
-      ;;          (window-y window) 0)
-      (xlib:add-to-save-set (window-xwin window))
-      (setf (window-parent window) master-window))))
+  (let* ((xwin (window-xwin window))
+         (master-window (xlib:create-window
+                         :parent (screen-root screen)
+                         :x (xlib:drawable-x (window-xwin window))
+                         :y (xlib:drawable-y (window-xwin window))
+                         :width (window-width window)
+                         :height (window-height window)
+                         :background (if (eq (window-type window) :normal)
+                                         (screen-win-bg-color screen)
+                                         :none)
+                         :border (screen-unfocus-color screen)
+                         :border-width (default-border-width-for-type window)
+                         :event-mask *window-parent-events*
+                         :depth (xlib:drawable-depth xwin)
+                         :visual (xlib:window-visual-info xwin)
+                         :colormap (xlib:window-colormap xwin))))
+    (unless (eq (xlib:window-map-state (window-xwin window)) :unmapped)
+      (incf (window-unmap-ignores window)))
+    (xlib:reparent-window (window-xwin window) master-window 0 0)
+    (xwin-grab-buttons master-window)
+    ;;     ;; we need to update these values since they get set to 0,0 on reparent
+    ;;     (setf (window-x window) 0
+    ;;          (window-y window) 0)
+    (xlib:add-to-save-set (window-xwin window))
+    (setf (window-parent window) master-window)))
 
 (defun process-existing-windows (screen)
   "Windows present when stumpwm starts up must be absorbed by stumpwm."
@@ -698,7 +675,8 @@ and bottom_end_x."
                       (eql wm-state +iconic-state+))
                   (progn
                     (dformat 1 "Processing ~S ~S~%" (xwin-name win) win)
-                    (process-mapped-window screen win))))))))
+                    (xlib:with-server-grabbed (*display*)
+                      (process-mapped-window screen win)))))))))
   (dolist (w (screen-windows screen))
     (setf (window-state w) +normal-state+)
     (xwin-hide w)))


### PR DESCRIPTION
SDL-1.2 in fullscreen mode draws to a override-redirect window it
places covering the entire screen. However, it still creates a normal
wm-controlled window that it will not paint to, and if we take too
long between mapping that window and raising it, then it can wind up
hiding the intended fullscreen window.

Rather than attempt to guess which windows are non-painted SDL
windows, just grab the server for the entire map+raise section.

See #138