### PR TITLE
Fixed documentation for *new-window-preferred-frame*

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1464,7 +1464,7 @@ An input function takes 2 arguments: the input structure and the key pressed.
 ### *window-format*
 ### *window-info-format*
 ### *window-name-source*
-### *new-window-prefered-frame*
+### *new-window-preferred-frame*
 
 @menu
 * Window Marks::


### PR DESCRIPTION
Fixed a typo in the documentation for `*new-window-preferred-frame*`.