### PR TITLE
 Add *remove-split-hook* 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,3 +69,4 @@ Moch Deden R        moch.deden.r at gmail com
 Audun Hoem          audun.hoem at gmail com
 Stuart Dilts        stuart.dilts at gmail com
 Ram Krishnan        kriyative at gmail.com
+Herbert Jones       jones dot herbert at gmail.com

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -48,6 +48,7 @@
           *focus-frame-hook*
           *new-frame-hook*
           *split-frame-hook*
+          *remove-split-hook*
           *message-hook*
           *top-level-error-hook*
           *focus-group-hook*
@@ -282,6 +283,10 @@ the frame as an argument.")
 (defvar *split-frame-hook* '()
   "A hook called when a frame is split. the hook is called with
 the old frame (window is removed), and two new frames as arguments.")
+
+(defvar *remove-split-hook* '()
+  "A hook called when a split is removed. the hook is called with
+the current frame and removed frame as arguments.")
 
 (defvar *message-hook* '()
   "A hook called whenever stumpwm displays a message. The hook

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1050,7 +1050,8 @@ space."
           (when (frame-window l)
             (update-decoration (frame-window l)))
           (when (eq frame current)
-            (show-frame-indicator group))))))
+            (show-frame-indicator group))
+          (run-hook-with-args *remove-split-hook* l frame)))))
 
 (defcommand-alias remove remove-split)
 


### PR DESCRIPTION
I would like the mouse to follow all folder splits and removals so the mouse stays inside the frame.  To do this I've added a hook so that the mouse can be repositioned when a frame is removed.

Example config code I use to get this functionality:
```common-lisp
;; :click, :ignore, :sloppy
(setf *mouse-focus-policy* :sloppy)
(defun temporarilly-disable-sloppy-pointer ()
  "Disable the sloppy pointer for a brief period of time."
  (when (eq *mouse-focus-policy* :sloppy)
    (setf *mouse-focus-policy* :ignore)
    (run-with-timer 0.2 nil #'reenable-sloppy-pointer)))
(defun reenable-sloppy-pointer ()
  (setf *mouse-focus-policy* :sloppy))

(defun mouse-inside-frame-p (frame)
  "Determine if mouse already inside frame."
  (multiple-value-bind (mouse-x mouse-y window)
      (xlib:global-pointer-position  *display*)
    (let* ((group (current-group))
           (min-x (frame-x frame))
           (min-y (frame-display-y group frame))
           (max-x (+ min-x (frame-width frame)))
           (max-y (+ min-y (frame-display-height group frame))))
      (and (<= min-x mouse-x max-x)
           (<= min-y mouse-y max-y)))))

(defun my-banish-frame (frame)
  "Banish mouse to corner of frame"
  (let* ((group (current-group))
         (x-offset 15)
         (y-offset 15)
         (win-x (frame-x frame))
         (win-y (frame-display-y group frame))
         (w (frame-width frame))
         (h (frame-display-height group frame))
         (x (- (+ win-x w)
               x-offset))
         (y (- (+ win-y h)
               y-offset)))
    (temporarilly-disable-sloppy-pointer)
    (ratwarp x y)))

(defun my-focus-frame-hook (cur-frame last-frame)
  (unless (eq cur-frame last-frame)
    (unless (mouse-inside-frame-p cur-frame)
      (my-banish-frame cur-frame))))

(defun my-split-frame-hook (original-frame a-frame b-frame)
  "Reposition the mouse when a frame is created."
  (my-banish-frame a-frame))

(defun my-remove-split-hook (cur-frame old-frame)
  "Reposition the mouse when a frame is removed."
  (my-banish-frame cur-frame))

;; Clear hooks I use on restart
(remove-all-hooks *focus-frame-hook*)
(remove-all-hooks *split-frame-hook*)
(remove-all-hooks *remove-split-hook*)

(add-hook *focus-frame-hook* #'my-focus-frame-hook)
(add-hook *split-frame-hook* #'my-split-frame-hook)
(add-hook *remove-split-hook* #'my-remove-split-hook)
```