### PR TITLE
Add session commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,4 @@ Thomas Atkinson     thomas at pinegrove io
 Grayson Croom       grayson at gmail com
 Sam Blumenthal      sam.sam.42 at gmail com
 Moch Deden R        moch.deden.r at gmail com
+Stuart Dilts        stuart.dilts at gmail com

--- a/user.lisp
+++ b/user.lisp
@@ -401,7 +401,7 @@ Returns true when yes is selected"
   ;; yes, this uses an external tool instead of stumpwm internals
   (let ((win-index-text (run-shell-command "wmctrl -l | awk '{print $1}'" t)))
     (dolist (window (cl-ppcre:split "\\\n" win-index-text))
-      (print (format nil "wmctrl -i -c ~A" window)))))
+      (run-shell-command (format nil "wmctrl -i -c ~A" window)))))
 
 (defcommand shutdown-computer () ()
   (let ((choice (yes-no-diag "Really Shutdown? (All programs will be closed)")))
@@ -409,7 +409,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Shutting down...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (print "systemctl shutdown"))))
+      (run-shell-command "systemctl shutdown"))))
 
 ;; can't name the function "restart"
 (defcommand restart-computer () ()
@@ -418,7 +418,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Restarting...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (print "systemctl restart"))))
+      (run-shell-command "systemctl restart"))))
 
 (defcommand end-session () ()
   (let ((choice (yes-no-diag "Close all programs and quit stumpwm?")))


### PR DESCRIPTION
This pull request adds the ability to cleanly shutdown, restart, and "logout" without root or having to manually close all windows first. Requires the user to use `systemd `and have the `polkit `package installed. See [the Arch wiki](https://wiki.archlinux.org/index.php/allow_users_to_shutdown) for details on how this works. 

This uses the external tool `wmctl` to close all windows before issuing any of the commands, and is needed as a dependency. This functionality should  be implemented in lisp instead, but I am not sure how to get a list of all available windows so that they can be killed.