### PR TITLE
Don't assume ASDF:SYSTEM-DEPENDS-ON exists

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -8,7 +8,7 @@
   ;; We register StumpWM and its dependencies as immutable, to stop ASDF from
   ;; looking for their source code when loading modules.
   (uiop:symbol-call '#:asdf '#:register-immutable-system :stumpwm)
-  (dolist (system-name (asdf:system-depends-on (asdf:find-system :stumpwm)))
+  (dolist (system-name (uiop:symbol-call '#:asdf '#:system-depends-on (asdf:find-system :stumpwm)))
     (uiop:symbol-call '#:asdf '#:register-immutable-system system-name)))
 
 #+sbcl


### PR DESCRIPTION
On ASDF versions prior to 3.15 we can't assume that the symbol
SYSTEM-DEPENDS-ON is exported in the ASDF package. If it is not present the
reader signals an error even though the code won't be executed.

As reported by user jmccabe on IRC. They were using SBCL 1.1.14 with ASDF 3.0.3 which are 3 years old on Linux Mint 17.