### PR TITLE
Don't update the modeline on mouse scroll events

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -589,18 +589,32 @@ the window in it's frame."
         (focus-all win)
         (update-all-mode-lines)))))
 
+(defun decode-button-code (code)
+  "Translate the mouse button number into a more readable format"
+  (ecase code
+    (1 :left-button)
+    (2 :middle-button)
+    (3 :right-button)
+    (4 :wheel-up)
+    (5 :wheel-down)
+    (6 :wheel-left)
+    (7 :wheel-right)
+    (8 :browser-back)
+    (9 :browser-front)))
+
 (define-stump-event-handler :button-press (window code x y child time)
-  (let ((screen (find-screen window))
+  (let ((button (decode-button-code code))
+        (screen (find-screen window))
         (mode-line (find-mode-line-by-window window))
         (win (find-window-by-parent window (top-windows))))
     (cond
       ((and screen (not child))
-       (group-button-press (screen-current-group screen) x y :root)
+       (group-button-press (screen-current-group screen) button x y :root)
        (run-hook-with-args *root-click-hook* screen code x y))
       (mode-line
        (run-hook-with-args *mode-line-click-hook* mode-line code x y))
       (win
-       (group-button-press (window-group win) x y win))))
+       (group-button-press (window-group win) button x y win))))
   ;; Pass click to client
   (xlib:allow-events *display* :replay-pointer time))
 

--- a/events.lisp
+++ b/events.lisp
@@ -602,6 +602,11 @@ the window in it's frame."
     (8 :browser-back)
     (9 :browser-front)))
 
+(defun scroll-button-keyword-p (button)
+  "Checks if button keyword is generated from the scroll wheel."
+  (or (eq button :wheel-down) (eq button :wheel-up)
+      (eq button :wheel-left) (eq button :wheel-right)))
+
 (define-stump-event-handler :button-press (window code x y child time)
   (let ((button (decode-button-code code))
         (screen (find-screen window))

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -262,7 +262,8 @@
     (when (and horizontal vertical)
       (float-window-move-resize window :x hx :y hy))))
 
-(defmethod group-button-press (group x y (window float-window))
+(defmethod group-button-press (group button x y (window float-window))
+  (declare (ignore button))
   (let ((screen (group-screen group))
         (initial-width (xlib:drawable-width (window-parent window)))
         (initial-height (xlib:drawable-height (window-parent window)))
@@ -356,8 +357,8 @@
 
       )))
 
-(defmethod group-button-press ((group float-group) x y where)
-  (declare (ignore x y where))
+(defmethod group-button-press ((group float-group) button x y where)
+  (declare (ignore button x y where))
   (when (next-method-p)
     (call-next-method)))
 

--- a/group.lisp
+++ b/group.lisp
@@ -81,7 +81,7 @@ about it."))
   (:documentation "The group is asked to in some way show the user where the keyboard focus is."))
 (defgeneric group-focus-window (group win)
   (:documentation "The group is asked to focus the specified window wherever it is."))
-(defgeneric group-button-press (group x y child)
+(defgeneric group-button-press (group button x y child)
   (:documentation "The user clicked somewhere in the group."))
 (defgeneric group-root-exposure (group)
   (:documentation "The root window got an exposure event. If the group

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -141,14 +141,14 @@
 (defmethod group-focus-window ((group tile-group) (window float-window))
   (focus-window window))
 
-(defmethod group-button-press ((group tile-group) x y (where (eql :root)))
+(defmethod group-button-press ((group tile-group) button x y (where (eql :root)))
   (when *root-click-focuses-frame*
     (when-let ((frame (find-frame group x y)))
       (focus-frame group frame)
       (unless (eq *mouse-focus-policy* :click)
         (update-all-mode-lines)))))
 
-(defmethod group-button-press ((group tile-group) x y (where window))
+(defmethod group-button-press ((group tile-group) button x y (where window))
   (declare (ignore x y))
   (when (typep where 'float-window)
     (call-next-method))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -145,7 +145,8 @@
   (when *root-click-focuses-frame*
     (when-let ((frame (find-frame group x y)))
       (focus-frame group frame)
-      (unless (eq *mouse-focus-policy* :click)
+      (unless (or (eq *mouse-focus-policy* :click)
+                  (scroll-button-keyword-p button))
         (update-all-mode-lines)))))
 
 (defmethod group-button-press ((group tile-group) button x y (where window))
@@ -154,7 +155,8 @@
     (call-next-method))
   (when (eq *mouse-focus-policy* :click)
     (focus-all where)
-    (update-all-mode-lines)))
+    (unless (scroll-button-keyword-p button)
+      (update-all-mode-lines))))
 
 (defmethod group-root-exposure ((group tile-group))
   (show-frame-outline group nil))


### PR DESCRIPTION
I don't have any lag on my system to actually check if this fixes #252, but I can confirm that the modeline no longer updates on each scroll event. Even if we go with the solution written by @ralt in #577, the first commit in this series should probably stick around.  