### PR TITLE
Add *float-window-modifier* for using modifiers other than super

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -12,6 +12,10 @@
 
 (defvar *float-window-border* 1)
 (defvar *float-window-title-height* 10)
+(defvar *float-window-modifier* :super
+  "The keyboard modifier used to resize and move floating windows
+  without clicking on the top border. Valid values include (but are not
+  limited to): :super, :meta, :hyper.")
 
 ;; some book keeping functions
 (defmethod (setf window-x) :before (val (window float-window))
@@ -253,8 +257,10 @@
                 (< y (xlib:drawable-y xwin))
                 (> y (+ (xlib:drawable-height xwin)
                         (xlib:drawable-y xwin)))
-                (intersection (modifiers-super *modifiers*) (xlib:make-state-keys state-mask)))
-      (when (find :button-1 (xlib:make-state-keys state-mask))
+                (intersection (slot-value *modifiers*
+                                          (find-symbol (symbol-name *float-window-modifier*)))
+                              (xlib:make-state-keys state-mask)))
+        (when (find :button-1 (xlib:make-state-keys state-mask))
           (let* ((current-time (/ (get-internal-real-time)
                                   internal-time-units-per-second))
                  (delta-t (- current-time *last-click-time*))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -353,6 +353,13 @@ to overlap. Each window has a thicker border at the top. Left click in
 this border and drag to move the window, or right click and drag to
 resize it.
 
+A modifier key can be used to perform the move and resize operations
+by clicking in the window itself instead of on its top border. The
+default modifier is super, and can be configured with
+@var{*float-window-modifier*}.
+
+### *float-window-modifier*
+
 Most of the window-switching commands listed below do not function in
 a floating group. You're restricted to `other', the `select-window-*'
 commands, and `windowlist'.


### PR DESCRIPTION
Previously windows could be moved or resized using the super modifier
plus a mouse click on the window. This variable allows the user to
customize which modifier is used.