### PR TITLE
Avoid escaping carets when window has no name

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -333,8 +333,10 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
     (utf8-to-string name)))
 
 (defun xwin-name (win)
-  (escape-caret (or (xwin-net-wm-name win)
-                    (xlib:wm-name win))))
+  (if-let ((name (or (xwin-net-wm-name win)
+                     (xlib:wm-name win))))
+    (escape-caret name)
+    ""))
 
 (defun update-configuration (win)
   ;; Send a synthetic configure-notify event so that the window


### PR DESCRIPTION
Fixes #524.