### PR TITLE
Fix focus click issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,3 +71,4 @@ Stuart Dilts        stuart.dilts at gmail com
 Ram Krishnan        kriyative at gmail.com
 Herbert Jones       jones dot herbert at gmail.com
 Daniel Oliveira     drdo at drdo.eu
+Panji Kusuma        epanji at gmail dot com

--- a/events.lisp
+++ b/events.lisp
@@ -592,8 +592,7 @@ the window in it's frame."
 (define-stump-event-handler :button-press (window code x y child time)
   (let ((screen (find-screen window))
         (mode-line (find-mode-line-by-window window))
-        (win (or (find-window-by-parent window (top-windows))
-                 (find-window-by-parent window (group-windows (current-group))))))
+        (win (find-window-by-parent window (top-windows))))
     (cond
       ((and screen (not child))
        (group-button-press (screen-current-group screen) x y :root)

--- a/events.lisp
+++ b/events.lisp
@@ -592,7 +592,8 @@ the window in it's frame."
 (define-stump-event-handler :button-press (window code x y child time)
   (let ((screen (find-screen window))
         (mode-line (find-mode-line-by-window window))
-        (win (find-window-by-parent window (top-windows))))
+        (win (or (find-window-by-parent window (top-windows))
+                 (find-window-by-parent window (group-windows (current-group))))))
     (cond
       ((and screen (not child))
        (group-button-press (screen-current-group screen) x y :root)


### PR DESCRIPTION
Apparently the tile-window behind the float-window is not included as a top-windows, so it fails when trying to get a window by parent. 

https://github.com/stumpwm/stumpwm/pull/544#issuecomment-450286794