### PR TITLE
Constantly fold key translations when possible

### DIFF
--- a/keysyms.lisp
+++ b/keysyms.lisp
@@ -34,14 +34,14 @@
   (setf (gethash keysym *keysym-name-translations*) name
         (gethash name *name-keysym-translations*) keysym))
 
-(defun keysym-name->keysym (name)
+(define-foldable keysym-name->keysym (name)
   "Return the keysym corresponding to NAME."
   (multiple-value-bind (value present-p)
       (gethash name *name-keysym-translations*)
     (declare (ignore present-p))
     value))
 
-(defun keysym->keysym-name (keysym)
+(define-foldable keysym->keysym-name (keysym)
   "Return the name corresponding to KEYSYM."
   (multiple-value-bind (value present-p)
       (gethash keysym *keysym-name-translations*)

--- a/keytrans.lisp
+++ b/keytrans.lisp
@@ -46,14 +46,14 @@ names."
                (return-from keysym-name->stumpwm-name k)))
            *stumpwm-name->keysym-name-translations*))
 
-(defun stumpwm-name->keysym (stumpwm-name)
+(define-foldable stumpwm-name->keysym (stumpwm-name)
   "Return the keysym corresponding to STUMPWM-NAME.
 If no mapping for STUMPWM-NAME exists, then fallback by calling
 KEYSYM-NAME->KEYSYM."
   (let ((keysym-name (stumpwm-name->keysym-name stumpwm-name)))
     (keysym-name->keysym (or keysym-name stumpwm-name))))
 
-(defun keysym->stumpwm-name (keysym)
+(define-foldable keysym->stumpwm-name (keysym)
   "Return the stumpwm key name corresponding to KEYSYM.
 If no mapping for the stumpwm key name exists, then fall back by
 calling KEYSYM->KEYSYM-NAME."

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1308,10 +1308,10 @@ of :error."
 
 (defmacro define-foldable (func-name (arg) &body body)
   (multiple-value-bind (body decls docstring) (parse-body body :documentation t)
-    ;; use prog1 so it looks like we are just calling (defun ...)
-    `(prog1
+    `(progn
        (defun ,func-name (,arg)
-         ,docstring
+         ,@(when docstring
+             (list docstring))
          ,@decls
          ,@body)
        (define-compiler-macro ,func-name (&whole original name)


### PR DESCRIPTION
Translate keysyms into the desired form when the original value is known at compile time. This assumes that the translations won't change at runtime, which should be the case. 

If a value isn't found in the appropriate table, then the code isn't transformed. This is done silently, although a  `STYLE-WARNING` could be emitted.

Frankly, there isn't much reason to add this, as in stumpwm itself, we only pass constant arguments to the affected functions twice, both in 'window-send-string`. A constant is also used once in the Logitech keyboard contrib module. The speedup is tiny, and no one will notice this change unless something goes wrong. That being said, the code exists and it works, so there isn't much of a reason *not* to include it.