### PR TITLE
Allow define-stumpwm-type :function to throw error

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -323,7 +323,7 @@ then describes the symbol."
 (define-stumpwm-type :function (input prompt)
   (multiple-value-bind (sym pkg var)
       (lookup-symbol (argument-pop-or-read input prompt))
-    (if (symbol-function sym)
+    (if (fboundp sym)
         (symbol-function sym)
         (throw 'error (format nil "the symbol ~a::~a has no function."
                               (package-name pkg) var)))))


### PR DESCRIPTION
define-stumpwm-type :function uses symbol-function to check if a
symbol is a function except symbol-function throws a error if the
symbol isn't a function instead of nil. Common Lisp the Language
provides a function to address this issue. Implement the logic to
allow our error handling to work.