### PR TITLE
ensure a key's modifiers exist before grabbing it

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -683,15 +683,17 @@ and bottom_end_x."
              (let ((key (copy-structure key)))
                (setf (key-shift key) t)
                key))
+           (key-modifiers-exist-p (key)
+             (and
+              (or (not (key-meta key)) (modifiers-meta *modifiers*))
+              (or (not (key-alt key)) (modifiers-alt *modifiers*))
+              (or (not (key-hyper key)) (modifiers-hyper *modifiers*))
+              (or (not (key-super key)) (modifiers-super *modifiers*))))
            (grabit (w key)
              (loop for code in (multiple-value-list (xlib:keysym->keycodes *display* (key-keysym key))) do
                ;; some keysyms aren't mapped to keycodes so just ignore them.
-               (when (and code
-                             ;;temporary hack to make sure H-a
-                             ;;doesn't cause "a" to be grabbed
-                             ;;when there is no H
-                             (or (not (key-hyper key))
-                                 (modifiers-hyper *modifiers*)))
+                  (when (and code
+                             (key-modifiers-exist-p key))
                  ;; Some keysyms, such as upper case letters, need the
                  ;; shift modifier to be set in order to grab properly.
                  (let ((key

--- a/window.lisp
+++ b/window.lisp
@@ -690,10 +690,10 @@ and bottom_end_x."
               (or (not (key-hyper key)) (modifiers-hyper *modifiers*))
               (or (not (key-super key)) (modifiers-super *modifiers*))))
            (grabit (w key)
-             (loop for code in (multiple-value-list (xlib:keysym->keycodes *display* (key-keysym key))) do
+             (loop for code in (multiple-value-list (xlib:keysym->keycodes *display* (key-keysym key)))
                ;; some keysyms aren't mapped to keycodes so just ignore them.
-                  (when (and code
-                             (key-modifiers-exist-p key))
+                when (and code (key-modifiers-exist-p key))
+                  do
                  ;; Some keysyms, such as upper case letters, need the
                  ;; shift modifier to be set in order to grab properly.
                  (let ((key
@@ -713,7 +713,7 @@ and bottom_end_x."
                                     :modifiers (x11-mods key t nil) :owner-p t
                                     :sync-pointer-p nil :sync-keyboard-p nil)
                      (xlib:grab-key w code :modifiers (x11-mods key t t) :owner-p t
-                                    :sync-keyboard-p nil :sync-keyboard-p nil)))))))
+                                    :sync-keyboard-p nil :sync-keyboard-p nil))))))
     (dolist (map (dereference-kmaps (top-maps group)))
       (dolist (i (kmap-bindings map))
         (grabit win (binding-key i))))))

--- a/window.lisp
+++ b/window.lisp
@@ -686,7 +686,12 @@ and bottom_end_x."
            (grabit (w key)
              (loop for code in (multiple-value-list (xlib:keysym->keycodes *display* (key-keysym key))) do
                ;; some keysyms aren't mapped to keycodes so just ignore them.
-               (when code
+               (when (and code
+                             ;;temporary hack to make sure H-a
+                             ;;doesn't cause "a" to be grabbed
+                             ;;when there is no H
+                             (or (not (key-hyper key))
+                                 (modifiers-hyper *modifiers*)))
                  ;; Some keysyms, such as upper case letters, need the
                  ;; shift modifier to be set in order to grab properly.
                  (let ((key


### PR DESCRIPTION
fix grabbing wrong key when modifier is missing
fixes #296