### PR TITLE
Fix key remapping by not using `MAPCAN`

### DIFF
--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -93,7 +93,7 @@ EXAMPLE:
                     (cons pattern (make-remap-keys kmap))))
                 specs))
   (let ((keys (mapcar 'car
-                      (mapcan 'cdr *remap-keys-window-class-list*))))
+                      (alexandria:mappend 'cdr *remap-keys-window-class-list*))))
     (dolist (k keys)
       (define-key *top-map*
           (kbd k)
@@ -102,7 +102,7 @@ EXAMPLE:
 (defun unbind-remapped-keys ()
   "Unbinds all previously remapped keybindings."
   (let ((keys (mapcar 'car
-                      (mapcan 'cdr *remap-keys-window-class-list*))))
+                      (alexandria:mappend 'cdr *remap-keys-window-class-list*))))
     (dolist (k keys)
       (undefine-key *top-map* (kbd k)))
     (setq *remap-keys-window-class-list* nil)))


### PR DESCRIPTION
I updated StumpWM and decided to try out the new key remapping stuff.  I ran into some really tricky bugs and hangs that I finally tracked down to some bad uses of `MAPCAN`. 

`MAPCAN` destructively modifies the lists to concatenate them together.  This is a problem because it changes the value of `*remap-keys-window-class-list*`, which results in incorrect functionality and totally breaks the unmapping process.

Example:

    (define-remapped-keys
      '(("Firefox"
         ("C-n" "down")
         ("C-p" "up"))
        ("xterm"
         ("s-c" "C-C")
         ("s-v" "C-V"))))

This attempts to add two remappings for Firefox and two for xterm. After the initial `setq` in `define-remapped-keys`, `*remap-keys-window-class-list*` looks something like this:

    (("Firefox"
       ("C-n" #S(KEY down))
       ("C-p" #S(KEY up)))
     ("xterm"
       ("s-c" #S(KEY ctrl-shift-c))
       ("s-v" #S(KEY ctrl-shift-v))))

This is what `send-remapped-key` expects.  But then the next line is:

    (let ((keys (mapcar 'car (mapcan 'cdr *remap-keys-window-class-list*))))

The `MAPCAN` destructively modifies the lists it receives, and `*remap-keys-window-class-list*` ends up looking something like this:

    (("Firefox"
       ("C-n" #S(KEY down))
       ("C-p" #S(KEY up))
       ("s-c" #S(KEY ctrl-shift-c))   ; the cons cell chain starting here is the same one as below
       ("s-v" #S(KEY ctrl-shift-v)))
     ("xterm"
       ("s-c" #S(KEY ctrl-shift-c))
       ("s-v" #S(KEY ctrl-shift-v))))

Which means that Firefox gets all the xterm keys too, which isn't right. This gets worse the more applications you've got, of course.  Also, `unbind-remapped-keys` will cause even more problems as it `MAPCAN`s the keys *again*.

The solution is to not destructively modify data that's not safe to modify.  `ALEXANDRIA:MAPPEND` is a safe alternative.