### PR TITLE
Do not export FLATTEN symbol

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -124,7 +124,6 @@
           concat
           data-dir-file
           dformat
-          flatten
           define-frame-preference
           redirect-all-output
           remove-hook


### PR DESCRIPTION
Although I can't reproduce the issue reported by [Dimitri](http://lists.nongnu.org/archive/html/stumpwm-devel/2017-01/msg00010.html), stump-tray loads fine and I have no issues using both packages at the same time, i.e.

```lisp
(defpackage #:foo
  (:use #:cl #:stumpwm #:alexandria))
```

There is no reason why we should be exporting the flatten function anyway. I rgrep'ed through our contrib folder and found no uses of it so we should be save.