### PR TITLE
Simplify the implementation of ALL-MODIFIER-CODES

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -755,17 +755,8 @@ input (pressing Return), nil otherwise."
        nil))))
 
 (defun all-modifier-codes ()
-  (multiple-value-bind
-        (shift-codes lock-codes control-codes mod1-codes mod2-codes mod3-codes mod4-codes mod5-codes)
-      (xlib:modifier-mapping *display*)
-    (append shift-codes
-            lock-codes
-            control-codes
-            mod1-codes
-            mod2-codes
-            mod3-codes
-            mod4-codes
-            mod5-codes)))
+  "Return all the keycodes that are associated with a modifier."
+  (flatten (multiple-value-list (xlib:modifier-mapping *display*))))
 
 (defun get-modifier-map ()
   (labels ((find-mod (mod codes)


### PR DESCRIPTION
This way `all-modifier-codes` is oblivious what to how many values or in which order `xlib:modifier-mapping` returns.