### PR TITLE
Don't crash when error happens in *message-hook*

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -33,6 +33,7 @@
           *frame-indicator-text*
           *frame-indicator-timer*
           *message-window-timer*
+          *hooks-enabled-p*
           *command-mode-start-hook*
           *command-mode-end-hook*
           *urgent-window-hook*
@@ -684,16 +685,19 @@ chosen, resignal the error."
        ,@body)))
 
 ;;; Hook functionality
+(defvar *hooks-enabled-p* t
+  "Controls whether hooks will actually run or not")
 
 (defun run-hook-with-args (hook &rest args)
   "Call each function in HOOK and pass args to it."
-  (handler-case
-      (with-simple-restart (abort-hooks "Abort running the remaining hooks.")
-        (with-restarts-menu
+  (when *hooks-enabled-p*
+    (handler-case
+        (with-simple-restart (abort-hooks "Abort running the remaining hooks.")
+          (with-restarts-menu
             (dolist (fn hook)
               (with-simple-restart (continue-hooks "Continue running the remaining hooks.")
                 (apply fn args)))))
-    (t (c) (message "^B^1*Error on hook ^b~S^B!~% ^n~A" hook c) (values nil c))))
+      (t (c) (message "^B^1*Error on hook ^b~S^B!~% ^n~A" hook c) (values nil c)))))
 
 (defun run-hook (hook)
   "Call each function in HOOK."

--- a/user.lisp
+++ b/user.lisp
@@ -37,7 +37,8 @@
   "Display a menu with the active restarts and let the user pick
 one. Error is the error being recovered from. If the user aborts the
 menu, the error is re-signalled."
-  (let ((restart (select-from-menu (current-screen)
+  (let* ((*hooks-enabled-p* nil) ;;disable hooks to avoid deadlocks involving errors in *message-hook*
+         (restart (select-from-menu (current-screen)
                                    (mapcar (lambda (r)
                                              (list (format nil "[~a] ~a"
                                                            (restart-name r)


### PR DESCRIPTION
This PR addresses #343 

The code is simple enough. Add the ability for hooks to be disabled, and disable them when drawing a restarts menu.

This is not necessarily the final way to solve this issue. Perhaps there is a way to still run all the hooks and ensure stumpwm doesn't crash if an error occurs. I'm open to suggestions!