### PR TITLE
exit keymap via specific bindings.

### DIFF
--- a/interactive-keymap.lisp
+++ b/interactive-keymap.lisp
@@ -38,6 +38,9 @@
 
 (defcommand call-and-exit-kmap (function exit-map) ((:command "command to run: ")
                                                    (:command "keymap to exit: "))
+  "This command effectively calls two other commands in succession, via run-commands.
+it is designed for use in the define-interactive-keymap macro, to implement exiting
+the keymap on keypress. "
   (run-commands function exit-command))
 
 (defmacro define-interactive-keymap

--- a/interactive-keymap.lisp
+++ b/interactive-keymap.lisp
@@ -36,6 +36,10 @@
   (message "~S finished" name)
   (pop-top-map))
 
+(defcommand call-and-exit-kmap (function exit-map) ((:command "command to run: ")
+                                                   (:command "keymap to exit: "))
+  (run-commands function exit-command))
+
 (defmacro define-interactive-keymap
     (name (&key on-enter on-exit abort-if (exit-on '((kbd "RET")
                                                      (kbd "ESC")
@@ -51,6 +55,8 @@ interactive keymap mode, respectively. If ABORT-IF is defined, the interactive
 keymap will only be activated if calling ABORT-IF returns true.
 
 KEY-BINDINGS is a list of the following form: ((KEY COMMAND) (KEY COMMAND) ...)
+If one appends t to the end of a binding like so: ((kbd \"n\") \"cmd\" t) then
+the keymap is immediately exited after running the command. 
 
 Each element in KEY-BINDINGS declares a command inside the interactive keymap.
 Be aware that these commands won't require a prefix to run."
@@ -61,7 +67,11 @@ Be aware that these commands won't require a prefix to run."
         (parse-body key-bindings :documentation t)
       `(let ((,keymap (make-sparse-keymap)))
          ,@(loop for keyb in key-bindings
-                 collect `(define-key ,keymap ,@keyb))
+                 collect `(define-key ,keymap ,(first keyb)
+                            ,(if (third keyb)
+                                 (concatenate 'string "call-and-exit-kmap \""
+                                              (second keyb) "\" " exit-command)
+                                 (second keyb))))
          ,@(loop for keyb in exit-on
                  collect `(define-key ,keymap ,keyb ,exit-command))
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1224,19 +1224,27 @@ The macro @command{define-interactive-keymap} is used to define an
 interactive keymap. The first argument is the same as
 @command{defcommand}. The second argument is a list of extra
 configurations that can be used for controlling the command and the
-rest are the key bindings for the new command.
+rest are the key bindings for the new command, optionally with a
+@code{t} appended; this tells @code{define-interactive-keymap} to
+exit the keymap upon use of that keybinding. 
 
 For instance, a simple interactive keymap:
 
 @example
 (define-interactive-keymap my-new-command nil
   ((kbd "a") "execute-a-command")
-  ((kbd "b") "execute-b-command"))
+  ((kbd "b") "execute-b-command" t))
 @end example
 
 This creates a command called @code{my-new-command} that, when called,
 will activate the interactive keymap mode. In this mode, the user can
 press ``a'' or ``b'' repeatedly, omitting any prefix. The default exit
+commands are @code{RET}, @code{C-g} and @code{ESC}.
+
+This creates a command called @code{my-new-command} that, when called,
+will activate the interactive keymap mode. In this mode, the user can
+press ``a'' or ``b'', omitting any prefix. The user can press ``a''
+repeatedly, however pressing ``b'' exits the keymap. The default exit
 commands are @code{RET}, @code{C-g} and @code{ESC}.
 
 The available configuration is @code{on-enter}, @code{on-exit} and
@@ -2152,6 +2160,7 @@ section.
 @@@ update-decoration
 
 @@@ run-commands
+!!! call-and-exit-kmap
 
 %%% defcommand
 %%% define-interactive-keymap


### PR DESCRIPTION
This adds the command call-and-exit-kmap, which allows us to run a command, and then run the exit command for the appropriate interactive keymap. It also modifies define-interactive-keymap so one can specify specific bindings that exit the keymap when run, by virtue of passing them to call-and-exit-kmap. This action is triggered by appending any true value to the end of the key binding. 
in the below example, pressing 'n' will run 'meta n', while pressing m will run 'meta x' and then exit the interactive keymap. 
(define-interactive-keymap example ()
  ((kbd "n") "meta N")
  ((kbd "m") "meta x" t))

this modification of define-interactive-keymap preserves the original usage, and doesnt break existing code using it.