### PR TITLE
Remove MAKE-XLIB-WINDOW

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -592,17 +592,6 @@ the window in it's frame."
         (win (getf event-slots :window))
         (*current-event-time* (getf event-slots :time)))
     (when eventfn
-      ;; XXX: In both the clisp and sbcl clx libraries, sometimes what
-      ;; should be a window will be a pixmap instead. In this case, we
-      ;; need to manually translate it to a window to avoid breakage
-      ;; in stumpwm. So far the only slot that seems to be affected is
-      ;; the :window slot for configure-request and reparent-notify
-      ;; events. It appears as though the hash table of XIDs and clx
-      ;; structures gets out of sync with X or perhaps X assigns a
-      ;; duplicate ID for a pixmap and a window.
-      (when (and win (not (xlib:window-p win)))
-        (dformat 10 "Pixmap Workaround! ~s should be a window!~%" win)
-        (setf (getf event-slots :window) (make-xlib-window win)))
       (handler-case
           (progn
             ;; This is not the stumpwm top level, but if the restart

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -262,14 +262,6 @@
   #-(or ccl clisp sbcl lispworks)
   (map 'list #'char-code string))
 
-(defun make-xlib-window (xobject)
-  "For some reason the clx xid cache screws up returns pixmaps when
-they should be windows. So use this function to make a window out of them."
-  #+clisp (make-instance 'xlib:window :id (slot-value xobject 'xlib::id) :display *display*)
-  #+(or sbcl ecl openmcl lispworks) (xlib::make-window :id (slot-value xobject 'xlib::id) :display *display*)
-  #-(or sbcl clisp ecl openmcl lispworks)
-  (error 'not-implemented))
-
 (defun directory-no-deref (pathspec)
   "Call directory without dereferencing symlinks in the results"
   #+(or cmu scl) (directory pathspec :truenamep nil)


### PR DESCRIPTION
Following up on https://github.com/stumpwm/stumpwm/pull/318#issuecomment-275911342
<hr />

The issue it works around was fixed in CLX in the commit 86dea89f[0].
The following discussion[1] on sbcl-devel for further context.

[0]: https://github.com/sharplispers/clx/commit/86dea89fe6f1fee4720ed8d8fea34ea6c2e06d7b
[1]: https://sourceforge.net/p/sbcl/mailman/message/19823960/

