### PR TITLE
Remove un-needed SBCL_HOME reference

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -13,8 +13,6 @@
 
 #+sbcl
 (sb-ext:save-lisp-and-die "stumpwm" :toplevel (lambda ()
-                                                ;; asdf requires sbcl_home to be set, so set it to the value when the image was built
-                                                (sb-posix:putenv (format nil "SBCL_HOME=~A" #.(sb-ext:posix-getenv "SBCL_HOME")))
                                                 (stumpwm:stumpwm)
                                                 0)
                                     :executable t


### PR DESCRIPTION
It's NIL on a current system, so this actually hard-sets SBCL_HOME to
NIL, which is not good.

SBCL_HOME doesn't appear to be required by ASDF anymore.

Fixes #332.