### PR TITLE
add :exit-on example for define-interactive-keymap

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1246,16 +1246,21 @@ The available configuration is @code{on-enter}, @code{on-exit} and
 (defun before-foo () (message "start foo"))
 (defun after-foo () (message "end foo"))
 (defun foo-p () (and *bar* *bhaz*))
+(defparameter *custom-exit-keys* '((kbd "RET") (kbd "SPC")
+                                   (kbd "C-g") (kbd "ESC")))
 
 (define-interactive-keymap foo (:on-enter #'before-foo
                                 :on-exit #'after-foo
-                                :abort-if #'foo-p))
+                                :abort-if #'foo-p
+                                :exit-on *custom-exit-keys*))
 @end example
 
 In the above example, the message ``start foo'' will appear before
 starting the interactive keymap, ``end foo'' will appear right after
-the command exits. Also, the command executes only if the variables
-@code{*bar*} and @code{*bhaz*} are true.
+the command exits; We've added SPC as an exit key with custom exit 
+keys. Also, the command executes only if the variables @code{*bar*}
+and @code{*bhaz*} are true.
+
 
 @node StumpWM Types,  , Writing Commands, Commands
 @section StumpWM Types

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1245,7 +1245,7 @@ The available configuration is @code{on-enter}, @code{on-exit} and
 @example
 (defun before-foo () (message "start foo"))
 (defun after-foo () (message "end foo"))
-(defun foo-p () (and *bar* *bhaz*))
+(defun foo-p () (and *bar* *baz*))
 (defparameter *custom-exit-keys* '((kbd "RET") (kbd "SPC")
                                    (kbd "C-g") (kbd "ESC")))
 
@@ -1259,7 +1259,7 @@ In the above example, the message ``start foo'' will appear before
 starting the interactive keymap, ``end foo'' will appear right after
 the command exits; We've added SPC as an exit key with custom exit 
 keys. Also, the command executes only if the variables @code{*bar*}
-and @code{*bhaz*} are true.
+and @code{*baz*} are true.
 
 
 @node StumpWM Types,  , Writing Commands, Commands


### PR DESCRIPTION
adds an example of overriding the default exit keys in define-interactive-keymap which adds SPC to the exit commands. It could also be rewritten without the defparameter, but i found it more readable this way. 