### PR TITLE
Fix style-warning about START being potentially NIL.

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -241,12 +241,13 @@ only return active commands."
              ;; START (if there is one) and the end position of the
              ;; string.
              (let ((start
-                     (loop for i from start below (length input)
-                           for char = (char input i)
-                           do (case char
-                                (#\space)             ;Skip spaces
-                                (#\" (return (1+ i))) ;Start position found
-                                (otherwise (return-from pop-string nil))))))
+                     (or (loop for i from start below (length input)
+                            for char = (char input i)
+                            do (case char
+                                 (#\space)               ;Skip spaces
+                                 (#\" (return (1+ i))) ;Start position found
+                                 (otherwise (return-from pop-string nil))))
+                         (return-from pop-string nil))))
                (let ((str (make-string-output-stream)))
                  (loop for i from start below (length input)
                        for char = (char input i)


### PR DESCRIPTION
SBCL doesn't like this LOOP with `return`. It can't correctly guess
the return type and thinks that the START symbol can be bound to NIL.

```
; caught STYLE-WARNING:
;   The binding of I is not a REAL:
;    NIL
;   See also:
;     The SBCL Manual, Node "Handling of Types"
```

By being slightly more defensive (i.e. return NIL from POP-STRING if
the loop returned NIL), we can get rid of the warning.

And with this, we have no STYLE-WARNING left in `make` :-)