### PR TITLE
Allows keys to be used when loading modules

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -117,6 +117,7 @@ an asdf system, and if so add it to the central registry"
 
 (defcommand load-module (name) ((:module "Load Module: "))
   "Loads the contributed module with the given NAME."
+  (setf name (string-downcase name))
   (let ((module (find-module name)))
       (when module
         (asdf:operate 'asdf:load-op module))))

--- a/module.lisp
+++ b/module.lisp
@@ -117,7 +117,7 @@ an asdf system, and if so add it to the central registry"
 
 (defcommand load-module (name) ((:module "Load Module: "))
   "Loads the contributed module with the given NAME."
-  (setf name (string-downcase name))
+  (string-downcase name)
   (let ((module (find-module name)))
       (when module
         (asdf:operate 'asdf:load-op module))))


### PR DESCRIPTION
When interacting with systems support is normally allowed to specify
the system by using a key instead of a string. Add this support to load-module.