### PR TITLE
head: use normal counters for xrandr heads.

### DIFF
--- a/head.lisp
+++ b/head.lisp
@@ -43,18 +43,27 @@
         (timestamp config-timestamp crtcs outputs)
       (xlib:rr-get-screen-resources root)
     (declare (ignore timestamp config-timestamp crtcs))
-    (let ((heads))
+    (let ((heads)
+          (counter 0))
       (dolist (output outputs)
         (multiple-value-bind (request-status
                               config-timestamp
                               crtc
                               width
                               height
-                              status)
+                              status
+                              sub-pixel-order
+                              num-crtcs
+                              unknown
+                              num-modes
+                              num-clones
+                              name)
             (xlib:rr-get-output-info *display*
                                      output
                                      (get-universal-time))
-          (declare (ignore config-timestamp width height))
+          (declare (ignore config-timestamp width height
+                           sub-pixel-order num-crtcs unknown
+                           num-modes num-clones))
           (when (and (eq request-status :success)
                      (eq status :connected))
             (multiple-value-bind (request-status
@@ -69,16 +78,15 @@
               (declare (ignore config-timestamp))
               (when (eq request-status :success)
                 (push
-                 (make-head :number (xlib:rr-get-output-property
-                                     *display*
-                                     output
-                                     :EDID)
+                 (make-head :number counter
                             :x x
                             :y y
                             :width width
                             :height height
-                            :window nil)
-                 heads))))))
+                            :window nil
+                            :name name)
+                 heads)
+                (incf counter))))))
       heads)))
 
 (defun make-screen-heads (screen root)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -536,7 +536,8 @@ Use the window's resource name.
   height
   window)
 
-(defstruct (head (:include frame)))
+(defstruct (head (:include frame))
+  (name "" :type string))
 
 (defclass screen ()
   ((id :initarg :id :reader screen-id)


### PR DESCRIPTION
It turns out that the EDID property returned by CLX is not unique at
all.

To fix this bug, we fallback to the previous behavior of using a
simple counter to assign the head number.

That said, because it can be useful later on, a new NAME property is
added to the head struct. _That_ property is unique, but turning it
into a number requires hashing it, which we might want to avoid as a
first step. (So, right now, it is only useful for introspection purposes.)