### PR TITLE
Improve search of modifier keys in get-modifier-map

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -763,7 +763,9 @@ input (pressing Return), nil otherwise."
 
 (defun get-modifier-map ()
   (labels ((find-mod (mod codes)
-             (find (xlib:keysym->keycodes *display* (keysym-name->keysym mod)) codes)))
+             (let* ((keysym (keysym-name->keysym mod))
+                    (keycodes (multiple-value-list (xlib:keysym->keycodes *display* keysym))))
+               (intersection keycodes codes))))
     (let ((modifiers (make-modifiers)))
       (multiple-value-bind
             (shift-codes lock-codes control-codes mod1-codes mod2-codes mod3-codes mod4-codes mod5-codes)


### PR DESCRIPTION
This patch allows detecting that ```ISO_Level3_Shift``` is ```mod5``` on my machine.

I needed another modification to make the AltGr-key combinations return the right symbols: replacing ```(base (if altgr-p 2 0))``` by ```(base (if altgr-p 4 0))``` in the ```code-state->key``` function.
However I didn't put it in this pull request, as I have no idea if 4 is the right value for all mappings or if there is a way to detect/compute what the right value for ```base``` is.

For information, I'm running XFCE 4 as desktop manager with stumpwm instead of xfwm4 as window manager, with a french keyboard layout.
