### PR TITLE
toggle-always-show for float windows

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -39,7 +39,8 @@
 (defvar *default-group-type* 'tile-group
   "The type of group that should be created by default.")
 
-(defvar *always-show-windows* ())
+(defvar *always-show-windows* ()
+  "The list of windows shown in all groups")
 
 (defclass group ()
   ((screen :initarg :screen :accessor group-screen)

--- a/group.lisp
+++ b/group.lisp
@@ -161,6 +161,8 @@ at 0. Return a netwm compliant group id."
   (let ((screen (group-screen group)))
     (position group (sort-groups screen))))
 
+(defvar always-show-windows ())
+
 (defun switch-to-group (new-group)
   (let* ((screen (group-screen new-group))
          (old-group (screen-current-group screen)))
@@ -180,8 +182,18 @@ at 0. Return a netwm compliant group id."
       (xlib:change-property (screen-root screen) :_NET_CURRENT_DESKTOP
                             (list (netwm-group-id new-group))
                             :cardinal 32)
+      (mapc (lambda (w)
+              (xwin-unhide (window-xwin w) (window-parent w)))
+            always-show-windows)
       (update-all-mode-lines)
       (run-hook-with-args *focus-group-hook* new-group old-group))))
+
+(defcommand toggle-always-show () ()
+  (let ((w (current-window)))
+    (when w
+      (if (find w always-show-windows)
+          (setq always-show-windows (remove w always-show-windows))
+          (push w always-show-windows)))))
 
 (defun move-window-to-group (window to-group)
   (labels ((really-move-window (window to-group)

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -149,7 +149,7 @@
   (when (typep where 'stumpwm.floating-group::float-window)
     (call-next-method))
   (when (eq *mouse-focus-policy* :click)
-    (group-focus-window group where)
+    (focus-all where)
     (update-all-mode-lines)))
 
 (defmethod group-root-exposure ((group tile-group))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -149,7 +149,7 @@
   (when (typep where 'stumpwm.floating-group::float-window)
     (call-next-method))
   (when (eq *mouse-focus-policy* :click)
-    (focus-all where)
+    (group-focus-window group where)
     (update-all-mode-lines)))
 
 (defmethod group-root-exposure ((group tile-group))

--- a/window.lisp
+++ b/window.lisp
@@ -54,7 +54,7 @@
    (x       :initarg :x       :accessor window-x)
    (y       :initarg :y       :accessor window-y)
    (gravity :initform nil     :accessor window-gravity)
-   (group   :initarg :group   :accessor window-group*)
+   (group   :initarg :group   :accessor window-group)
    (number  :initarg :number  :accessor window-number)
    (parent                    :accessor window-parent)
    (title   :initarg :title   :accessor window-title)
@@ -91,13 +91,11 @@ may need to sync itself. WHAT-CHANGED is a hint at what changed."))
 (defgeneric really-raise-window (window)
   (:documentation "Really bring the window to the top of the window stack in group"))
 
-(defun (setf window-group) (group window)
-  (setf (window-group* window) group))
 
-(defun window-group (window)
+(defmethod window-group :around ((window window))
   (if (find window *always-show-windows*)
       (current-group)
-      (window-group* window)))
+      (call-next-method)))
 
 ;; Urgency / demands attention
 

--- a/window.lisp
+++ b/window.lisp
@@ -54,7 +54,7 @@
    (x       :initarg :x       :accessor window-x)
    (y       :initarg :y       :accessor window-y)
    (gravity :initform nil     :accessor window-gravity)
-   (group   :initarg :group   :accessor window-group)
+   (group   :initarg :group   :accessor window-group*)
    (number  :initarg :number  :accessor window-number)
    (parent                    :accessor window-parent)
    (title   :initarg :title   :accessor window-title)
@@ -90,6 +90,14 @@ may need to sync itself. WHAT-CHANGED is a hint at what changed."))
   (:documentation "Report what window the head is currently on."))
 (defgeneric really-raise-window (window)
   (:documentation "Really bring the window to the top of the window stack in group"))
+
+(defun (setf window-group) (group window)
+  (setf (window-group* window) group))
+
+(defun window-group (window)
+  (if (find window *always-show-windows*)
+      (current-group)
+      (window-group* window)))
 
 ;; Urgency / demands attention
 

--- a/window.lisp
+++ b/window.lisp
@@ -249,8 +249,10 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
   (xlib:window-id (window-xwin window)))
 
 (defun window-in-current-group-p (window)
-  (eq (window-group window)
-      (screen-current-group (window-screen window))))
+  (or
+   (find window *always-show-windows*)
+   (eq (window-group window)
+       (screen-current-group (window-screen window)))))
 
 (defun window-screen (window)
   (group-screen (window-group window)))
@@ -968,6 +970,8 @@ selected."
   "Delete a window. By default delete the current window. This is a
 request sent to the window. The window's client may decide not to
 grant the request or may not be able to if it is unresponsive."
+  (when (find window *always-show-windows*)
+    (disable-always-show-window window (current-screen)))
   (when window
     (send-client-message window :WM_PROTOCOLS (xlib:intern-atom *display* :WM_DELETE_WINDOW))))
 


### PR DESCRIPTION
This PR is branched off https://github.com/stumpwm/stumpwm/pull/298
This allows one to display a float window on all groups. Combined with https://github.com/stumpwm/stumpwm/pull/302 should give some really nice support for floating windows. I watched lord of the rings using this functionality to create picture in picture viewer with Xephyr :) 
![img](https://cloud.githubusercontent.com/assets/4379046/22186625/65e4602a-e0ad-11e6-9ed6-768258d31efc.png)

I considered adding support for always showing tile windows as well, but that is much more complex, and I'm not too sure that it's a very common use case at all.