### PR TITLE
Top-level condition handling

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -146,6 +146,11 @@ The action is to call FUNCTION with arguments ARGS."
   (muffle-warning))
 
 (defmethod handle-top-level-condition ((c serious-condition))
+  (when (and (find-restart :remove-channel)
+             (not (typep *current-io-channel*
+                         '(or stumpwm-timer-channel display-channel))))
+    (message "Removed channel ~S due to uncaught error '~A'." *current-io-channel* c)
+    (invoke-restart :remove-channel))
   (ecase *top-level-error-action*
     (:message
      (let ((s (format nil "~&Caught '~a' at the top level. Please report this." c)))

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -161,11 +161,6 @@ The action is to call FUNCTION with arguments ARGS."
     (:abort
      (throw :top-level (list c (backtrace-string))))))
 
-(defmethod handle-top-level-condition ((c xlib:lookup-error))
-  (if (lookup-error-recoverable-p)
-      (recover-from-lookup-error)
-      (call-next-method)))
-
 (defclass stumpwm-timer-channel () ())
 
 (defmethod io-channel-ioport (io-loop (channel stumpwm-timer-channel))

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -261,15 +261,6 @@ they should be windows. So use this function to make a window out of them."
   #-(or sbcl clisp ecl openmcl lispworks)
   (error 'not-implemented))
 
-;; Right now clisp and sbcl both work the same way
-(defun lookup-error-recoverable-p ()
-  #+(or clisp sbcl) (find :one (compute-restarts) :key 'restart-name)
-  #-(or clisp sbcl) nil)
-
-(defun recover-from-lookup-error ()
-  #+(or clisp sbcl) (invoke-restart :one)
-  #-(or clisp sbcl) (error 'not-implemented))
-
 (defun directory-no-deref (pathspec)
   "Call directory without dereferencing symlinks in the results"
   #+(or cmu scl) (directory pathspec :truenamep nil)


### PR DESCRIPTION
I wanted to add more proper error-handling for I/O channels that cause errors, but the top-level condition handling was already quite complex, so I tried to clean it up a bit by moving its functionality to a generic function. Then I added I/O channel error handling.

One advantage of handling errors this way is also that new methods can be defined/redefined on HANDLE-TOP-LEVEL-CONDITION without having to restart the STUMPWM-INTERNAL-LOOP, making it easier to patch error-handling at runtime.

The resulting functionality should be similar to previously, but as I was at it, I did change so that non-warning, non-serious conditions are ignored, rather than handled as if they were errors. I would like to think that is the correct way of handling them, as they are likely to be "informational" conditions rather than things to be handled.

Also, this allows for the possibility to move the whole XLIB:LOOKUP-ERROR handling to workarounds.lisp, where the rest of it is, but I wasn't sure whether I should do so.