### PR TITLE
Fix style-warning.

### DIFF
--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -34,8 +34,9 @@ Repeat until there is only one window left."
 there are no more hidden windows. Tiling is done by splitting in the
 direction that is widest, and choosing the frame that has the largest
 area."
+  (declare (ignore win))
   (let* ((windows (group-windows group))
-        (num-win (length windows)))
+         (num-win (length windows)))
     (only)
     (recursive-tile (min *expose-n-max* num-win) group)))
 


### PR DESCRIPTION
The argument is defined so that user-provided hooks can play with it,
but the default function does not use it, so we can declare it as
ignored to remove the style-warning during compilation.