### PR TITLE
Fix double click behavior on float window title.

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -213,18 +213,21 @@
   "Returns maximum displayable height of window accounting for the mode-line"
   (let* ((head (window-head window))
          (ml (head-mode-line head))
-         (ml-height (mode-line-height ml)))
-    (if (and ml (not (eq (mode-line-mode ml) :hidden)))
-        (- (head-height head) ml-height)
-        (window-height window))))
+         (ml-height (if (null ml) 0 (mode-line-height ml))))
+    (- (head-height head) ml-height
+       *normal-border-width*
+       *float-window-border*
+       *float-window-title-height*)))
   
 (defun maximize-float (window &key horizontal vertical)
   (let* ((head (window-head window))
          (ml (head-mode-line head))
          (hx (head-x head))
-         (hy (mode-line-height ml))
-         (w (head-width head))
-         (h (window-display-height window))) 
+         (hy (if (null ml) 0 (mode-line-height ml)))
+         (w (- (head-width head)
+               (* 2 *normal-border-width*)
+               *float-window-border*))
+         (h (window-display-height window)))
     (when horizontal
       (float-window-move-resize window :width w)) 
     (when vertical


### PR DESCRIPTION
- Avoid type-error by checking ml before retrieving ml-height in
window-display-height and maximize-float function.

- Adding default 0 for ml-height and remove checking :hidden mode for
ml before calculating maximum displayable height.

- Calculating width and height must involve \*normal-border-width\*,
\*float-window-border\* and \*float-window-title-height\*.

![floating-window-title-double-click](https://user-images.githubusercontent.com/4687211/49021508-5adbb680-f1c5-11e8-9429-efcc134e3cc7.gif)
