### PR TITLE
find-asd-file now only loads files with .asd extensions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ Grayson Croom       grayson at gmail com
 Sam Blumenthal      sam.sam.42 at gmail com
 Moch Deden R        moch.deden.r at gmail com
 Audun Hoem          audun.hoem at gmail com
+Stuart Dilts        stuart.dilts at gmail com

--- a/module.lisp
+++ b/module.lisp
@@ -79,14 +79,9 @@ called each time StumpWM starts with the argument `*module-dir'"
 
 (defun find-asd-file (path)
   "Returns the first file ending with asd in `PATH', nil else."
-  (flet ((is-asd-file-p (file)
-           (let* ((file-string (file-namestring file))
-                  (extension-start  (position #\. file-string :from-end t)))
-             (when extension-start
-               (string-equal ".asd"
-                             (subseq file-string extension-start))))))
-    (first (remove-if-not #'is-asd-file-p
-                          (list-directory path)))))
+  (first (remove-if-not (lambda (file)
+                          (uiop:string-suffix-p (file-namestring file) ".asd"))
+                        (list-directory path))))
 
 (defun list-modules ()
   "Return a list of the available modules."

--- a/module.lisp
+++ b/module.lisp
@@ -76,12 +76,18 @@ called each time StumpWM starts with the argument `*module-dir'"
 (define-stumpwm-type :module (input prompt)
   (or (argument-pop-rest input)
       (completing-read (current-screen) prompt (list-modules) :require-match t)))
+
 (defun find-asd-file (path)
   "Returns the first file ending with asd in `PATH', nil else."
-  (first (remove-if-not
-          (lambda (file)
-            (search "asd" (file-namestring file)))
-          (list-directory path))))
+  (flet ((is-asd-file-p (file)
+           (let* ((file-string (file-namestring file))
+                  (extension-start  (position #\. file-string :from-end t)))
+             (when extension-start
+               (string-equal ".asd"
+                             (subseq file-string extension-start))))))
+    (first (remove-if-not #'is-asd-file-p
+                          (list-directory path)))))
+
 (defun list-modules ()
   "Return a list of the available modules."
   (flet ((list-module (dir)


### PR DESCRIPTION
Previously,` find-asd-file `could return files that contained "asd" in its name. This caused backup files or other unwanted files to be returned, which in turn caused some modules to not be found. This pull request makes `find-asd-file` check the full file extension before returning.