### PR TITLE
Make the mode-line faster and less intrusive.

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1293,7 +1293,11 @@ of :error."
   cc
   height
   factor
-  (mode :stump))
+  (mode :stump)
+
+  thread
+  lock
+  event)
 
 (defstruct timer
   time repeat function args)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1885,6 +1885,8 @@ color variables.
 ### *mode-line-foreground-color*
 ### *mode-line-border-color*
 ### *mode-line-timeout*
+### *mode-line-refresh-interval*
+### *mode-line-throttle-interval*
 
 @node Groups, Screens, Mode-line, Top
 @chapter Groups


### PR DESCRIPTION
Essentially, instead of redrawing the mode-line every time it is asked
to, a new thread is spawned for each mode-line, and that thread
redraws the mode-line every *mode-line-refresh-interval* (every 200ms
by default).

In practice, 200ms is not noticeable by the human eye. If you have
great eyes, it is very easy to reduce the interval.

Testing with this change, and the following mode-line:

```
(ql:quickload :local-time)

(defun get-date-modeline ()
  (local-time:format-timestring
   nil
   (local-time:now)
   :format '(:short-weekday #\space :short-month #\space
	     (:day 2 #\space) #\space (:hour 2) #\: (:min 2)
	     #\: (:sec 2))))

(setf *screen-mode-line-format*
      (list "^n^b %g ^n^b %W ^> "
            "  "
            "^n^b%B "
            '(:eval (get-date-modeline))))
```

I now have:

- The Slack web application no longer lags when scrolling. I believe
  it could solve the issue mentioned in #252 for a few people.
- The mode-line updates the time with the new second constantly.

I understand that this is a fairly consequential change, so I don't
expect that to be merged without discussion :-)

Also worth noting that the code in this PR takes special care in not breaking BC for the existing function signatures.