### PR TITLE
Add documentation of the other '-root-map*' vars

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -58,9 +58,14 @@ the list (inactive maps being skipped). In general the order should go
 from most specific groups to most general groups.")
 
 (defvar *group-top-map* nil)
-(defvar *group-root-map* nil)
+(defvar *group-root-map* nil
+  "Commands specific to a group context hang from this keymap.
+It is available as part of the @dnf{prefix map}.")
 (defvar *tile-group-top-map* nil)
-(defvar *tile-group-root-map* nil)
+(defvar *tile-group-root-map* nil
+  "Commands specific to a tile-group context hang from this keymap.
+It is available as part of the @dnf{prefix map} when the active group
+is a tile group.")
 
 ;; Do it this way so its easier to wipe the map and get a clean one.
 (defmacro fill-keymap (map &rest bindings)

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -289,7 +289,10 @@
 
 (pushnew '(float-group *float-group-top-map*) *group-top-maps*)
 (defvar *float-group-top-map* (make-sparse-keymap))
-(defvar *float-group-root-map* (make-sparse-keymap))
+(defvar *float-group-root-map* (make-sparse-keymap)
+  "Commands specific to a floating group context hang from this keymap.
+It is available as part of the @dnf{prefix map} when the active group
+is a tile group.")
 
 
 (defcommand gnew-float (name) ((:rest "Group Name: "))

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -38,7 +38,9 @@
 @dfn{prefix map}.")
 
 (defvar *root-map* nil
-  "This is the keymap by default bound to @kbd{C-t} (along with *group-root-map* and either *tile-group-root-map* or *float-group-root-map*). It is known as the @dfn{prefix map}.")
+  "This is the keymap by default bound to @kbd{C-t} (along with 
+ *group-root-map* and either *tile-group-root-map* or 
+ *float-group-root-map*). It is known as the @dfn{prefix map}.")
 
 (defstruct key
   keysym shift control meta alt hyper super)

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -38,7 +38,7 @@
 @dfn{prefix map}.")
 
 (defvar *root-map* nil
-  "This is the keymap by default bound to @kbd{C-t}. It is known as the @dfn{prefix map}.")
+  "This is the keymap by default bound to @kbd{C-t} (along with *group-root-map* and either *tile-group-root-map* or *float-group-root-map*). It is known as the @dfn{prefix map}.")
 
 (defstruct key
   keysym shift control meta alt hyper super)


### PR DESCRIPTION
In #480 I was confused because the documentation strongly implies that `*root-map*` is what you see when you type the prefix key. But actually what you see is a concatenation of `*root-map*` and `*group-root-map*` and (`*tile-group-root-map*`|`*float-group-root-map*`). This was frustrating because I was trying to throw away the entire prefix menu by altering `*root-map*`.

Probably, I would not have found this info even if the variables were documented because I was reading https://stumpwm.github.io/git/stumpwm-git.html

Still, hopefully this PR is more helpful than not.