### PR TITLE
Fix float window map request crash in tile group

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -486,9 +486,11 @@ converted to an atom is removed."
         (if (eq (window-group window) (current-group))
             (echo-string (window-screen window) (format nil "'~a' denied map request" (window-name window)))
             (echo-string (window-screen window) (format nil "'~a' denied map request in group ~a" (window-name window) (group-name (window-group window))))))
-      (frame-raise-window (window-group window) (window-frame window) window
-                          (eq (window-frame window)
-                              (tile-group-current-frame (window-group window))))))
+      (if (typep window 'tile-window)
+          (frame-raise-window (window-group window) (window-frame window) window
+                              (eq (window-frame window)
+                                  (tile-group-current-frame (window-group window))))
+          (raise-window window))))
 
 (defun maybe-raise-window (window)
   (if (deny-request-p window *deny-raise-request*)


### PR DESCRIPTION
Previously, when a window in a tiling group was made to float, then
unmapped and then mapped again, StumpWM would crash. The tile-group
method for group-raise-request calls maybe-map-window, and
maybe-map-window assumed its argument was a tile-window.

The crash is easy to reproduce using Inkscape:

1. Start Inkscape
2. Press `C-P` to open the preferences
3. Use the command `float-this` to make the preferences window float
4. Use the command `delete` (`C-t k`) to close the window
5. Press `C-P` again