### PR TITLE
Feature selection notify hook

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -383,6 +383,21 @@ converted to an atom is removed."
 (define-stump-event-handler :selection-clear (selection)
   (setf (getf *x-selection* selection) nil))
 
+(define-stump-event-handler :selection-notify (window property selection)
+  (dformat 2 "selection-notify: ~s ~s ~s~%" window property selection)
+  (when property
+    (let* ((selection (or selection :primary))
+           (sel-value (xlib:get-property window
+                                         property
+                                         :type :utf8_string
+                                         :result-type 'vector
+                                         :delete-p t))
+           (sel-string (when sel-value
+                         (utf8-to-string sel-value))))
+      (when sel-string
+        (setf (getf *x-selection* selection) sel-string)
+        (run-hook-with-args *selection-notify-hook* sel-string)))))
+
 (defun find-message-window-screen (win)
   "Return the screen, if any, that message window WIN belongs."
   (dolist (screen *screen-list*)

--- a/events.lisp
+++ b/events.lisp
@@ -387,14 +387,13 @@ converted to an atom is removed."
   (dformat 2 "selection-notify: ~s ~s ~s~%" window property selection)
   (when property
     (let* ((selection (or selection :primary))
-           (sel-value (xlib:get-property window
-                                         property
-                                         :type :utf8_string
-                                         :result-type 'vector
-                                         :delete-p t))
-           (sel-string (when sel-value
-                         (utf8-to-string sel-value))))
-      (when sel-string
+           (sel-string (utf8-to-string
+                        (xlib:get-property window
+                                           property
+                                           :type :utf8_string
+                                           :result-type 'vector
+                                           :delete-p t))))
+      (when (< 0 (length sel-string))
         (setf (getf *x-selection* selection) sel-string)
         (run-hook-with-args *selection-notify-hook* sel-string)))))
 

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -58,6 +58,7 @@
           *mode-line-click-hook*
           *pre-command-hook*
           *post-command-hook*
+          *selection-notify-hook*
           *display*
           *shell-program*
           *maxsize-border-width*
@@ -322,6 +323,10 @@ the command as a symbol.")
 (defvar *post-command-hook* '()
   "Called after a command is called. It is called with 1 argument:
 the command as a symbol.")
+
+(defvar *selection-notify-hook* '()
+  "Called after a :selection-notify event is processed. It is called
+with 1 argument: the selection as a string.")
 
 ;; Data types and globals used by stumpwm
 


### PR DESCRIPTION
Adds a `:selection-notify` event handler and `*selection-notify-hook*` to allow StumpWM to get clipboard (and other) selection from other X clients. Selection is saved in `*x-selection*`

The hook can be used to build useful utilities such as a `clipboard-history` module - an early draft (which depends on this hook) can be previewed [here](https://github.com/kriyative/stumpwm-contrib/commit/c25f6dfa887dd7f7ad1c18148592d76a6102d086).