### PR TITLE
Export *RESTART-HOOK*

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -43,6 +43,7 @@
           *focus-window-hook*
           *place-window-hook*
           *start-hook*
+          *restart-hook*
           *quit-hook*
           *internal-loop-hook*
           *event-processing-hook*


### PR DESCRIPTION
It'd probably be good were it exported as well as defined …

Sorry, I was in the STUMPWM package when testing.