### PR TITLE
Register systems as immutable in a built image

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -4,6 +4,13 @@
 
 #-ecl (stumpwm:set-module-dir "@MODULE_DIR@")
 
+(when (uiop:version<= "3.1.5" (asdf:asdf-version))
+  ;; We register StumpWM and its dependencies as immutable, to stop ASDF from
+  ;; looking for their source code when loading modules.
+  (asdf:register-immutable-system :stumpwm)
+  (dolist (system-name (asdf:system-depends-on (asdf:find-system :stumpwm)))
+    (asdf:register-immutable-system system-name)))
+
 #+sbcl
 (sb-ext:save-lisp-and-die "stumpwm" :toplevel (lambda ()
                                                 ;; asdf requires sbcl_home to be set, so set it to the value when the image was built


### PR DESCRIPTION
If a contrib module depends on the `stumpwm` system, ASDF will look for it in the build directory. When that directory no longer exists (which is fairly likely), loading of the module will fail.

By registering StumpWM and dependencies as ["immutable"](https://common-lisp.net/project/asdf/asdf.html#index-register_002dimmutable_002dsystem-1), we tell ASDF to treat the system as already loaded. It will not look for the system definition nor the source code again, unless you explicitly request it to be loaded.

Fixes stumpwm/stumpwm-contrib#17 (already marked as fixed, but not generally)
Fixes stumpwm/stumpwm-contrib#53

Some more testing would be appreciated.