### PR TITLE
Fix window border updating on Java windows

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -901,10 +901,10 @@ needed."
             (member :WM_TAKE_FOCUS (xlib:wm-protocols xwin) :test #'eq))
        (let ((hints (xlib:wm-hints xwin)))
          (when (or (null hints) (eq (xlib:wm-hints-input hints) :on))
-           (screen-set-focus screen window)
-           (update-decoration window)
-           (when cw
-             (update-decoration cw))))
+           (screen-set-focus screen window)))
+       (update-decoration window)
+       (when cw
+         (update-decoration cw))
        (move-window-to-head group window)
        (send-client-message window :WM_PROTOCOLS
                             (xlib:intern-atom *display* :WM_TAKE_FOCUS)


### PR DESCRIPTION
When focusing some Java windows, like the IntelliJ app, window borders were not updated. I think this commit fixes that and I haven't noticed it causing any problems with other windows.

To test:

Without patch, move focus to IntelliJ window, notice that border doesn't update to show the window as selected.

With this patch, do the same thing, notice window border shows that it is selected.