### PR TITLE
Only try to handle events with XLIB:WINDOW windows

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -597,7 +597,7 @@ they should be windows. So use this function to make a window out of XOBJECT."
   (let ((eventfn (gethash event-key *event-fn-table*))
         (win (getf event-slots :window))
         (*current-event-time* (getf event-slots :time)))
-    (when eventfn
+    (when (and eventfn (typep win 'xlib:window))
       (handler-case
           (progn
             ;; This is not the stumpwm top level, but if the restart

--- a/events.lisp
+++ b/events.lisp
@@ -585,11 +585,11 @@ the window in it's frame."
   ;; Pass click to client
   (xlib:allow-events *display* :replay-pointer time))
 
-(defun make-xlib-window (xobject)
+(defun make-xlib-window (drawable)
   "For some reason the CLX xid cache screws up returns pixmaps when
-they should be windows. So use this function to make a window out of XOBJECT."
-   (xlib::make-window :id (xlib:window-id xobject)
-                      :display *display*))
+they should be windows. So use this function to make a window out of DRAWABLE."
+  (xlib::make-window :id (xlib:drawable-id drawable)
+                     :display *display*))
 
 (defun handle-event (&rest event-slots &key display event-key &allow-other-keys)
   (declare (ignore display))
@@ -597,7 +597,24 @@ they should be windows. So use this function to make a window out of XOBJECT."
   (let ((eventfn (gethash event-key *event-fn-table*))
         (win (getf event-slots :window))
         (*current-event-time* (getf event-slots :time)))
-    (when (and eventfn (typep win 'xlib:window))
+    (when eventfn
+      ;; XXX: In both the clisp and sbcl clx libraries, sometimes what
+      ;; should be a window will be a pixmap instead. In this case, we
+      ;; need to manually translate it to a window to avoid breakage
+      ;; in stumpwm. So far the only slot that seems to be affected is
+      ;; the :window slot for configure-request and reparent-notify
+      ;; events. It appears as though the hash table of XIDs and clx
+      ;; structures gets out of sync with X or perhaps X assigns a
+      ;; duplicate ID for a pixmap and a window.
+      ;;
+      ;; If it's neither a window nor a drawable, just short-circuit.
+      (cond
+        ((xlib:drawable-p win)
+         (dformat 10 "Pixmap Workaround! ~s should be a window!~%" win)
+         (setf (getf event-slots :window) (make-xlib-window win)))
+        ((not (xlib:window-p win))
+         (dformat 10 "Event window ~s not a window!" win)
+         (return-from handle-event)))
       (handler-case
           (progn
             ;; This is not the stumpwm top level, but if the restart


### PR DESCRIPTION
For some reason, XLIB:PROCESS-EVENT sometimes sends events for
drawables as well as for windows; this causes crashes later on.

Fixes #334.