### PR TITLE
Fix remap-keys related issues

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -199,15 +199,14 @@ The Caller is responsible for setting up the input focus."
     (when update-fn
       (funcall update-fn key-seq))
     (cond ((kmap-or-kmap-symbol-p match)
-           (with-focus (screen-key-window (current-screen))
-             (when grab
-               (grab-pointer (current-screen)))
-             (let* ((code-state (read-key-no-modifiers))
-                    (code (car code-state))
-                    (state (cdr code-state)))
-               (unwind-protect
-                    (handle-keymap (remove-if-not 'kmap-or-kmap-symbol-p bindings) code state key-seq nil update-fn)
-                 (when grab (ungrab-pointer))))))
+           (when grab
+             (grab-pointer (current-screen)))
+           (let* ((code-state (read-key-no-modifiers))
+                  (code (car code-state))
+                  (state (cdr code-state)))
+             (unwind-protect
+                  (handle-keymap (remove-if-not 'kmap-or-kmap-symbol-p bindings) code state key-seq nil update-fn)
+               (when grab (ungrab-pointer)))))
           (match
            (values match key-seq))
           ((and (find key (list (kbd "?")
@@ -240,7 +239,8 @@ The Caller is responsible for setting up the input focus."
 
 (define-stump-event-handler :key-press (code state #|window|#)
   (labels ((get-cmd (code state)
-             (handle-keymap (top-maps) code state nil t nil)))
+             (with-focus (screen-key-window (current-screen))
+               (handle-keymap (top-maps) code state nil t nil))))
     (unwind-protect
          ;; modifiers can sneak in with a race condition. so avoid that.
          (unless (is-modifier code)

--- a/events.lisp
+++ b/events.lisp
@@ -238,9 +238,9 @@ The Caller is responsible for setting up the input focus."
   REMAP-KEYS contrib module for a working use case.")
 
 (defvar *custom-key-event-handler* nil
-  "An custom key event handler can be installed in this variable,
-  which will take precedence over the keymap based handler defined
-  in the default :KEY-PRESS event handler.")
+  "A custom key event handler can be set in this variable,
+  which will take precedence over the keymap based handler defined in
+  the default :KEY-PRESS event handler.")
 
 (define-stump-event-handler :key-press (code state #|window|#)
   (labels ((get-cmd (code state)

--- a/events.lisp
+++ b/events.lisp
@@ -237,22 +237,29 @@ The Caller is responsible for setting up the input focus."
   dispatch further based on the value in *current-key-seq*. See the
   REMAP-KEYS contrib module for a working use case.")
 
+(defvar *custom-key-event-handler* nil
+  "An custom key event handler can be installed in this variable,
+  which will take precedence over the keymap based handler defined
+  in the default :KEY-PRESS event handler.")
+
 (define-stump-event-handler :key-press (code state #|window|#)
   (labels ((get-cmd (code state)
              (with-focus (screen-key-window (current-screen))
                (handle-keymap (top-maps) code state nil t nil))))
     (unwind-protect
-         ;; modifiers can sneak in with a race condition. so avoid that.
-         (unless (is-modifier code)
-           (multiple-value-bind (cmd key-seq) (get-cmd code state)
-             (cond
-               ((eq cmd t))
-               (cmd
-                (unmap-message-window (current-screen))
-                (let ((*current-key-seq* key-seq))
-                  (eval-command cmd t))
-                t)
-               (t (message "~{~a ~}not bound." (mapcar 'print-key (nreverse key-seq))))))))))
+         (or (and *custom-key-event-handler*
+                  (funcall *custom-key-event-handler* code state))
+             ;; modifiers can sneak in with a race condition. so avoid that.
+             (unless (is-modifier code)
+               (multiple-value-bind (cmd key-seq) (get-cmd code state)
+                 (cond
+                   ((eq cmd t))
+                   (cmd
+                    (unmap-message-window (current-screen))
+                    (let ((*current-key-seq* key-seq))
+                      (eval-command cmd t))
+                    t)
+                   (t (message "~{~a ~}not bound." (mapcar 'print-key (nreverse key-seq)))))))))))
 
 (defun bytes-to-window (bytes)
   "Combine a list of 4 8-bit bytes into a 32-bit number. This is because

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -57,6 +57,7 @@
       (xwin-grab-key (window-xwin win) (kbd key)))))
 
 (defun remap-keys-focus-window-hook (new-focus cur-focus)
+  (declare (ignorable cur-focus))
   (remap-keys-grab-keys new-focus))
 
 (defun remap-keys-event-handler (code state)

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -58,7 +58,8 @@
 
 (defun remap-keys-focus-window-hook (new-focus cur-focus)
   (declare (ignorable cur-focus))
-  (remap-keys-grab-keys new-focus))
+  (when new-focus
+    (remap-keys-grab-keys new-focus)))
 
 (defun remap-keys-event-handler (code state)
   (let* ((raw-key (code-state->key code state))

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -106,14 +106,15 @@ EXAMPLE:
 (defcommand send-raw-key () ()
   "Prompts for a key and forwards it to the CURRENT-WINDOW."
   (message "Press a key to send")
-  (let* ((k (read-key))
+  (let* ((screen (current-screen))
+         (win (screen-current-window screen))
+         (k (with-focus (screen-key-window screen)
+              (read-key)))
          (code (car k))
-         (state (cdr k))
-         (screen (current-screen)))
+         (state (cdr k)))
     (unmap-message-window screen)
-    (when (screen-current-window screen)
-      (let* ((win (screen-current-window screen))
-             (xwin (window-xwin win)))
+    (when win
+      (let ((xwin (window-xwin win)))
         (dolist (event '(:key-press :key-release))
           (xlib:send-event xwin
                            event

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -80,7 +80,7 @@
   "Define the keys to be remapped and their mappings. The SPECS
 argument needs to be of the following structure:
 
-  (regexp . ((\"key-to-remap\" . <new-keycodes>) ...))
+  (regexp-or-function . ((\"key-to-remap\" . <new-keycodes>) ...))
 
 EXAMPLE:
   (define-remapped-keys

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1056,6 +1056,29 @@ keybindings.
 
 The above form adds Emacs like keybindings to windows whose @var{window-class} matches ``Firefox'' or ``Chrome''. Additional application specific bindings may be included by using the specific X @var{window-class} values.
 
+The window matching pattern can also be specified as a function which returns @code{T} if the focused window matches.
+
+@example
+;; Match any window with a window-class matching "Firefox"
+(define-remapped-keys
+    `((,(lambda (win)
+          (string-equal "Firefox" (window-class win)))
+       ("C-n"   . "Down")
+       ("C-p"   . "Up")
+       ("C-f"   . "Right")
+       ("C-b"   . "Left")
+       ("C-v"   . "Next")
+       ("M-v"   . "Prior")
+       ("M-w"   . "C-c")
+       ("C-w"   . "C-x")
+       ("C-y"   . "C-v")
+       ("M-<"   . "Home")
+       ("M->"   . "End")
+       ("C-M-b" . "M-Left")
+       ("C-M-f" . "M-Right")
+       ("C-k"   . ("C-S-End" "C-x")))))
+@end example
+
 @subsection Circumventing Remapped Keys
 
 However, if the original key binding needs to be explictly applied the
@@ -1073,7 +1096,6 @@ the prompt will send the keystroke as-is to Firefox, causing it to
 open a new window.
 
 !!! send-raw-key
-!!! send-remapped-key
 
 @node Commands, Message and Input Bar, Key Bindings, Top
 @chapter Commands


### PR DESCRIPTION
- Revamps the remap-keys implementation by introducing a new `*custom-key-event-handler*` in events.lisp
- Reverts a previous commit, which was the cause of issue #494 
- Adds support for functions which can be used to switch remap-keys based on different properties of the focused window