### PR TITLE
Handle user-provided declare forms correctly in event-handlers

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -37,10 +37,10 @@
         (parse-body body :documentation t)
       `(setf (gethash ,event *event-fn-table*)
              (lambda (&rest ,event-slots &key ,@keys &allow-other-keys)
-               (declare (ignore ,event-slots))
+               (declare (ignore ,event-slots)
+                        ,@(cdar declarations))
                ,@(when docstring
                    (list docstring))
-               ,@declarations
                ,@body)))))
 
 ;;; Configure request

--- a/events.lisp
+++ b/events.lisp
@@ -32,17 +32,16 @@
 (defvar *current-event-time* nil)
 
 (defmacro define-stump-event-handler (event keys &body body)
-  (let ((fn-name (gensym))
-        (event-slots (gensym)))
+  (let ((event-slots (gensym)))
     (multiple-value-bind (body declarations docstring)
         (parse-body body :documentation t)
-        `(labels ((,fn-name (&rest ,event-slots &key ,@keys &allow-other-keys)
-                    (declare (ignore ,event-slots))
-                    ,@(when docstring
-                        (list docstring))
-                    ,@declarations
-                    ,@body))
-           (setf (gethash ,event *event-fn-table*) #',fn-name)))))
+      `(setf (gethash ,event *event-fn-table*)
+             (lambda (&rest ,event-slots &key ,@keys &allow-other-keys)
+               (declare (ignore ,event-slots))
+               ,@(when docstring
+                   (list docstring))
+               ,@declarations
+               ,@body)))))
 
 ;;; Configure request
 


### PR DESCRIPTION
The expansion of DEFINE-STUMP-EVENT-HANDLER would place any extra declarations
provided by the user of the macro below the always present (declare (ignore
,event-slots)) forsm. So any extra declare forms provided by the user of the
macro would be discarded as a there can only be one declare expression at the
start of the function body. Merge the user-provided declarations with the first
declare form.