### PR TITLE
Declare mode-line and timer before using them.

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -131,18 +131,6 @@ timer.")
 (defvar *mode-lines* ()
   "All current mode lines.")
 
-(defstruct (mode-line (:constructor %make-mode-line))
-  screen
-  head
-  window
-  format
-  position
-  contents
-  cc
-  height
-  factor
-  (mode :stump))
-
 ;;; Utilities
 
 (defun screen-mode-lines (screen)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1264,3 +1264,18 @@ of :error."
 
 (defun command-mode-end-message ()
   (message "Exited command-mode."))
+
+(defstruct (mode-line (:constructor %make-mode-line))
+  screen
+  head
+  window
+  format
+  position
+  contents
+  cc
+  height
+  factor
+  (mode :stump))
+
+(defstruct timer
+  time repeat function args)

--- a/timers.lisp
+++ b/timers.lisp
@@ -39,9 +39,6 @@
 (defvar *timer-list-lock* (sb-thread:make-mutex)
   "Lock that should be held whenever *TIMER-LIST* is modified.")
 
-(defstruct timer
-  time repeat function args)
-
 (defun idle-time (screen)
   "Returns the time in seconds since idle according to the root window
 of the `screen'."


### PR DESCRIPTION
Various mode-line functions and timer functions are used before the
struct is declared, which means the functions were already compiled,
and they thus can't be inlined.

SBCL gives this warning:

; caught STYLE-WARNING:
;   Previously compiled calls to STUMPWM::MODE-LINE-SCREEN,
;   STUMPWM::MODE-LINE-POSITION, STUMPWM::MODE-LINE-HEIGHT,
;   STUMPWM::MODE-LINE-FACTOR and STUMPWM::MODE-LINE-MODE could not be inlined
;   because the structure definition for STUMPWM::MODE-LINE was not yet seen. To
;   avoid this warning, DEFSTRUCT should precede references to the affected
;   functions, or they must be declared locally notinline at each call site.

Which this commit fixes by moving the struct declarations earlier.

It also probably gives a very tiny bit of better performance.