### PR TITLE
Fix typos

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -222,6 +222,7 @@ at 0. Return a netwm compliant group id."
                           :cardinal 32)))
 
 (defcommand toggle-always-show () ()
+  "Toggle whether the current window is shown in all groups."
   (let ((w (current-window))
         (screen (current-screen)))
     (when w

--- a/manual.lisp
+++ b/manual.lisp
@@ -79,7 +79,8 @@
 (defun generate-command-doc (s line)
   (ppcre:register-groups-bind (name) ("^!!! (.*)" line)
                               (dprint name)
-                              (let ((cmd (symbol-function (find-symbol (string-upcase name) :stumpwm))))
+                              (let ((cmd (symbol-function (find-symbol (string-upcase name) :stumpwm)))
+                                    (*print-pretty* nil))
                                 (format s "@deffn {Command} ~a ~{~a~^ ~}~%~a~&@end deffn~%~%"
                                         name
                                         (sb-introspect:function-lambda-list cmd)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1200,7 +1200,7 @@ A frame
 @item :shell
 A shell command
 @item :rest
-The rest of the input yes to be parsed.
+The rest of the input yet to be parsed.
 @item :module
 An existing stumpwm module
 @end table
@@ -1555,7 +1555,7 @@ Window Selection Expressions (WSE) were inspired by SQL. The intent is
 to allow writing consise code to select the windows you need and to
 act upon them (or just to get the list of selected windows). The
 implementation includes a set of (hopefully) consistent
-consisely-named wrappers for the StumpWM functionality useful for
+concisely-named wrappers for the StumpWM functionality useful for
 window set description and the act-on-matching-windows macro that
 encapsulates the logic of iterating over a window set.
 
@@ -1945,9 +1945,9 @@ start stumpwm. Also include what the expected behavior was.
 Be as detailed as possible. Then add more detail!
 @item
 Make sure its not something you introduced by using an empty @file{.xinitrc}
-containing only 'exec /path/to/stumpwm'.
+containing only @samp{exec /path/to/stumpwm}.
 @item
-Make sure the bug is present even when @file{.stumwmrc} is empty.
+Make sure the bug is present even when @file{.stumpwmrc} is empty.
 @item
 If you are using the git version, include the hash of the master
 branch, or better include the commit when you started to notice the
@@ -2142,7 +2142,7 @@ $$$ *post-command-hook*
 
 @node Modules, Hacking, Hooks, Top
 @chapter Modules
-A module is a ASDF system that adds additional functionality to
+A module is an ASDF system that adds additional functionality to
 StumpWM.  StumpWM searches for modules in the
 @var{*data-dir*}@file{/modules} directory.  By default this is
 @file{~/.stumpwm.d/modules}.

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -872,6 +872,7 @@ Describe the specified command.
 ### *exchange-window-map*
 
 !!! bind
+!!! send-escape
 
 @node Modifiers,  , Binding Keys, Key Bindings
 @section Modifiers
@@ -1447,6 +1448,8 @@ An input function takes 2 arguments: the input structure and the key pressed.
 !!! meta
 !!! select-window
 !!! select-window-by-number
+!!! select-window-by-name
+!!! repack-window-numbers
 !!! title
 !!! windowlist
 !!! windowlist-by-class
@@ -1454,6 +1457,11 @@ An input function takes 2 arguments: the input structure and the key pressed.
 !!! info
 !!! refresh
 !!! redisplay
+!!! float-this
+!!! unfloat-this
+!!! unmaximize
+!!! toggle-always-on-top
+!!! toggle-always-show
 
 ### *window-format*
 ### *window-info-format*
@@ -1569,21 +1577,21 @@ actions, for example getting all the windows titled XTerm into the
 current group:
 @code{(act-on-matching-windows (w) (titled-p w "XTerm") (pull-w w))}
 
-!!! move-windows-to-group
+@@@ move-windows-to-group
 %%% act-on-matching-windows
-!!! pull-w
-!!! titled-p
-!!! title-re-p
-!!! classed-p
-!!! class-re-p
-!!! typed-p
-!!! type-re-p
-!!! roled-p
-!!! role-re-p
-!!! resed-p
-!!! res-re-p
-!!! grouped-p
-!!! in-frame-p
+@@@ pull-w
+@@@ titled-p
+@@@ title-re-p
+@@@ classed-p
+@@@ class-re-p
+@@@ typed-p
+@@@ type-re-p
+@@@ roled-p
+@@@ role-re-p
+@@@ resed-p
+@@@ res-re-p
+@@@ grouped-p
+@@@ in-frame-p
 
 @node Frames, Mode-line, Windows, Top
 @chapter Frames
@@ -1605,6 +1613,7 @@ window pool, where windows and frames are not so tightly connected.
 !!! fother
 !!! fselect
 !!! resize
+!!! resize-direction
 !!! balance-frames
 !!! fclear
 !!! move-focus
@@ -1612,6 +1621,8 @@ window pool, where windows and frames are not so tightly connected.
 !!! next-in-frame
 !!! prev-in-frame
 !!! other-in-frame
+!!! next-urgent
+!!! frame-window-list
 !!! echo-frame-windows
 !!! exchange-direction
 
@@ -1752,6 +1763,8 @@ Groups in StumpWM are more commonly known as @dfn{virtual desktops} or
 !!! vgroups
 !!! gselect
 !!! gmove
+!!! gmove-and-follow
+!!! gmove-marked
 !!! gkill
 !!! grename
 !!! grouplist
@@ -1855,6 +1868,9 @@ section.
 !!! commands
 !!! lastmsg
 !!! list-window-properties
+!!! show-window-properties
+!!! version
+!!! which-key-mode
 
 @@@ run-commands
 
@@ -1977,6 +1993,7 @@ Return T if TIMER is a timer structure.
 !!! describe-key
 !!! describe-variable
 !!! describe-function
+!!! describe-command
 !!! where-is
 !!! modifiers
 

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -372,7 +372,7 @@ when selecting another window."
 
 (defcommand (fullscreen tile-group) () ()
   "Toggle the fullscreen mode of the current widnow. Use this for clients
-with broken (non-NETWM) fullscreen implemenations, such as any program
+with broken (non-NETWM) fullscreen implementations, such as any program
 using SDL."
   (update-fullscreen (current-window) 2))
 

--- a/window.lisp
+++ b/window.lisp
@@ -1087,8 +1087,8 @@ is using the number, then the windows swap numbers. Defaults to current group."
 ;; but window-list was added latter and I didn't want to break other's code.
 (defcommand windowlist (&optional (fmt *window-format*)
                                   window-list) (:rest)
-  "Allow the user to select a window from the list of windows and focus the 
-selected window. For information of menu bindings @xref{Menus}. The optional
+  "Allow the user to select a window from the list of windows and focus the
+selected window. For information of menu bindings see @ref{Menus}. The optional
  argument @var{fmt} can be specified to override the default window formatting.
 The optional argument @var{window-list} can be provided to show a custom window
 list (see @command{windowlist-by-class}). The default window list is the list of
@@ -1108,7 +1108,7 @@ by number and if the @var{windows-list} is provided, it is shown unsorted (as-is
 
 (defcommand windowlist-by-class (&optional (fmt *window-format-by-class*)) (:rest)
   "Allow the user to select a window from the list of windows (sorted by class)
- and focus the selected window. For information of menu bindings @xref{Menus}. 
+ and focus the selected window. For information of menu bindings see @ref{Menus}.
 The optional argument @var{fmt} can be specified to override the default window
 formatting. This is a simple wrapper around the command @command{windowlist}."
   (windowlist fmt (sort-windows-by-class (group-windows (current-group)))))


### PR DESCRIPTION
Fix a few typos and disable line breaks for command lambda lists (right now if they are too long, they are broken across a few lines and texi renders them incorrectly).
Also add all missing commands to the documentation, and fix a few functions to actually be documented as functions, not commands.