### PR TITLE
Remove unused screen argument from RENDER-STRINGS

### DIFF
--- a/color.lisp
+++ b/color.lisp
@@ -352,7 +352,7 @@ rendered width."
               (apply #'apply-color cc (first part) (rest part))))
     (values height draw-x)))
 
-(defun render-strings (screen cc padx pady strings highlights)
+(defun render-strings (cc padx pady strings highlights)
   (let* ((gc (ccontext-gc cc))
          (xwin (ccontext-win cc))
          (px (ccontext-px cc))

--- a/message-window.lisp
+++ b/message-window.lisp
@@ -220,7 +220,7 @@ function expects to be wrapped in a with-state for win."
       (multiple-value-bind (width height)
           (rendered-size strings (screen-message-cc screen))
         (setup-message-window screen width height)
-        (render-strings screen (screen-message-cc screen) *message-window-padding* 0 strings highlights))
+        (render-strings (screen-message-cc screen) *message-window-padding* 0 strings highlights))
       (setf (screen-current-msg screen)
             strings
             (screen-current-msg-highlights screen)

--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -412,9 +412,8 @@ critical."
       (when (or force (not (string= (mode-line-contents ml) string)))
         (setf (mode-line-contents ml) string)
         (resize-mode-line ml)
-        (render-strings (mode-line-screen ml) (mode-line-cc ml)
-                        *mode-line-pad-x*     *mode-line-pad-y*
-                        (split-string string (string #\Newline)) '())))))
+        (render-strings (mode-line-cc ml) *mode-line-pad-x* *mode-line-pad-y*
+                        (split-string string (string #\Newline)) ())))))
 
 (defun find-mode-line-window (xwin)
   (dolist (s *screen-list*)


### PR DESCRIPTION
Its use in the function was removed in #251. Remove it as it is no
longer necessary