### PR TITLE
Command 'gnew' no longer shows error when exited with C-g

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -400,12 +400,14 @@ current group. If @var{name} begins with a dot (``.'') the group new
 group will be created in the hidden state. Hidden groups have group
 numbers less than one and are invisible to from gprev, gnext, and, optionally,
 groups and vgroups commands."
-  (if name
-      (add-group (current-screen) name)
-      (message "No name given")))
+  (unless name 
+            (throw 'error :abort))  
+  (add-group (current-screen) name))
 
 (defcommand gnewbg (name) ((:string "Group Name: "))
   "Create a new group but do not switch to it."
+  (unless name
+            (throw 'error :abort))
   (add-group (current-screen) name :background t))
 
 (defcommand gnext () ()

--- a/group.lisp
+++ b/group.lisp
@@ -400,7 +400,9 @@ current group. If @var{name} begins with a dot (``.'') the group new
 group will be created in the hidden state. Hidden groups have group
 numbers less than one and are invisible to from gprev, gnext, and, optionally,
 groups and vgroups commands."
-  (add-group (current-screen) name))
+  (if name
+      (add-group (current-screen) name)
+      (message "No name given")))
 
 (defcommand gnewbg (name) ((:string "Group Name: "))
   "Create a new group but do not switch to it."


### PR DESCRIPTION
Exactly what the commit message says. This fixes a cosmetic error that occurs when the user exits an interactive call to `gnew`.