### PR TITLE
add purify to image dump for sbcl.

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -10,7 +10,8 @@
                                                 (sb-posix:putenv (format nil "SBCL_HOME=~A" #.(sb-ext:posix-getenv "SBCL_HOME")))
                                                 (stumpwm:stumpwm)
                                                 0)
-                          :executable t)
+                                    :executable t
+                                    :purify t)
 
 #+clisp
 (ext:saveinitmem "stumpwm" :init-function (lambda ()


### PR DESCRIPTION
If true (the default on cheneygc), do a purifying gc which moves all dynamically allocated objects into static space. This takes somewhat longer than the normal gc which is otherwise done, but it’s only done once, and subsequent GC’s will be done less often and will take less time in the resulting core file. See the purify function. This parameter has no effect on platforms using the generational garbage collector[1].

[1] - http://www.sbcl.org/manual/