### PR TITLE
Fix doc generation failure

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -79,7 +79,9 @@
 (defun generate-command-doc (s line)
   (ppcre:register-groups-bind (name) ("^!!! (.*)" line)
                               (dprint name)
-                              (let ((cmd (symbol-function (find-symbol (string-upcase name) :stumpwm)))
+                              (let* ((symbol (or (find-symbol (string-upcase name) :stumpwm)
+                                                 (error "cannot find symbol ~a in :stumpwm" name)))
+                                    (cmd (symbol-function symbol))
                                     (*print-pretty* nil))
                                 (format s "@deffn {Command} ~a ~{~a~^ ~}~%~a~&@end deffn~%~%"
                                         name

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1620,7 +1620,7 @@ window pool, where windows and frames are not so tightly connected.
 !!! prev-in-frame
 !!! other-in-frame
 !!! next-urgent
-!!! frame-window-list
+!!! frame-windowlist
 !!! echo-frame-windows
 !!! exchange-direction
 


### PR DESCRIPTION
This fixes a typo in the doc source, and adds a somewhat-more-useful error message.