### PR TITLE
Add more split functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,7 +14,7 @@ David Hansen        david.hansen at gmx net
 Gwern Branwen       gwern0 at gmail com
 Jay Belanger        belanger at truman edu
 Magnus Henoch       mange at freemail hu
-Johannes Weiner   
+Johannes Weiner
 Luca Capello        luca at pca it
 Luigi Panzeri
 James Wright        james at chumsley org
@@ -61,3 +61,4 @@ Joram Schrijver     i at joram io
 Yu Changyuan        reivzy at gmail com
 Edward Trumbo       trumboe at comcast net
 Javier Olaechea     pirata at gmail com
+Caio Oliveira       caioaao at gmail com

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1595,6 +1595,8 @@ window pool, where windows and frames are not so tightly connected.
 !!! pull-window-by-number
 !!! hsplit
 !!! vsplit
+!!! hsplit-equally
+!!! vsplit-equally
 !!! remove-split
 !!! only
 !!! curframe

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -931,7 +931,7 @@ windows used to draw the numbers in. The caller must destroy them."
   (split-frame-in-dir (current-group) :row (read-from-string ratio)))
 
 (defun split-frame-eql-parts* (group dir amt)
-  (when (not (eq amt 1))
+  (when (> amt 1)
     (when-let ((new-frame (split-frame group dir (/ (- amt 1) amt))))
       (cons new-frame (split-frame-eql-parts* group dir (- amt 1))))))
 

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -930,9 +930,46 @@ windows used to draw the numbers in. The caller must destroy them."
 "Split the current frame into 2 frames, one on top of the other."
   (split-frame-in-dir (current-group) :row (read-from-string ratio)))
 
-(defcommand (remove-split tile-group) (&optional (group (current-group)) (frame (tile-group-current-frame group))) ()
-"Remove the specified frame in the specified group (defaults to current
-group, current frame). Windows in the frame are migrated to the frame taking up its
+(defun split-frame-eql-parts* (group dir amt)
+  (when (not (eq amt 1))
+    (when-let ((new-frame (split-frame group dir (/ (- amt 1) amt))))
+      (cons new-frame (split-frame-eql-parts* group dir (- amt 1))))))
+
+(defun split-frame-eql-parts (group dir amt)
+  "Splits frame in equal parts defined by amt."
+  (assert (> amt 1))
+  (let ((f (tile-group-current-frame group))
+        (new-frame-numbers (split-frame-eql-parts* group dir amt)))
+    (if (= (list-length new-frame-numbers) (- amt 1))
+        (progn
+          (when (frame-window f)
+            (update-decoration (frame-window f)))
+          (show-frame-indicator group))
+        (progn
+          (let ((head (frame-head group f)))
+            (setf (tile-group-frame-head group head)
+                  (reduce (lambda (tree num)
+                            (remove-frame tree
+                                          (frame-by-number group num)))
+                          new-frame-numbers
+                          :initial-value (tile-group-frame-head group head))))
+          (message "Cannot split. Maybe current frame is too small.")))))
+
+(defcommand (hsplit-equally tile-group) (amt)
+    ((:number "Enter the number of frames: "))
+"Split current frame in n rows of equal size."
+  (split-frame-eql-parts (current-group) :row amt))
+
+(defcommand (vsplit-equally tile-group) (amt)
+    ((:number "Enter the number of frames: "))
+"Split current frame in n columns of equal size."
+  (split-frame-eql-parts (current-group) :column amt))
+
+(defcommand (remove-split tile-group)
+    (&optional (group (current-group))
+               (frame (tile-group-current-frame group))) ()
+"Remove the specified frame in the specified group (defaults to current group,
+current frame). Windows in the frame are migrated to the frame taking up its
 space."
   (let* ((head (frame-head group frame))
          (current (tile-group-current-frame group))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -945,14 +945,13 @@ windows used to draw the numbers in. The caller must destroy them."
           (when (frame-window f)
             (update-decoration (frame-window f)))
           (show-frame-indicator group))
-        (progn
-          (let ((head (frame-head group f)))
-            (setf (tile-group-frame-head group head)
-                  (reduce (lambda (tree num)
-                            (remove-frame tree
-                                          (frame-by-number group num)))
-                          new-frame-numbers
-                          :initial-value (tile-group-frame-head group head))))
+        (let ((head (frame-head group f)))
+          (setf (tile-group-frame-head group head)
+                (reduce (lambda (tree num)
+                          (remove-frame tree
+                                        (frame-by-number group num)))
+                        new-frame-numbers
+                        :initial-value (tile-group-frame-head group head)))
           (message "Cannot split. Maybe current frame is too small.")))))
 
 (defcommand (hsplit-equally tile-group) (amt)


### PR DESCRIPTION
So we can split a frame in n rows/columns of equal sizes.

I also reorganized the next command defined to fit in 80 columns, but I don't know if I'm breaking some style rule.