### PR TITLE
Fix checking if a directory contains a .asd file when loading modules

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -43,8 +43,8 @@
   path which contain any files ending in .asd"
   (map 'list #'directory-namestring
        (remove-if-not (lambda (file)
-                        (search "asd"
-                                (file-namestring file)))
+                        (equal "asd"
+                               (nth-value 1 (uiop:split-name-type (file-namestring file)))))
                       (list-directory-recursive path t))))
 
 (defvar *load-path* nil


### PR DESCRIPTION
Previously the check only checked if asd was contained in the entire
filename. Change this to only check the file type by splitting out the
type from the file before performing the check.