### PR TITLE
Message window input gravity (split from https://github.com/stumpwm/stumpwm/pull/517)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,3 +70,4 @@ Audun Hoem          audun.hoem at gmail com
 Stuart Dilts        stuart.dilts at gmail com
 Ram Krishnan        kriyative at gmail.com
 Herbert Jones       jones dot herbert at gmail.com
+Daniel Oliveira     drdo at drdo.eu

--- a/message-window.lisp
+++ b/message-window.lisp
@@ -68,6 +68,15 @@ GRAVITY."))
 (define-simple-gravity :bottom :center :max)
 (define-simple-gravity :center :center :center)
 
+(defun message-window-real-gravity (screen)
+  "Returns the gravity that should be used when displaying the
+message window, taking into account *message-window-gravity*
+and *message-window-input-gravity*."
+  (if (eq (xlib:window-map-state (screen-input-window screen))
+          :unmapped)
+      *message-window-gravity*
+      *message-window-input-gravity*))
+
 (defun setup-win-gravity (screen win gravity)
   "Position the x, y of the window according to its gravity. This
 function expects to be wrapped in a with-state for win."
@@ -92,7 +101,7 @@ function expects to be wrapped in a with-state for win."
       (setf (xlib:drawable-height win) (+ height (* *message-window-y-padding* 2))
             (xlib:drawable-width win) (+ width (* *message-window-padding* 2))
             (xlib:window-priority win) :above)
-      (setup-win-gravity screen win *message-window-gravity*))
+      (setup-win-gravity screen win (message-window-real-gravity screen)))
     (xlib:map-window win)
     (incf (screen-ignore-msg-expose screen))
     ;; Have to flush this or the window might get cleared

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -72,6 +72,7 @@
           *message-window-padding*
           *message-window-y-padding*
           *message-window-gravity*
+          *message-window-real-gravity*
           *editor-bindings*
           *input-window-gravity*
           *normal-gravity*
@@ -437,8 +438,23 @@ Include only those we are ready to support.")
   "The number of pixels that pad the text in the message window vertically.")
 
 (defvar *message-window-gravity* :top-right
-  "This variable controls where the message window appears. The follow
+  "This variable controls where the message window appears. The following
 are valid values.
+@table @asis
+@item :top-left
+@item :top-right
+@item :bottom-left
+@item :bottom-right
+@item :center
+@item :top
+@item :left
+@item :right
+@item :bottom
+@end table")
+
+(defvar *message-window-input-gravity* :top-left
+  "This variable controls where the message window appears
+when the input window is being displayed. The following are valid values.
 @table @asis
 @item :top-left
 @item :top-right
@@ -456,7 +472,7 @@ are valid values.
   "A list of key-bindings for line editing.")
 
 (defvar *input-window-gravity* :top-right
-  "This variable controls where the input window appears. The follow
+  "This variable controls where the input window appears. The following
 are valid values.
 @table @asis
 @item :top-left

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1401,6 +1401,7 @@ set these color variables.
 ### *message-window-padding*
 ### *message-window-y-padding*
 ### *message-window-gravity*
+### *message-window-input-gravity*
 ### *message-window-timer*
 ### *timeout-wait*
 ### *input-window-gravity*


### PR DESCRIPTION
The same gravity setting was being used for both the message window
and the input window, making displaying both at once problematic.

Added special variable *message-window-input-gravity*
that is to be used as a message window's gravity
when the input window is being displayed so that they do not overlap.

The function message-window-real-gravity should be used to compute
the proper gravity to use when displaying a message window.