### PR TITLE
add command 'remove-sibling'

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1055,9 +1055,8 @@ space."
 (defcommand (remove-sibling tile-group)
     (&optional (group (current-group))
 	       (frame (let ((window-type (type-of (current-window))))
-			           (if (eq window-type 'float-window)
-			               nil ;; (focus-all (current-window))
-			               (window-frame (current-window))))))
+			           (unless (eq window-type 'float-window)
+			             (window-frame (current-window))))))
     ()
   "removes the closest sibling frame to the specified frame, which defaults
 to the current frame. if the closes sibling is split, we call 

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1052,6 +1052,39 @@ space."
             (show-frame-indicator group))
           (run-hook-with-args *remove-split-hook* l frame)))))
 
+(defcommand (remove-sibling tile-group)
+    (&optional (group (current-group))
+	       (frame (let ((window-type (type-of (current-window))))
+			           (if (eq window-type 'float-window)
+			               nil ;; (focus-all (current-window))
+			               (window-frame (current-window))))))
+    ()
+  "removes the closest sibling frame to the specified frame, which defaults
+to the current frame. if the closes sibling is split, we call 
+remove-split-sibling, otherwise we just remove the sibling frame. "
+  (when frame
+    (labels ((remove-split-sibling (tree group)
+	       (let ((left (car tree))
+		     (right (second tree)))
+		 (when (listp left)
+		   (remove-split-sibling left group))
+		 (when (listp right)
+		   (remove-split-sibling right group))
+		 (when (frame-p left)
+		   (remove-split group left))
+		 (when (frame-p right)
+		   (remove-split group right)))))
+      (let ((sibling
+	     (closest-sibling
+	      (list (tile-group-frame-head group (frame-head group frame)))
+	      frame)))
+	     (cond ((listp sibling) ;; sibling is split
+	            (remove-split-sibling sibling group))
+	           ((frame-p sibling) ;; sibling is a frame
+	            (remove-split group sibling))
+	           (t ;; something went wrong, show the current frame.
+	            (curframe)))))))
+
 (defcommand-alias remove remove-split)
 
 (defcommand (only tile-group) () ()


### PR DESCRIPTION
adding the command remove-sibling, which recursively removes the sibling* frame of the current frame. I'm not sure if this functionality exists, but I couldn't find it. I think that having the ability to remove the sibling frame is useful and worth having in stumpwm, but if its better suited to the ~/.stumpwm.d/init.lisp let me know. I generally use this command as a more malleable 'only' command - executing it on a frame removes all other frames in that branch of the frame tree. 

*sibling here refers to whats on the other side of a split, not the frame focused by the sibling command (which seems to always be the 0th frame)