### PR TITLE
Find current head from pointer in floating group

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -150,6 +150,13 @@
 
 (defmethod group-suspend ((group float-group)))
 
+(defmethod group-current-head ((group float-group))
+  (if-let ((current-window (group-current-window group)))
+    (window-head current-window)
+    (multiple-value-bind (x y)
+        (xlib:global-pointer-position *display*)
+      (find-head-by-position (group-screen group) x y))))
+
 (defun float-window-align (window)
   (with-accessors ((parent window-parent)
                    (xwin window-xwin)

--- a/group.lisp
+++ b/group.lisp
@@ -106,11 +106,6 @@ needs to redraw anything on it, this is where it should do it."))
   (:documentation "When a head or its usable area is resized, this is
 called. When the modeline size changes, this is called."))
 
-(defmethod group-current-head (group)
-  (if (group-current-window group)
-      (window-head (group-current-window group))
-      (first (screen-heads (group-screen group)))))
-
 (defmethod group-delete-window (group window)
   (when (find window *always-show-windows*)
     (disable-always-show-window window (current-screen)))

--- a/head.lisp
+++ b/head.lisp
@@ -53,22 +53,21 @@
   "Return a copy of screen's heads."
   (mapcar 'copy-frame (screen-heads screen)))
 
+(defun find-head-by-position (screen x y)
+  (dolist (head (screen-heads screen))
+    (when (and (>= x (head-x head))
+               (>= y (head-y head))
+               (<= x (+ (head-x head) (head-width head)))
+               (<= y (+ (head-y head) (head-height head))))
+      (return head))))
 
 ;; Determining a frame's head based on position probably won't
 ;; work with overlapping heads. Would it be better to walk
 ;; up the frame tree?
 (defun frame-head (group frame)
   (let ((center-x (+ (frame-x frame) (ash (frame-width frame) -1)))
-       (center-y (+ (frame-y frame) (ash (frame-height frame) -1))))
-    (dolist (head (screen-heads (group-screen group)))
-      (when (and
-            (>= center-x (frame-x head))
-            (>= center-y (frame-y head))
-            (<= center-x
-                (+ (frame-x head) (frame-width head)))
-            (<= center-y
-                (+ (frame-y head) (frame-height head))))
-       (return head)))))
+        (center-y (+ (frame-y frame) (ash (frame-height frame) -1))))
+    (find-head-by-position (group-screen group) center-x center-y)))
 
 (defun group-heads (group)
   (screen-heads (group-screen group)))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -88,9 +88,9 @@
           (really-raise-window window)))))
 
 (defmethod group-current-head ((group tile-group))
-  (if (group-current-window group)
-      (window-head (group-current-window group))
-      (frame-head group (tile-group-current-frame group))))
+  (if-let ((current-window (group-current-window group)))
+    (window-head current-window)
+    (frame-head group (tile-group-current-frame group))))
 
 (defmethod group-move-request ((group tile-group) (window tile-window) x y relative-to)
   (when *honor-window-moves*


### PR DESCRIPTION
In the tiling group the pointer is usually ignored, but in the floating
group it is essential. Thus it makes sense to use its position to
determine the current head.

I think this makes sense, do you (@PuercoPop , @dbjergaard) agree?