### PR TITLE
Fixes for *new-head-hook*

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -106,9 +106,7 @@
          (dformat 1 "Updating Xrandr or Xinerama configuration for ~S.~%" screen)
          (if new-heads
              (progn (head-force-refresh screen new-heads)
-                    (update-mode-lines screen)
-                    (loop for new-head in new-heads
-                       do (run-hook-with-args *new-head-hook* new-head screen)))
+                    (update-mode-lines screen))
              (dformat 1 "Invalid configuration! ~S~%" new-heads)))))))
 
 (define-stump-event-handler :map-request (parent send-event-p window)

--- a/head.lisp
+++ b/head.lisp
@@ -190,7 +190,9 @@
 
 (defun head-force-refresh (screen new-heads)
   (scale-screen screen new-heads)
-  (mapc 'group-sync-all-heads (screen-groups screen)))
+  (mapc 'group-sync-all-heads (screen-groups screen))
+  (loop for new-head in new-heads
+     do (run-hook-with-args *new-head-hook* new-head screen)))
 
 (defcommand refresh-heads (&optional (screen (current-screen))) ()
   "Refresh screens in case a monitor was connected, but a

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -37,6 +37,7 @@
           *command-mode-end-hook*
           *urgent-window-hook*
           *new-window-hook*
+          *new-head-hook*
           *destroy-window-hook*
           *focus-window-hook*
           *place-window-hook*


### PR DESCRIPTION
The documented `*new-head-hook*` has a couple of issues:

- The first one, reported in #567, is that the hook is not exported, despite being present in the documentation.
- The second one is that it wouldn't run for a manual `refresh-heads` command, which is unfortunately needed quite often in my limited experience when plugging/unplugging monitors. Note that the proposed fix has a small BC break: the hook is now run before `(update-mode-lines)` instead of after.