### PR TITLE
Warn if SBCL_HOME is unset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,9 @@ fi
 
 if test "x$LISP" = "xsbcl"; then
    LISP_PROGRAM=$SBCL
+   if test -z "$SBCL_HOME"; then
+      AC_MSG_WARN(SBCL_HOME must be defined to use asdf/quicklisp (it should be where your sbcl.core resides))
+   fi
 elif test "x$LISP" = "xclisp"; then
    LISP_PROGRAM=$CLISP
 elif test "x$LISP" = "xccl"; then


### PR DESCRIPTION
- Prevents issues with calls to #'require failing when sbcl is the core