### PR TITLE
Add keysym for XF86RFKill

### DIFF
--- a/keysyms.lisp
+++ b/keysyms.lisp
@@ -2068,6 +2068,7 @@
 (define-keysym #x1008FFB0 "XF86TouchpadOn")
 (define-keysym #x1008FFB1 "XF86TouchpadOff")
 (define-keysym #x1008FFB2 "XF86AudioMicMute")
+(define-keysym #x1008FFB5 "XF86RFKill")
 (define-keysym #x1008FE01 "XF86_Switch_VT_1")
 (define-keysym #x1008FE02 "XF86_Switch_VT_2")
 (define-keysym #x1008FE03 "XF86_Switch_VT_3")


### PR DESCRIPTION
Hello, I noticed that my laptop has a key that was not defined by StumpWM.  I found its name (`XF86RFKill`) and keysym with `xev`.

I thought that it is probably not the only key missing in stumpwm, so I tried to find keysyms of other keys, but I quickly gave up.  All these keysyms and keycodes is a black magic for me.  The only source of `XF86RFKill` key I could find is:

https://cgit.freedesktop.org/xkeyboard-config/commit/?id=39927132729bcd8569716f4ccd3a2e3eadfaf186

And I have no idea how it relates to the hexadecimal keysym value I got from `xev` :blush:

Anyway, I hope adding just one new key is better then nothing.
