### PR TITLE
Rename &float-focus-next to %float-focus-next

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -136,17 +136,17 @@
   (defmethod group-add-window (group (window float-window) &key &allow-other-keys)
     (add-float-window group window)))
 
-(defun &float-focus-next (group)
+(defun %float-focus-next (group)
   (if (group-windows group)
       (group-focus-window group (first (group-windows group)))
       (no-focus group nil)))
 
 (defmethod group-delete-window ((group float-group) (window float-window))
   (declare (ignore window))
-  (&float-focus-next group))
+  (%float-focus-next group))
 
 (defmethod group-wake-up ((group float-group))
-  (&float-focus-next group))
+  (%float-focus-next group))
 
 (defmethod group-suspend ((group float-group)))
 
@@ -183,7 +183,7 @@
   (group-focus-window group window))
 
 (defmethod group-lost-focus ((group float-group))
-  (&float-focus-next group))
+  (%float-focus-next group))
 
 (defmethod group-indicate-focus ((group float-group))
   )


### PR DESCRIPTION
The & sigil is used to refer to lambda list keywords. It confuses Emacs's
syntax highlighting, which highlights calls to the function as lambda list
keywords even outside. Replace it with the more common idiom of using the % to
signal that it is an internal function that shouldn't be called directly.