### PR TITLE
Fix :configuration-notify event

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -341,8 +341,10 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
   ;; Send a synthetic configure-notify event so that the window
   ;; knows where it is onscreen.
   (xwin-send-configuration-notify (window-xwin win)
-                                  (xlib:drawable-x (window-parent win))
-                                  (xlib:drawable-y (window-parent win))
+                                  (+ (xlib:drawable-x (window-parent win))
+                                     (xlib:drawable-x (window-xwin win)))
+                                  (+ (xlib:drawable-y (window-parent win))
+                                     (xlib:drawable-y (window-xwin win)))
                                   (window-width win) (window-height win) 0))
 
 ;; FIXME: should we raise the window or its parent?


### PR DESCRIPTION
Before this commit stumpwm send a :configuration-notify event to the
managed xwindow that doesn't take in account the border of the
xwindow, but only the position of the parent xwindow.

This is particular important for float windows where the border is not
zero by default and there is a high top border for title.

This fix issue #613 