### PR TITLE
Use UIOP for pathname handling instead of cl-fad extract

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -81,7 +81,7 @@ called each time StumpWM starts with the argument `*module-dir'"
   (first (remove-if-not
           (lambda (file)
             (search "asd" (file-namestring file)))
-          (list-directory path))))
+          (uiop:directory* path))))
 (defun list-modules ()
   "Return a list of the available modules."
   (flet ((list-module (dir)

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -15,7 +15,8 @@
   :depends-on (#:alexandria
                #:cl-ppcre
                #:clx
-               #:sb-posix)
+               #:sb-posix
+               #:uiop)
   :components ((:file "package")
                (:file "primitives")
                (:file "wrappers")


### PR DESCRIPTION
UIOP is available by default in SBCL due to SBCL bundling asdf as a
dependency. As UIOP is meant to be a wrapper layer on top of different
lisp distributions and is bundled in the most well used one it could
be considered a almost standard pathname api for modern systems. Due
to this using UIOP for pathnames instead of cl-fad allows us to reduce
our maintenance burden through using a proper library.