### PR TITLE
Move MAKE-XLIB-WINDOW out wrappers.lisp

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -585,6 +585,12 @@ the window in it's frame."
   ;; Pass click to client
   (xlib:allow-events *display* :replay-pointer time))
 
+(defun make-xlib-window (xobject)
+  "For some reason the CLX xid cache screws up returns pixmaps when
+they should be windows. So use this function to make a window out of XOBJECT."
+   (xlib::make-window :id (xlib:window-id xobject)
+                      :display *display*))
+
 (defun handle-event (&rest event-slots &key display event-key &allow-other-keys)
   (declare (ignore display))
   (dformat 1 ">>> ~S~%" event-key)

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -262,14 +262,6 @@
   #-(or ccl clisp sbcl lispworks)
   (map 'list #'char-code string))
 
-(defun make-xlib-window (xobject)
-  "For some reason the clx xid cache screws up returns pixmaps when
-they should be windows. So use this function to make a window out of them."
-  #+clisp (make-instance 'xlib:window :id (slot-value xobject 'xlib::id) :display *display*)
-  #+(or sbcl ecl openmcl lispworks) (xlib::make-window :id (slot-value xobject 'xlib::id) :display *display*)
-  #-(or sbcl clisp ecl openmcl lispworks)
-  (error 'not-implemented))
-
 (defun directory-no-deref (pathspec)
   "Call directory without dereferencing symlinks in the results"
   #+(or cmu scl) (directory pathspec :truenamep nil)


### PR DESCRIPTION
Remove support for other implementations other than SBCL. Use XLIB:WINDOW-ID
instead of accessing the direct slot of the DRAWABLE.

Moved the function to where it is used.
I would like to remove the function altogether but I have to investigate if the issue it is working around of (the cache returning a pixmap instead of a window) is still present in CLX.