### PR TITLE
Fix "y-or-n" prompt

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -300,8 +300,7 @@ then describes the symbol."
 (define-stumpwm-type :y-or-n (input prompt)
   (let ((s (or (argument-pop input)
                (read-one-line (current-screen) (concat prompt "(y/n): ")))))
-    (when s
-      (values (list (equal s "y"))))))
+    (equal s "y")))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -415,7 +415,7 @@ frame. Possible values are:
                                   ((:y-or-n "Lock to group? ")
                                    (:y-or-n "Use title? "))
   "Make a generic placement rule for the current window. Might be too specific/not specific enough!"
-  (make-rule-for-window (current-window) (first lock) (first title)))
+  (make-rule-for-window (current-window) lock title))
 
 (defcommand (forget tile-group) () ()
   "Forget the window placement rule that matches the current window."


### PR DESCRIPTION
Hello, try this command:

```lisp
(defcommand bool-test (bool) ((:y-or-n ""))
  (if bool
      (echo "yes")
      (echo "no")))
```

Now call it interactively and you always get "yes" message no matter if
you press `y` or `n`.

Alternatively, try this:

```lisp
(defcommand bool-test (bool) ((:y-or-n ""))
  (echo bool))
```

It will display either `(T)` or `(NIL)`.  As you can see it wraps the
boolean value into a list. ``(define-stumpwm-type :y-or-n ...)`` does
this.  I also don't see a reason to use `values` and `when` there, or do
I miss anything?
