### PR TITLE
D-F-P: Use the same indentation for all the FRAME-RULES

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1078,7 +1078,7 @@ will have no effect.")
   "List of rules governing window placement. Use define-frame-preference to
 add rules")
 
-(defmacro define-frame-preference (target-group &rest frame-rules)
+(defmacro define-frame-preference (target-group &body frame-rules)
   "Create a rule that matches windows and automatically places them in
 a specified group and frame. Each frame rule is a lambda list:
 @example


### PR DESCRIPTION
Using the &BODY lambda list keyword instead of &REST hints the CL IDE to
indent to declare FRAME-RULES using the same offset. Using &rest the
indentation would be as follows

```lisp
(define-frame-preference "Shareland"
    (0  t 0 :calss "XTerm")
  (1  0 t :class "aMule"))
```

Using &BODY the alignment is

```lisp
(define-frame-preference "Shareland"
  (0  t 0 :calss "XTerm")
  (1  0 t :class "aMule"))
```