### PR TITLE
create wrapper for getting decoded system time

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -789,7 +789,7 @@ output directly to a file.")
 
 (defun dformat (level fmt &rest args)
   (when (>= *debug-level* level)
-    (multiple-value-bind (sec m h) (decode-universal-time (get-universal-time))
+    (multiple-value-bind (sec m h) (get-decoded-system-time)
       (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d " h m sec))
     ;; strip out non base-char chars quick-n-dirty like
     (write-string (map 'string (lambda (ch)

--- a/time.lisp
+++ b/time.lisp
@@ -113,9 +113,13 @@
 ;;; Helper functions
 ;;; ------------------------------------------------------------------
 
+(defun get-decoded-system-time ()
+  (decode-universal-time (+ (encode-universal-time 0 0 0 1 1 1970 0)
+                            (sb-posix:time))))
+
 (defun time-plist (&optional time)
   (multiple-value-bind (sec min hour dom mon year dow dstp tz)
-      (or time (get-decoded-time))
+      (or time (get-decoded-system-time))
     (list :second sec :minute min :hour hour :dom dom :month mon
           :year year :dow dow :dlsavings-p dstp :tz tz)))
 
@@ -205,9 +209,7 @@
 			    (* 60 decimal-local) 0))))))
 
 (defun time-unix-era ()
-  (format nil "~D"
-	  (- (get-universal-time)
-	     (encode-universal-time 0 0 0 1 1 1970 0))))
+  (format nil "~D" (sb-posix:time)))
 
 (defun time-date-and-time ()
   (time-format "%a %h %d %H:%M:%S %Y"))


### PR DESCRIPTION
https://github.com/stumpwm/stumpwm/issues/393

Unfortunately, I have not had time to test this yet, but it seems to compile fine and the changes are quite simple. If anyone can test that it runs as expected and there are no issues with the related time commands that would be awesome. 

I can confirm that using the `sb-posix:time` function fixes the system time change issue described in the bug report.