### PR TITLE
Add XF86XK_AudioMicMute to keysims

### DIFF
--- a/keysyms.lisp
+++ b/keysyms.lisp
@@ -1923,6 +1923,7 @@
 (define-keysym #x1008FF15 "XF86AudioStop")
 (define-keysym #x1008FF16 "XF86AudioPrev")
 (define-keysym #x1008FF17 "XF86AudioNext")
+(define-keysym #x1008FFB2 "XF86XK_AudioMicMute")
 (define-keysym #x1008FF18 "XF86HomePage")
 (define-keysym #x1008FF19 "XF86Mail")
 (define-keysym #x1008FF1A "XF86Start")


### PR DESCRIPTION
Add `XF86XK_AudioMicMute` keysim as defined in `XF86keysym.h`. This file can be found at [freedesktop.org](https://cgit.freedesktop.org/xorg/proto/x11proto/tree/XF86keysym.h) if you want to verify.