### PR TITLE
Add the visual-pull-from-windowlist command.

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -8,6 +8,9 @@
   "Set this to T if you never want windows to resize based on incremental WM_HINTs,
 like xterm and emacs.")
 
+(defvar *is-in-visual-pull* nil
+  "Whether we are visually pulling a window or not. Used to keep track of state.")
+
 (defclass tile-window (window)
   ((frame   :initarg :frame   :accessor window-frame)
    (normal-size :initform nil :accessor window-normal-size)))
@@ -335,6 +338,47 @@ when selecting another window."
                         *window-format*)))
     (when pulled-window
       (pull-window pulled-window))))
+
+(defun pull-selected-window (menu)
+  (let ((selected-window (second
+                          (nth (menu-state-selected menu)
+                               (menu-state-table menu)))))
+    (unless (some (lambda (frame)
+                    (= (window-id (frame-window (if (listp frame) (first frame) frame)))
+                       (window-id selected-window)))
+                  (tile-group-frame-tree (current-group)))
+      (pull-window selected-window))))
+
+(defun restored-windows (pulled-window original-group-windows)
+  (let ((new-group-windows (group-windows (current-group))))
+    (if pulled-window
+        (append (list pulled-window)
+                (remove pulled-window
+                        (mapcar (lambda (window)
+                                  (find-if
+                                   (lambda (w)
+                                     (eq (window-id w) (window-id window)))
+                                   new-group-windows))
+                                original-group-windows)))
+        original-group-windows)))
+
+(add-hook *menu-selection-hook*
+          (lambda (menu)
+            (when *is-in-visual-pull*
+              (pull-selected-window menu))))
+
+(defcommand (visual-pull-from-windowlist tile-group) () ()
+  (setf *is-in-visual-pull* t)
+  (unwind-protect
+       (let ((original-window (current-window))
+             (original-group-windows (group-windows (current-group)))
+             (pulled-window (select-window-from-menu (group-windows (current-group)) *window-format*)))
+         (setf (group-windows (current-group))
+               (restored-windows pulled-window original-group-windows))
+         (when (and (not pulled-window)
+                    (not (= (window-id original-window) (window-id (current-window)))))
+           (pull-window original-window)))
+    (setf *is-in-visual-pull* nil)))
 
 (defun exchange-windows (win1 win2)
   "Exchange the windows in their respective frames."


### PR DESCRIPTION
Following on up #394, this new command implements a new way to cycle
through the list of open windows and select the appropriate one.

This version has no drawback that I'm aware of:

- If a window is on another frame, it won't be pulled
- Windows are only pulled when necessary
- Stack history of windows is properly kept in the group's list.

The real drawback of this solution is that it's using a hook that is
externalised, and it's the only one that is non-nil that I can
see. Should it use a separate, internal-only, hook, that select-menu
will also call? Or instead, add a new argument to `select-window-from-menu`?