### PR TITLE
Border calculation on float-window

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -226,7 +226,7 @@
          (ml (head-mode-line head))
          (ml-height (if (null ml) 0 (mode-line-height ml))))
     (- (head-height head) ml-height
-       *normal-border-width*
+       (* 2 *normal-border-width*)
        *float-window-border*
        *float-window-title-height*)))
   
@@ -237,7 +237,7 @@
          (hy (if (null ml) 0 (mode-line-height ml)))
          (w (- (head-width head)
                (* 2 *normal-border-width*)
-               *float-window-border*))
+               (* 2 *float-window-border*)))
          (h (window-display-height window)))
     (when horizontal
       (float-window-move-resize window :width w)) 


### PR DESCRIPTION
___
After I change config to distinct border like this:
```
(setf *normal-border-width* 4
      *transient-border-width* 3
      *float-window-border* 5
      *float-window-title-height* 10)
```
I realize i made mistake with counting windows geometry. Here is what I got:

- It seem \*normal-border-width\* only showed on float-window and not selected tile-window
- frame-height != window-height, it's involve \*normal-border-width\*
- frame-height not always same with window-height  plus 2  \*normal-border-width\*
- geometry-hints always helpful to work with tile-windows

With that discovery I changed the float-window-align and set the geometry so that when adding borders, it won't change the size of the window. Although it change the width and height of slot from window because of addition borders.
___

Set mouse focus policy to :click
```
(setf *mouse-focus-policy* :click)
```
Everything works fine except when I only have one frame, two or more tile-window then execute command ```float-this```,  move or resize float-window and finally click tile-window behind it. The focus did not change to tile-window.

So I change float-window function to find tile-window on list and use it to set in funcall-on-node and set focus on the float-window. Additionally I add check type for float-window to not call ```change-class``` and ```float-window-align```.
___

Sorry about mistake I made concerning my previous PR.