### PR TITLE
Let shell to be run be set by user

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -451,14 +451,11 @@ then describes the symbol."
     (or (choose-frame-by-number (current-group))
         (throw 'error :abort))))
 
-(defvar *shell-to-use* nil)
-
 (define-stumpwm-type :shell (input prompt)
-  (if (eq *shell-to-use* nil)
-      (or (argument-pop-rest input)
-          (completing-read (current-screen) prompt 'complete-program))
-      (or (argument-pop-rest input)
-          (completing-read (current-screen) *shell-to-use* 'complete-program))))
+  (declare (ignore prompt))
+  (let ((prompt (format nil "~A -c " *shell-program*)))
+    (or (argument-pop-rest input)
+        (completing-read (current-screen) prompt 'complete-program))))
 
 (define-stumpwm-type :rest (input prompt)
   (or (argument-pop-rest input)

--- a/command.lisp
+++ b/command.lisp
@@ -451,9 +451,14 @@ then describes the symbol."
     (or (choose-frame-by-number (current-group))
         (throw 'error :abort))))
 
+(defvar *shell-to-use* nil)
+
 (define-stumpwm-type :shell (input prompt)
-  (or (argument-pop-rest input)
-      (completing-read (current-screen) prompt 'complete-program)))
+  (if (eq *shell-to-use* nil)
+      (or (argument-pop-rest input)
+          (completing-read (current-screen) prompt 'complete-program))
+      (or (argument-pop-rest input)
+          (completing-read (current-screen) *shell-to-use* 'complete-program))))
 
 (define-stumpwm-type :rest (input prompt)
   (or (argument-pop-rest input)


### PR DESCRIPTION
Change define-stumpwm-type :shell to allow the setting of the shell which the user wishes to run.
This is done by the addition of the variable *shell-to-use*.
When *shell-to-use* is nil the default "/bin/sh -c" is used otherwise the value of *shell-to-use* is used. 

Fixes issue #325 