### PR TITLE
Allow double quotes as string delimiters for command arguments

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -581,7 +581,12 @@ know lisp very well. One might put the following in one's rc file:
 
 (defcommand colon (&optional initial-input) (:rest)
   "Read a command from the user. @var{initial-text} is optional. When
-supplied, the text will appear in the prompt."
+supplied, the text will appear in the prompt.
+
+String arguments with spaces may be passed to the command by
+delimiting them with double quotes. A backslash can be used to escape
+double quotes or backslashes inside the string. This does not apply to
+commands taking :REST or :SHELL type arguments."
   (let ((cmd (completing-read (current-screen) ": " (all-commands) :initial-input (or initial-input ""))))
     (unless cmd
       (throw 'error :abort))

--- a/command.lisp
+++ b/command.lisp
@@ -241,19 +241,21 @@ only return active commands."
              ;; START (if there is one) and the end position of the
              ;; string.
              (let ((start
-                     (loop for i from start to (length input)
+                     (loop for i from start below (length input)
                            for char = (char input i)
                            do (case char
                                 (#\space)             ;Skip spaces
                                 (#\" (return (1+ i))) ;Start position found
                                 (otherwise (return-from pop-string nil))))))
                (let ((str (make-string-output-stream)))
-                 (loop for i from start to (length input)
+                 (loop for i from start below (length input)
                        for char = (char input i)
                        do (case char
                             (#\\        ;Escape next char
                              (incf i)
-                             (write-char (char input i) str))
+                             (if (< i (length input))
+                                 (write-char (char input i) str)
+                                 (return nil)))
                             (#\"        ;End delimiter
                              (return (values (get-output-stream-string str)
                                              (1+ i))))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1233,8 +1233,10 @@ of ``input'':
 
 @itemize
 @item
-@command{argument-pop} (input) pop the next space-delimited
-argument from the argument line.
+@command{argument-pop} (input) pop the next space-delimited word or a
+double quote delimited string argument from the argument
+line. Backslashes may be used to escape double quotes or backslashes
+inside double quoted strings.
 
 @item
 @command{argument-pop-rest} (input) return the remainder of the


### PR DESCRIPTION
When using the `colon` command or stumpish to execute commands, there currently seems to be no way to enter strings with spaces as a single argument. In interactive use this isn't that big of a problem since you can enter the string in the separate prompt, but when controlling Stumpwm via stumpish it would be nice to be able to, for example, create a group with spaces in the name.

This changes the `ARGUMENT-POP` function so that it allows double quotes to be used as string delimiters. For example, with the `colon` command `gnew "foo bar"`will create a group named `foo bar`. Non-quoted arguments still work the same as before, so this shouldn't break anything.