### PR TITLE
Add tests for PARSE-KEY

### DIFF
--- a/stumpwm-tests.asd
+++ b/stumpwm-tests.asd
@@ -1,0 +1,10 @@
+(defsystem "stumpwm-tests"
+  :name "StumpWM tests"
+  :serial t
+  :depends-on ("stumpwm"
+               "fiasco")
+  :pathname "tests/"
+  :components ((:file "package")
+               (:file "kmap"))
+  :perform (test-op (o c)
+             (uiop/package:symbol-call "FIASCO" "RUN-TESTS" 'stumpwm-tests)))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -59,4 +59,5 @@
                (:file "remap-keys")
                ;; keep this last so it always gets recompiled if
                ;; anything changes
-               (:file "version")))
+               (:file "version"))
+  :in-order-to ((test-op (test-op "stumpwm-tests"))))

--- a/tests/kmap.lisp
+++ b/tests/kmap.lisp
@@ -1,0 +1,22 @@
+(in-package #:stumpwm-tests)
+
+(defun expand-key-description (&rest desc)
+  (let ((args (list (car desc) :keysym)))
+    (dolist (mod (cdr desc))
+      (push mod args)
+      (push t args))
+    (apply 'stumpwm::make-key (nreverse args))))
+
+(defmacro expect-key (kbd &key to-be)
+  `(is (equalp (stumpwm::parse-key ,kbd) (expand-key-description ,@to-be))))
+
+(fiasco:deftest test-parse-key ()
+
+  (expect-key "C-l" :to-be (108 :control))
+  (expect-key "C-S-l" :to-be (108 :control :shift))
+  (expect-key "C-s-l" :to-be (108 :control :super))
+  (expect-key "C--" :to-be (45 :control))
+  (expect-key "-" :to-be (45))
+
+  (signals stumpwm::kbd-parse-error (stumpwm::parse-key "C-")))
+

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,0 +1,2 @@
+(fiasco:define-test-package #:stumpwm-tests
+  (:use #:stumpwm))


### PR DESCRIPTION
Also setup the necessary machinery to run the tests through ASDF's
test-op:

  (asdf:test-system "stumpwm")

While trying to rewrite parse-key I kept running into edge-cases. I've added some happy path examples as well as some edge cases to test parse-key to get a test suite going.

Something I'm unsure of, although it makes sense conceptually for the test-op to be on StumpWM, as it currently stands every time we change a file on StumpWM the test-op will recompile the system before running the tests, which are not immediate.

Let me know what you think

Ref. #453 