### PR TITLE
Add new command place-current-window

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -156,6 +156,7 @@ is a tile group.")
   (kbd "C-p")     "pull-hidden-previous"
   (kbd "M-p")     "prev"
   (kbd "C-M-p")   "prev-in-frame"
+  (kbd "P")       "place-current-window"
   (kbd "W")       "place-existing-windows"
   *escape-key*     "pull-hidden-other"
   (kbd "M-t")     "other-in-frame"

--- a/fdump.lisp
+++ b/fdump.lisp
@@ -223,3 +223,7 @@
 (defcommand place-existing-windows () ()
   "Re-arrange existing windows according to placement rules."
   (sync-window-placement))
+
+(defcommand place-current-window () ()
+  "Re-arrange current window according to placement rules."
+  (sync-single-window-placement (current-screen) (current-window) t))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1729,6 +1729,7 @@ the following commands.
 !!! dump-screen-to-file
 !!! restore-from-file
 !!! place-existing-windows
+!!! place-current-window
 
 @node Mode-line, Groups, Frames, Top
 @chapter The Mode Line

--- a/window-placement.lisp
+++ b/window-placement.lisp
@@ -95,7 +95,7 @@
                        (values)))))
         (values))))
 
-(defun sync-single-window-placement (screen window)
+(defun sync-single-window-placement (screen window &optional show)
   "Re-arrange the window according to placement rules"
   (multiple-value-bind (to-group frame raise)
       (with-current-screen screen
@@ -105,7 +105,10 @@
         (move-window-to-group window to-group)))
     (when frame
       (unless (eq (window-frame window) frame)
-        (pull-window window frame raise)))))
+        (pull-window window frame raise)))
+    (when show
+      (switch-to-group (window-group window))
+      (really-raise-window window))))
 
 (defun sync-window-placement ()
   "Re-arrange existing windows according to placement rules"


### PR DESCRIPTION
I sometimes move windows to different groups.

The new command place-current-window re-places the current window according to the placement rules