### PR TITLE
Use CLX's Xinerama extesion to query screen heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,6 @@ Hopefully that will put you in X running stumpwm! See [StartUp on the
 wiki](https://github.com/sabetts/stumpwm/wiki/StartUp) for more
 examples.
 
-## Requirements for multiple monitor setups
-
-For stumpwm to work as intended with multiple monitors setups the 
-`xdpyinfo` utility is needed.
-
 # Contributing
 
 Pull requests are always welcome! Here are some guidelines to ensure


### PR DESCRIPTION
I've done some light testing with Xephyr, `Xephyr -screen 640x480 -screen 640x480 +xinerama :1 &`
