### PR TITLE
Misc fixes

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -143,11 +143,10 @@
 
 (defmethod group-button-press ((group tile-group) x y (where (eql :root)))
   (when *root-click-focuses-frame*
-    (let* ((frame (find-frame group x y)))
-      (when frame
-        (focus-frame group frame)
-        (unless (eq *mouse-focus-policy* :click)
-          (update-all-mode-lines))))))
+    (when-let ((frame (find-frame group x y)))
+      (focus-frame group frame)
+      (unless (eq *mouse-focus-policy* :click)
+        (update-all-mode-lines)))))
 
 (defmethod group-button-press ((group tile-group) x y (where window))
   (declare (ignore x y))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -239,9 +239,9 @@
            (fwx (+ fx (frame-width f)))
            (fhy (+ fy (frame-height f))))
       (when (and
-             (>= y fy) (<= y fhy)
-             (>= x fx) (<= x fwx)
-             (return f))))))
+             (<= fy y fhy)
+             (<= fx x fwx))
+        (return f)))))
 
 
 (defun frame-set-x (frame v)


### PR DESCRIPTION
- GROUP-BUTTON-PRESS: Use WHEN-LET

- Refactor FIND-FRAME

The WHEN had not body, instead we depended on the short-circuiting
behaviour of AND. Move the RETURN form to the body of the WHEN. The <=
is varidic in CL, we can merge both comparisons for y/x into one call to
<=.

I'm leaning towards leaving the WHEN because it is explicity about what
are the preconditions and what is the consequent. If we opt to eliminate
the WHEN form, sacrificing explicitness we would have more compact code:

    (and
     (<= fy y fhy)
     (<= fx x fwx)
     (return f))