### PR TITLE
Generate the heads using Xrandr instead of Xinerama.

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -103,7 +103,7 @@
         ((equalp old-heads new-heads)
          (dformat 3 "Bogus configure-notify on root window of ~S~%" screen) t)
         (t
-         (dformat 1 "Updating Xinerama configuration for ~S.~%" screen)
+         (dformat 1 "Updating Xrandr or Xinerama configuration for ~S.~%" screen)
          (if new-heads
              (progn (head-force-refresh screen new-heads)
                     (update-mode-lines screen)


### PR DESCRIPTION
Xinerama has several drawbacks, including that it doesn't support
dynamic reconfiguration of monitors by default (e.g. the list of
numbers is random).

Using RandR API, we notably gain the ability to get the EDID of the
monitors, which means we'll be able to store where frames were between
monitors plugs and restore them when it makes sense, for example.

Given that older machines might not support RandR (it's fairly
"young"), Xinerama support is still left in the existing
implementation.

PS: I also sneak in a trailing whitespace removal, sorry :stuck_out_tongue: 