### PR TITLE
Allow user to change the vertical padding of message windows

### DIFF
--- a/color.lisp
+++ b/color.lisp
@@ -382,7 +382,7 @@ rendered width."
        for row from 0 to (length strings)
        for line-height = (max-font-height parts cc)
        if (find row highlights :test 'eql)
-       do (xlib:draw-rectangle px gc 0 y (xlib:drawable-width px) line-height t)
+       do (xlib:draw-rectangle px gc 0 (+ pady y) (xlib:drawable-width px) line-height t)
          (xlib:with-gcontext (gc :foreground (xlib:gcontext-background gc)
                                  :background (xlib:gcontext-foreground gc))
            ;; If we don't switch the default colors, a color operation

--- a/input.lisp
+++ b/input.lisp
@@ -114,7 +114,8 @@
 
 (defun setup-input-window (screen prompt input)
   "Set the input window up to read input"
-  (let* ((height (font-height (screen-font screen)))
+  (let* ((height (+ (font-height (screen-font screen))
+                    (* *message-window-y-padding* 2)))
          (win (screen-input-window screen)))
     ;; Window dimensions
     (xlib:with-state (win)
@@ -125,7 +126,7 @@
     (draw-input-bucket screen prompt input)
     ;; Ready to recieve input
     
-))
+    ))
 
 (defun shutdown-input-window (screen)
   (xlib:ungrab-keyboard *display*)
@@ -272,9 +273,7 @@ match with an element of the completions."
         (xlib:draw-rectangle win gcontext 0 0
                              (xlib:drawable-width win)
                              (xlib:drawable-height win) t))
-      (setf (xlib:drawable-width win) (+ width (* *message-window-padding* 2))
-            (xlib:drawable-height win) (+ (font-height (screen-font screen))
-                                          (* *message-window-y-padding* 2)))
+      (setf (xlib:drawable-width win) (+ width (* *message-window-padding* 2)))
       (setup-win-gravity screen win *input-window-gravity*))
     (xlib:with-state (win)
       (draw-image-glyphs win gcontext (screen-font screen)

--- a/input.lisp
+++ b/input.lisp
@@ -262,20 +262,24 @@ match with an element of the completions."
          (full-string-width (+ string-width space-width))
          (pos (input-line-position input))
          (width (+ prompt-width
-                   (max 100 (+ full-string-width space-width tail-width)))))
+                   (max 100 (+ full-string-width space-width tail-width))))
+         (text-y (+ (font-ascent (screen-font screen))
+                    *message-window-y-padding*)))
     (when errorp (rotatef (xlib:gcontext-background gcontext)
                           (xlib:gcontext-foreground gcontext)))
     (xlib:with-state (win)
       (xlib:with-gcontext (gcontext :foreground (xlib:gcontext-background gcontext))
         (xlib:draw-rectangle win gcontext 0 0
-                           (xlib:drawable-width win)
-                           (xlib:drawable-height win) t))
-      (setf (xlib:drawable-width win) (+ width (* *message-window-padding* 2)))
+                             (xlib:drawable-width win)
+                             (xlib:drawable-height win) t))
+      (setf (xlib:drawable-width win) (+ width (* *message-window-padding* 2))
+            (xlib:drawable-height win) (+ (font-height (screen-font screen))
+                                          (* *message-window-y-padding* 2)))
       (setup-win-gravity screen win *input-window-gravity*))
     (xlib:with-state (win)
       (draw-image-glyphs win gcontext (screen-font screen)
                          *message-window-padding*
-                         (font-ascent (screen-font screen))
+                         text-y
                          prompt
                          :translate #'translate-id
                          :size 16)
@@ -288,14 +292,14 @@ match with an element of the completions."
                                                :background (xlib:gcontext-foreground gcontext))
                    (draw-image-glyphs win gcontext (screen-font screen)
                                       x
-                                      (font-ascent (screen-font screen))
+                                      text-y
                                       (string char)
                                       :translate #'translate-id
                                       :size 16))
             else
               do (draw-image-glyphs win gcontext (screen-font screen)
                                     x
-                                    (font-ascent (screen-font screen))
+                                    text-y
                                     (string char)
                                     :translate #'translate-id
                                     :size 16)
@@ -306,16 +310,16 @@ match with an element of the completions."
                                                     :background (xlib:gcontext-foreground gcontext))
                         (draw-image-glyphs win gcontext (screen-font screen)
                                            x
-                                           (font-ascent (screen-font screen))
+                                           text-y
                                            " "
                                            :translate #'translate-id
                                            :size 16))))
-         (draw-image-glyphs win gcontext (screen-font screen)
-                            (+ *message-window-padding* prompt-width full-string-width space-width)
-                            (font-ascent (screen-font screen))
-                            tail
-                            :translate #'translate-id
-                            :size 16))
+      (draw-image-glyphs win gcontext (screen-font screen)
+                         (+ *message-window-padding* prompt-width full-string-width space-width)
+                         text-y
+                         tail
+                         :translate #'translate-id
+                         :size 16))
     (when errorp
       (sleep 0.05)
       (rotatef (xlib:gcontext-background gcontext)

--- a/message-window.lisp
+++ b/message-window.lisp
@@ -87,7 +87,7 @@ function expects to be wrapped in a with-state for win."
   (let ((win (screen-message-window screen)))
     ;; Now that we know the dimensions, raise and resize it.
     (xlib:with-state (win)
-      (setf (xlib:drawable-height win) height
+      (setf (xlib:drawable-height win) (+ height (* *message-window-y-padding* 2))
             (xlib:drawable-width win) (+ width (* *message-window-padding* 2))
             (xlib:window-priority win) :above)
       (setup-win-gravity screen win *message-window-gravity*))
@@ -220,7 +220,11 @@ function expects to be wrapped in a with-state for win."
       (multiple-value-bind (width height)
           (rendered-size strings (screen-message-cc screen))
         (setup-message-window screen width height)
-        (render-strings (screen-message-cc screen) *message-window-padding* 0 strings highlights))
+        (render-strings (screen-message-cc screen)
+                        *message-window-padding*
+                        *message-window-y-padding*
+                        strings
+                        highlights))
       (setf (screen-current-msg screen)
             strings
             (screen-current-msg-highlights screen)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -69,6 +69,7 @@
           *window-events*
           *window-parent-events*
           *message-window-padding*
+          *message-window-y-padding*
           *message-window-gravity*
           *editor-bindings*
           *input-window-gravity*
@@ -426,6 +427,9 @@ Include only those we are ready to support.")
 ;; Message window variables
 (defvar *message-window-padding* 5
   "The number of pixels that pad the text in the message window.")
+
+(defvar *message-window-y-padding* 0
+  "The number of pixels that pad the text in the message window vertically.")
 
 (defvar *message-window-gravity* :top-right
   "This variable controls where the message window appears. The follow


### PR DESCRIPTION
Currently only the horizontal padding can be changed throught the variable `STUMPWM:*MESSAGE-WINDOW-PADDING*`. This adds another variable, `STUMPWM:*MESSAGE-WINDOW-Y-PADDING*` to control the vertical padding.

I just wanted to do something very simple to learn how to contribute things. Let me know if I'm doing something wrong here.