### PR TITLE
Clean up current window tracking for groups

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -134,7 +134,7 @@
          (declare (ignore group))
          (change-class window 'float-window)
          (float-window-align window)
-         (focus-window window)))
+         (group-focus-window group window)))
   (defmethod group-add-window ((group float-group) window &key &allow-other-keys)
     (add-float-window group window))
   (defmethod group-add-window (group (window float-window) &key &allow-other-keys)
@@ -142,7 +142,7 @@
 
 (defun &float-focus-next (group)
   (if (group-windows group)
-      (focus-window (first (group-windows group)))
+      (group-focus-window group (first (group-windows group)))
       (no-focus group nil)))
 
 (defmethod group-delete-window ((group float-group) (window float-window))
@@ -177,7 +177,7 @@
 
 (defmethod group-raise-request ((group float-group) window type)
   (declare (ignore type))
-  (focus-window window))
+  (group-focus-window group window))
 
 (defmethod group-lost-focus ((group float-group))
   (&float-focus-next group))
@@ -186,7 +186,7 @@
   )
 
 (defmethod group-focus-window ((group float-group) window)
-  (focus-window window nil))
+  (focus-window window))
 
 (defmethod group-root-exposure ((group float-group))
   )
@@ -212,7 +212,7 @@
         (initial-width (xlib:drawable-width (window-parent window)))
         (initial-height (xlib:drawable-height (window-parent window))))
     (when (member *mouse-focus-policy* '(:click :sloppy))
-      (focus-window window))
+      (group-focus-window group window))
 
     ;; When in border
     (multiple-value-bind (relx rely same-screen-p child state-mask)

--- a/group.lisp
+++ b/group.lisp
@@ -42,6 +42,7 @@
 (defclass group ()
   ((screen :initarg :screen :accessor group-screen)
    (windows :initform nil :accessor group-windows)
+   (current-window :initform nil :accessor group-current-window)
    (number :initarg :number :accessor group-number)
    (name :initarg :name :accessor group-name)))
 
@@ -100,9 +101,6 @@ needs to redraw anything on it, this is where it should do it."))
 (defgeneric group-sync-head (group head)
   (:documentation "When a head or its usable area is resized, this is
 called. When the modeline size changes, this is called."))
-
-(defmethod group-current-window (group)
-  (screen-focus (group-screen group)))
 
 (defmethod group-current-head (group)
   (if (group-current-window group)

--- a/window.lisp
+++ b/window.lisp
@@ -912,6 +912,7 @@ needed."
        (let ((hints (xlib:wm-hints xwin)))
          (when (or (null hints) (eq (xlib:wm-hints-input hints) :on))
            (screen-set-focus screen window)))
+       (setf (group-current-window group) window)
        (update-decoration window)
        (when cw
          (update-decoration cw))
@@ -925,6 +926,7 @@ needed."
        (run-hook-with-args *focus-window-hook* window cw))
       (t
        (screen-set-focus screen window)
+       (setf (group-current-window group) window)
        (update-decoration window)
        (when cw
          (update-decoration cw))


### PR DESCRIPTION
The first commit fixes the issue that a group's current window would not actually be a window in that group. The issue has always been present in the floating group, but was recently also introduced in the tiling group when it gained the ability to contain floating windows.

The second commit allows focusing behavior to properly be managed by the group the window is in.

It introduces one possible change in behavior: The floating group's GROUP-FOCUS-WINDOW method now always raises the window. I am not sure this actually changes anything user-visible.