### PR TITLE
Make explicit that "" is the default value of XWIN-NAME

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -334,7 +334,8 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
 
 (defun xwin-name (win)
   (escape-caret (or (xwin-net-wm-name win)
-                    (xlib:wm-name win))))
+                    (xlib:wm-name win)
+                    "")))
 
 (defun update-configuration (win)
   ;; Send a synthetic configure-notify event so that the window


### PR DESCRIPTION
Before commit 3e3ce5b this was not necessary as ESCAPE-CARET defaulted
to the empty string when passed NIL.

Closes #524

Co-authored-by: Javier Olaechea <pirata@gmail.com>