### PR TITLE
Implement CALL-IN-MAIN-THREAD

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -19,7 +19,9 @@
 
 (defpackage :stumpwm
   (:use :cl)
-  (:shadow #:yes-or-no-p #:y-or-n-p))
+  (:shadow #:yes-or-no-p #:y-or-n-p)
+  (:export
+   #:call-in-main-thread))
 
 (defpackage :stumpwm-user
   (:use :cl :stumpwm))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -19,7 +19,7 @@
   ;; :license "GNU General Public License"
   :description "A tiling, keyboard driven window manager" 
   :serial t
-  :depends-on (:cl-ppcre #-cmu :clx #+sbcl :sb-posix :bordeaux-threads)
+  :depends-on (:cl-ppcre #-cmu :clx #+sbcl :sb-posix)
   :components ((:file "package")
                (:file "primitives")
                (:file "workarounds")

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -19,7 +19,7 @@
   ;; :license "GNU General Public License"
   :description "A tiling, keyboard driven window manager" 
   :serial t
-  :depends-on (:cl-ppcre #-cmu :clx #+sbcl :sb-posix)
+  :depends-on (:cl-ppcre #-cmu :clx #+sbcl :sb-posix :bordeaux-threads)
   :components ((:file "package")
                (:file "primitives")
                (:file "workarounds")

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -227,7 +227,7 @@ The action is to call FUNCTION with arguments ARGS."
   (declare (ignore io-loop))
   (ccl::stream-device channel :input))
 
-#+(or sbcl ccl)
+#+sbcl
 (defun call-in-main-thread (fn)
   (with-lock-held ((request-channel-lock *request-channel*))
     (push fn (request-channel-queue *request-channel*)))
@@ -239,7 +239,7 @@ The action is to call FUNCTION with arguments ARGS."
     (write-byte 0 out)
     (finish-output out)))
 
-#-(or sbcl ccl)
+#-sbcl
 (defun call-in-main-thread (fn)
   (run-with-timer 0 nil fn))
 
@@ -275,10 +275,8 @@ The action is to call FUNCTION with arguments ARGS."
          (io-loop-add io (make-instance 'display-channel :display *display*))
 
          ;; If we have no implementation for the current CL, then
-         ;; don't register the channel, and the implementation of
-         ;; call-in-main-thread will simply call the function directly
-         ;; even though that's completely thread-unsafe.
-         #+(or sbcl ccl)
+         ;; don't register the channel.
+         #+sbcl
          (multiple-value-bind (in out)
              (open-pipe)
            (let ((channel (make-instance 'request-channel :in in :out out)))

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -222,6 +222,11 @@ The action is to call FUNCTION with arguments ARGS."
     (dolist (event (reverse events))
       (funcall event))))
 
+#+ccl
+(defmethod io-channel-ioport (io-loop (channel ccl::fd-binary-input-stream))
+  (declare (ignore io-loop))
+  (ccl::stream-device channel :input))
+
 #+(or sbcl ccl)
 (defun call-in-main-thread (fn)
   (with-lock-held ((request-channel-lock *request-channel*))

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -162,7 +162,7 @@ The action is to call FUNCTION with arguments ARGS."
 (defmethod handle-top-level-condition ((c serious-condition))
   (when (and (find-restart :remove-channel)
              (not (typep *current-io-channel*
-                         '(or stumpwm-timer-channel display-channel))))
+                         '(or stumpwm-timer-channel display-channel request-channel))))
     (message "Removed channel ~S due to uncaught error '~A'." *current-io-channel* c)
     (invoke-restart :remove-channel))
   (ecase *top-level-error-action*
@@ -188,6 +188,62 @@ The action is to call FUNCTION with arguments ARGS."
   (run-expired-timers))
 (defmethod io-channel-handle ((channel stumpwm-timer-channel) (event (eql :loop)) &key)
   (run-expired-timers))
+
+(defclass request-channel ()
+  ((in    :initarg :in
+          :reader request-channel-in)
+   (out   :initarg :out
+          :reader request-channel-out)
+   (queue :initform nil
+          :accessor request-channel-queue)
+   (lock  :initform (bordeaux-threads:make-lock)
+          :reader request-channel-lock)))
+
+(defvar *request-channel* nil)
+
+#+sbcl
+(defun open-pipe (&key (element-type '(unsigned-byte 8)))
+  (multiple-value-bind (in-fd out-fd)
+      (sb-posix:pipe)
+    (let ((in-stream (sb-sys:make-fd-stream in-fd :input t :element-type element-type))
+          (out-stream (sb-sys:make-fd-stream out-fd :output t :element-type element-type)))
+      (values in-stream out-stream))))
+
+#-sbcl
+(defun open-pipe (&key (element-type '(unsigned-byte 8)))
+  (error "Unsupported CL implementation"))
+
+(defmethod io-channel-ioport (io-loop (channel request-channel))
+  (io-channel-ioport io-loop (request-channel-in channel)))
+
+(defmethod io-channel-events ((channel request-channel))
+  (list :read))
+
+(defmethod io-channel-handle ((channel request-channel) (event (eql :read)) &key)
+  ;; At this point, we know that there is at least one request written
+  ;; on the pipe. We read all the data off the pipe and then evaluate
+  ;; all the waiting jobs.
+  (loop
+    with in = (request-channel-in channel)
+    do (read-byte in)
+    while (listen in))
+  (let ((events (bordeaux-threads:with-lock-held ((request-channel-lock channel))
+                  (let ((queue-copy (request-channel-queue channel)))
+                    (setf (request-channel-queue channel) nil)
+                    queue-copy))))
+    (dolist (event (reverse events))
+      (funcall event))))
+
+(defun call-in-main-thread (fn)
+  (bordeaux-threads:with-lock-held ((request-channel-lock *request-channel*))
+    (push fn (request-channel-queue *request-channel*)))
+  (let ((out (request-channel-out *request-channel*)))
+    ;; For now, just write a single byte since all we want is for the
+    ;; main thread to process the queue. If we want to handle
+    ;; different types of events, we'll have to change this so that
+    ;; the message sent indicates the event type instead.
+    (write-byte 0 out)
+    (finish-output out)))
 
 (defclass display-channel ()
   ((display :initarg :display)))
@@ -219,6 +275,11 @@ The action is to call FUNCTION with arguments ARGS."
        (let ((io (make-instance *default-io-loop*)))
          (io-loop-add io (make-instance 'stumpwm-timer-channel))
          (io-loop-add io (make-instance 'display-channel :display *display*))
+         (multiple-value-bind (in out)
+             (open-pipe)
+           (let ((channel (make-instance 'request-channel :in in :out out)))
+             (io-loop-add io channel)
+             (setq *request-channel* channel)))
          (setf *toplevel-io* io)
          (loop
             (handler-bind

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -397,13 +397,13 @@ stream, and the second valus is the output stream."
   (sb-thread:make-mutex)
   #+ccl
   (ccl:make-lock "Anonymous lock")
-  #+clisp
+  #+(and clisp mt)
   (mt:make-mutex)
   #+lispworks
   (mp:make-lock)
   #+ecl
   (mp:make-lock)
-  #-(or sbcl ccl clisp lispworks ecl)
+  #-(or sbcl ccl (and clisp mt) lispworks ecl)
   nil)
 
 (defmacro with-lock-held ((lock) &body body)
@@ -413,7 +413,7 @@ stream, and the second valus is the output stream."
   #+ccl
   `(ccl:with-lock-grabbed (,lock)
      ,@body)
-  #+clisp
+  #+(and clisp mt)
   `(mt:with-mutex-lock (,lock)
      ,@body)
   #+lispworks
@@ -422,7 +422,7 @@ stream, and the second valus is the output stream."
   #+ecl
   `(mp:with-lock (,lock)
      ,@body)
-  #-(or sbcl ccl clisp ecl)
+  #-(or sbcl ccl (and clisp mt) ecl)
   `(progn
      ,@body))
 

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -385,7 +385,7 @@ regarding files in sysfs. Data is read in chunks of BLOCKSIZE bytes."
 
 (defun open-pipe (&key (element-type '(unsigned-byte 8)))
   "Create a pipe and return two streams. The first value is the input
-stream, and the second valus is the output stream."
+stream, and the second value is the output stream."
   #+sbcl
   (multiple-value-bind (in-fd out-fd)
       (sb-posix:pipe)

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -420,8 +420,8 @@ stream, and the second valus is the output stream."
   `(mp:with-lock (,lock)
      ,@body)
   #+ecl
-  (mp:with-lock (,lock)
-    ,@body)
+  `(mp:with-lock (,lock)
+     ,@body)
   #-(or sbcl ccl clisp ecl)
   `(progn
      ,@body))


### PR DESCRIPTION
This function allows a multi-threaded module to perform actions on the main
event handler thread and should be used whenever a different thread
needs to invoke any stumpwm functions.

Currently, only SBCL is supported.
