### PR TITLE
Add which-key-mode

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -141,8 +141,7 @@ KMAPS are enabled"
 (defun which-key-mode-key-press-hook (key key-seq cmd)
   "*key-press-hook* for which-key-mode"
   (declare (ignore key))
-  (when (and (find 'which-key *enabled-minor-modes*)
-             (not (eq *top-map* *resize-map*)))
+  (when (not (eq *top-map* *resize-map*))
     (let* ((oriented-key-seq (reverse key-seq))
            (maps (get-kmaps-at-key-seq (dereference-kmaps (top-maps)) oriented-key-seq)))
       (when (remove-if-not 'kmap-p maps)
@@ -150,10 +149,9 @@ KMAPS are enabled"
 
 (defcommand which-key-mode () ()
   "Toggle which-key-mode"
-  (setf *enabled-minor-modes*
-        (if (find 'which-key *enabled-minor-modes*)
-            (remove 'which-key *enabled-minor-modes*)
-            (cons 'which-key *enabled-minor-modes*))))
+  (if (find 'which-key-mode-key-press-hook *key-press-hook*)
+      (remove-hook *key-press-hook* 'which-key-mode-key-press-hook)
+      (add-hook *key-press-hook* 'which-key-mode-key-press-hook)))
 
 (defcommand modifiers () ()
   "List the modifiers stumpwm recognizes and what MOD-X it thinks they're on."

--- a/help.lisp
+++ b/help.lisp
@@ -115,7 +115,45 @@ command prints the command bound to the specified key sequence."
                       cmd
                       (mapcar 'print-key-seq bindings))
       (message-no-timeout "Command \"~a\" is not currently bound"
-                      cmd))))
+                          cmd))))
+
+(defun get-kmaps-at-key (kmaps key)
+  (dereference-kmaps
+   (reduce
+    (lambda (result map)
+      (let* ((binding (find key (kmap-bindings map)
+                            :key 'binding-key :test 'equalp))
+             (command (when binding (binding-command binding))))
+        (if command
+            (setf result (cons command result))
+            result)))
+    kmaps
+    :initial-value ())))
+
+(defun get-kmaps-at-key-seq (kmaps key-seq)
+  "get a list of kmaps that are activated when pressing KEY-SEQ when
+KMAPS are enabled"
+  (if (= 1 (length key-seq))
+      (get-kmaps-at-key kmaps (first key-seq))
+      (get-kmaps-at-key-seq (get-kmaps-at-key kmaps (first key-seq))
+                            (rest key-seq))))
+
+(defun which-key-mode-key-press-hook (key key-seq cmd)
+  "*key-press-hook* for which-key-mode"
+  (declare (ignore key))
+  (when (and (find 'which-key *enabled-minor-modes*)
+             (not (eq *top-map* *resize-map*)))
+    (let* ((oriented-key-seq (reverse key-seq))
+           (maps (get-kmaps-at-key-seq (dereference-kmaps (top-maps)) oriented-key-seq)))
+      (when (remove-if-not 'kmap-p maps)
+        (apply 'display-bindings-for-keymaps oriented-key-seq maps)))))
+
+(defcommand which-key-mode () ()
+  "Toggle which-key-mode"
+  (setf *enabled-minor-modes*
+        (if (find 'which-key *enabled-minor-modes*)
+            (remove 'which-key *enabled-minor-modes*)
+            (cons 'which-key *enabled-minor-modes*))))
 
 (defcommand modifiers () ()
   "List the modifiers stumpwm recognizes and what MOD-X it thinks they're on."

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -168,10 +168,7 @@
           ;; Conditions
           stumpwm-condition
           stumpwm-error
-          stumpwm-warning
-
-          ;; Minor Mode
-          *enabled-minor-modes*))
+          stumpwm-warning))
 
 
 
@@ -305,7 +302,7 @@ run before the error is dealt with according to
 (defvar *focus-group-hook* '()
   "A hook called whenever stumpwm switches groups. It is called with 2 arguments: the current group and the last group.")
 
-(defvar *key-press-hook* `(which-key-mode-key-press-hook)
+(defvar *key-press-hook* '()
   "A hook called whenever a key under *top-map* is pressed.
 It is called with 3 argument: the key, the (possibly incomplete) key
 sequence it is a part of, and command value bound to the key.")
@@ -334,11 +331,6 @@ the command as a symbol.")
 (defvar *post-command-hook* '()
   "Called after a command is called. It is called with 1 argument:
 the command as a symbol.")
-
-;; Minor-mode related variables
-
-(defvar *enabled-minor-modes* '()
-  "Contains the list of enabled minor modes.")
 
 ;; Data types and globals used by stumpwm
 

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -168,7 +168,10 @@
           ;; Conditions
           stumpwm-condition
           stumpwm-error
-          stumpwm-warning))
+          stumpwm-warning
+
+          ;; Minor Mode
+          *enabled-minor-modes*))
 
 
 
@@ -302,7 +305,7 @@ run before the error is dealt with according to
 (defvar *focus-group-hook* '()
   "A hook called whenever stumpwm switches groups. It is called with 2 arguments: the current group and the last group.")
 
-(defvar *key-press-hook* '()
+(defvar *key-press-hook* `(which-key-mode-key-press-hook)
   "A hook called whenever a key under *top-map* is pressed.
 It is called with 3 argument: the key, the (possibly incomplete) key
 sequence it is a part of, and command value bound to the key.")
@@ -331,6 +334,11 @@ the command as a symbol.")
 (defvar *post-command-hook* '()
   "Called after a command is called. It is called with 1 argument:
 the command as a symbol.")
+
+;; Minor-mode related variables
+
+(defvar *enabled-minor-modes* '()
+  "Contains the list of enabled minor modes.")
 
 ;; Data types and globals used by stumpwm
 


### PR DESCRIPTION
This replaces: https://github.com/stumpwm/stumpwm-contrib/pull/58
![out](https://cloud.githubusercontent.com/assets/4379046/21130448/5f1d80ce-c0bd-11e6-95d8-bb8a8805aac5.gif)
I've attached a GIF demonstrating the behavior of `which-key-mode`