### PR TITLE
Add a selection hook in select-from-menu.

### DIFF
--- a/menu.lisp
+++ b/menu.lisp
@@ -243,6 +243,7 @@ Returns the selected element in TABLE or nil if aborted. "
                     (when prompt-line
                       (push prompt-line strings)
                       (incf highlight))
+                    (run-hook-with-args *menu-selection-hook* menu)
                     (echo-string-list screen strings highlight))
                   (multiple-value-bind (action key-seq) (read-from-keymap keymap)
                     (if action

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -59,6 +59,7 @@
           *pre-command-hook*
           *post-command-hook*
           *selection-notify-hook*
+          *menu-selection-hook*
           *display*
           *shell-program*
           *maxsize-border-width*
@@ -327,6 +328,10 @@ the command as a symbol.")
 (defvar *selection-notify-hook* '()
   "Called after a :selection-notify event is processed. It is called
 with 1 argument: the selection as a string.")
+
+(defvar *menu-selection-hook* '()
+  "Called after an item is selected in the windows menu. It is called
+with 1 argument: the menu.")
 
 ;; Data types and globals used by stumpwm
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2152,6 +2152,7 @@ $$$ *urgent-window-hook*
 $$$ *event-processing-hook*
 $$$ *pre-command-hook*
 $$$ *post-command-hook*
+$$$ *menu-selection-hook*
 
 @node Modules, Hacking, Hooks, Top
 @chapter Modules


### PR DESCRIPTION
This lets the caller do something every time an item is selected.

A use case for this is is a "visual-pull-from-windowlist", which pulls
the selected window every time you select it. Here is an example
implementation that is currently used:

```common-lisp
(defcommand (visual-pull-from-windowlist tile-group) () ()
  (flet ((pull-selected-window (menu)
           (let ((selected-window (nth (menu-state-selected menu)
                                       (menu-state-table menu))))
             (pull-window (second selected-window)))))
    (let ((original-window (current-window))
          (pulled-window (select-window-from-menu
                          (group-windows (current-group))
                          *window-format*
                          nil
                          *window-menu-filter*
                          #'pull-selected-window)))
      (pull-window (if pulled-window pulled-window original-window)))))
```