### PR TITLE
Focus on click with sloppy mouse focus policy

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -153,7 +153,7 @@
   (declare (ignore x y))
   (when (typep where 'float-window)
     (call-next-method))
-  (when (eq *mouse-focus-policy* :click)
+  (when (member *mouse-focus-policy* '(:click :sloppy))
     (focus-all where)
     (unless (scroll-button-keyword-p button)
       (update-all-mode-lines))))


### PR DESCRIPTION
Closes #600.
Also relevant is #597.

This reduces the number of surprising focus situations, especially for new users, and I don't think there's much of a use for the old behavior.