### PR TITLE
Use UIOP for pathname handling instead of cl-fad extract

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -81,7 +81,7 @@ called each time StumpWM starts with the argument `*module-dir'"
   (first (remove-if-not
           (lambda (file)
             (search "asd" (file-namestring file)))
-          (list-directory path))))
+          (uiop:directory* path))))
 (defun list-modules ()
   "Return a list of the available modules."
   (flet ((list-module (dir)

--- a/pathnames.lisp
+++ b/pathnames.lisp
@@ -36,53 +36,16 @@
 (export '(list-directory
           pathname-as-directory))
 
-(defun component-present-p (value)
-  "Helper function for DIRECTORY-PATHNAME-P which checks whether VALUE
-is neither NIL nor the keyword :UNSPECIFIC."
-  (and value (not (eql value :unspecific))))
-
-(defun directory-pathname-p (pathspec)
-  "Returns NIL if PATHSPEC \(a pathname designator) does not designate
-a directory, PATHSPEC otherwise.  It is irrelevant whether file or
-directory designated by PATHSPEC does actually exist."
-  (and 
-    (not (component-present-p (pathname-name pathspec)))
-    (not (component-present-p (pathname-type pathspec)))
-    pathspec))
+(defun list-directory (dirname)
+  (uiop:directory* dirname))
 
 (defun pathname-as-directory (pathspec)
   "Converts the non-wild pathname designator PATHSPEC to directory
 form."
-  (let ((pathname (pathname pathspec)))
-    (when (wild-pathname-p pathname)
-      (error "Can't reliably convert wild pathnames."))
-    (cond ((not (directory-pathname-p pathspec))
-           (make-pathname :directory (append (or (pathname-directory pathname)
-                                                 (list :relative))
-                                             (list (file-namestring pathname)))
-                          :name nil
-                          :type nil
-                          :defaults pathname))
-          (t pathname))))
+  (uiop:ensure-directory-pathname pathspec)))
 
-(defun directory-wildcard (dirname)
-  "Returns a wild pathname designator that designates all files within
-the directory named by the non-wild pathname designator DIRNAME."
-  (when (wild-pathname-p dirname)
-    (error "Can only make wildcard directories from non-wildcard directories."))
-  (make-pathname :name :wild
-                 :type :wild
-                 :defaults (pathname-as-directory dirname)))
 
-(defun list-directory (dirname)
-  "Returns a fresh list of pathnames corresponding to the truenames of
-all files within the directory named by the non-wild pathname
-designator DIRNAME.  The pathnames of sub-directories are returned in
-directory form - see PATHNAME-AS-DIRECTORY."
-  (when (wild-pathname-p dirname)
-    (error "Can only list concrete directory names.")) 
-  (let ((wildcard (directory-wildcard dirname)))
- (directory wildcard)))
+
 (defun list-directory-recursive (dirname &optional flatten-p)
   "Returns a list of pathnames corresponding to the truenames all
   files within the directory and in any subdirectories.  If
@@ -90,7 +53,7 @@ directory form - see PATHNAME-AS-DIRECTORY."
   (let ((files (map 'list (lambda (dir)
                (if (directory-pathname-p dir)
                    (list-directory-recursive dir)
-                   dir)) (list-directory dirname))))
+                   dir)) (uiop:directory* dirname))))
     (if flatten-p
       (flatten files)
       files)))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -15,7 +15,8 @@
   :depends-on (#:alexandria
                #:cl-ppcre
                #:clx
-               #:sb-posix)
+               #:sb-posix
+               #:uiop)
   :components ((:file "package")
                (:file "primitives")
                (:file "wrappers")


### PR DESCRIPTION
UIOP is available by default in SBCL due to SBCL bundling asdf as a
dependency. As UIOP is meant to be a wrapper layer on top of different
lisp distributions and is bundled in the most well used one it could
be considered a almost standard pathname api for modern systems. Due
to this using UIOP for pathnames instead of cl-fad allows us to reduce
our maintenance burden through using a proper library.