### PR TITLE
Fix incorrect behavior when XDG_CONFIG_HOME doesn't end with /

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -44,7 +44,7 @@ further up. "
            (let ((dir (getenv "XDG_CONFIG_HOME")))
              (if (or (not dir) (string= dir ""))
                  (merge-pathnames  #p".config/" (user-homedir-pathname))
-                 dir)))
+                 (concatenate 'string dir "/"))))
          (user-rc
            (probe-file (merge-pathnames #p".stumpwmrc" (user-homedir-pathname))))
          (dir-rc


### PR DESCRIPTION
I have $XDG_CONFIG_HOME set to $HOME/.config without the slash at the end (which is how it's defined in [the spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)) so merge-pathnames would think .config is a file and elide it.

Adding a slash to the end would fix this behavior and still work even if the path already ends with a slash.