### PR TITLE
Added functions IN-MAIN-THREAD-P and PUSH-EVENT

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -20,9 +20,7 @@
 (defpackage :stumpwm
   (:use :cl
         #:alexandria)
-  (:shadow #:yes-or-no-p #:y-or-n-p)
-  (:export
-   #:call-in-main-thread))
+  (:shadow #:yes-or-no-p #:y-or-n-p))
 
 (defpackage :stumpwm-user
   (:use :cl :stumpwm))

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -26,7 +26,10 @@
 	  run-with-timer
           *toplevel-io*
 	  stumpwm
-	  timer-p))
+	  timer-p
+          call-in-main-thread
+          in-main-thread-p
+          push-event))
 
 
 ;;; Main
@@ -236,19 +239,25 @@ The action is to call FUNCTION with arguments ARGS."
     (dolist (event (reverse events))
       (funcall event))))
 
+(defun in-main-thread-p ()
+  *in-main-thread*)
+
+(defun push-event (fn)
+  (sb-thread:with-mutex ((request-channel-lock *request-channel*))
+    (push fn (request-channel-queue *request-channel*)))
+  (let ((out (request-channel-out *request-channel*)))
+    ;; For now, just write a single byte since all we want is for the
+    ;; main thread to process the queue. If we want to handle
+    ;; different types of events, we'll have to change this so that
+    ;; the message sent indicates the event type instead.
+    (write-byte 0 out)
+    (finish-output out)))
+
 (defun call-in-main-thread (fn)
-  (cond (*in-main-thread*
+  (cond ((in-main-thread-p)
          (funcall fn))
         (t
-         (sb-thread:with-mutex ((request-channel-lock *request-channel*))
-           (push fn (request-channel-queue *request-channel*)))
-         (let ((out (request-channel-out *request-channel*)))
-           ;; For now, just write a single byte since all we want is for the
-           ;; main thread to process the queue. If we want to handle
-           ;; different types of events, we'll have to change this so that
-           ;; the message sent indicates the event type instead.
-           (write-byte 0 out)
-           (finish-output out)))))
+         (push-event fn))))
 
 (defclass display-channel ()
   ((display :initarg :display)))


### PR DESCRIPTION
The function `CALL-IN-MAIN-THREAD` checks whether the current thread is the main thread, in which case the function is called immediately. If not, an event is scheduled which will be called at a later time.

There are cases when one wants to schedule a function to be called from the event loop even if the executing thread is the event thread. A specific case for this is when calling the function `FLOAT-WINDOW` from a window create hook. `FLOAT-WINDOW` assumes that the window has already been placed, and if it's called directly from the hook, StumpWM will crash. Scheduling the call as an event using the new function `PUSH-EVENT` fixes this.