### PR TITLE
Remove *RESIZE-BACKUP*

### DIFF
--- a/iresize.lisp
+++ b/iresize.lisp
@@ -30,8 +30,6 @@
           abort-iresize
           exit-iresize))
 
-(defvar *resize-backup* nil)
-
 (defvar *resize-increment* 10
   "Number of pixels to increment by when interactively resizing frames.")
 
@@ -82,9 +80,7 @@ resizing the current frame is loaded. Hit @key{C-g}, @key{RET}, or
               (clear-frame f (current-group))))
           (message "Resize Frame")
           (push-top-map *resize-map*)
-          (draw-frame-outlines (current-group) (current-head)))
-        ;;   (setf *resize-backup* (copy-frame-tree (current-group)))
-        )))
+          (draw-frame-outlines (current-group) (current-head))))))
 
 (defun resize-unhide ()
   (clear-frame-outlines (current-group))


### PR DESCRIPTION
It was never used anywhere. The variable was introduced alongside the
initial implementation of iresize, in the commit https://github.com/stumpwm/stumpwm/commit/a71e89. It was
probably used for for debugging purposes.