### PR TITLE
Solve error when calling `resize-direction` directly as command and add docstring to it

### DIFF
--- a/iresize.lisp
+++ b/iresize.lisp
@@ -56,8 +56,8 @@
   (draw-frame-outlines (current-group) (current-head)))
 
 (defcommand resize-direction (d)
-  "Resize frame to direction @var{d}"
   ((:direction "Direction: "))
+  "Resize frame to direction @var{d}"
   (let* ((formats '((:up . "0 -~D")
                     (:down . "0 ~D")
                     (:left . "-~D 0")

--- a/iresize.lisp
+++ b/iresize.lisp
@@ -56,7 +56,8 @@
   (draw-frame-outlines (current-group) (current-head)))
 
 (defcommand resize-direction (d)
-  (:direction)
+  "Resize frame to direction @var{d}"
+  ((:direction "Direction: "))
   (let* ((formats '((:up . "0 -~D")
                     (:down . "0 ~D")
                     (:left . "-~D 0")


### PR DESCRIPTION
There is no problem when i call it within iresize, but error occur when i call `resize-direction` directly as command
![error](https://user-images.githubusercontent.com/10782979/35922663-b4539aee-0c50-11e8-9f40-736033c8e069.png)