### PR TITLE
Use SYNONYM-STREAM for *DEBUG-STREAM*

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -773,7 +773,7 @@ string which is split to obtain the individual regexps. "
 (defvar *debug-expose-events* nil
   "Set this variable for a visual indication of expose events on internal StumpWM windows.")
 
-(defvar *debug-stream* *error-output*
+(defvar *debug-stream* (make-synonym-stream '*error-output*)
   "This is the stream debugging output is sent to. It defaults to
 *error-output*. It may be more convenient for you to pipe debugging
 output directly to a file.")


### PR DESCRIPTION
Currently *DEBUG-STREAM* points to the value that *ERROR-OUTPUT* has when the
code is loaded. And it is unaffected by any modifications to *error-output*. By
using a SYNONYM-STREAM, *DEBUG-STREAM* defaults to the value
that *ERROR-OUTPUT* is bound at the moment *DEBUG-STREAM* is referenced.

This [lisp-tip](http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful) explains the issue in further detail