### PR TITLE
introduce toggle for remapped-keys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,3 +72,4 @@ Ram Krishnan        kriyative at gmail.com
 Herbert Jones       jones dot herbert at gmail.com
 Daniel Oliveira     drdo at drdo.eu
 Panji Kusuma        epanji at gmail dot com
+Andrin Bertschi     hi at abertschi dot ch

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -28,7 +28,9 @@
 (export '(define-remapped-keys remap-keys-enable))
  
 (defvar *remap-keys-window-match-list* nil)
-(defvar *remap-keys-enable* t)
+
+(defvar *remap-keys-enable* t
+  "Toggle remap-keys on/off ")
 
 (defun find-remap-keys-by-window (window)
   (first

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -25,9 +25,10 @@
 
 (in-package #:stumpwm)
 
-(export '(define-remapped-keys))
-
+(export '(define-remapped-keys remap-keys-enable))
+ 
 (defvar *remap-keys-window-match-list* nil)
+(defvar *remap-keys-enable* t)
 
 (defun find-remap-keys-by-window (window)
   (first
@@ -73,7 +74,9 @@
          (keys (cdr (assoc (print-key raw-key) keymap :test 'equal))))
     (when keys
       (dolist (key keys)
-        (send-fake-key window key))
+        (if (eq *remap-keys-enable* t)
+            (send-fake-key window key)
+            (send-fake-key window raw-key)))
       t)))
 
 (defun define-remapped-keys (specs)

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -25,12 +25,12 @@
 
 (in-package #:stumpwm)
 
-(export '(define-remapped-keys *remap-keys-enable*))
- 
+(export '(define-remapped-keys *remapped-keys-enabled-p*))
+
 (defvar *remap-keys-window-match-list* nil)
 
-(defvar *remap-keys-enable* t
-  "Toggle remap-keys on/off ")
+(defvar *remapped-keys-enabled-p* t
+  "Bool to toggle remapped-keys on/off ")
 
 (defun find-remap-keys-by-window (window)
   (first
@@ -76,9 +76,9 @@
          (keys (cdr (assoc (print-key raw-key) keymap :test 'equal))))
     (when keys
       (dolist (key keys)
-        (if (eq *remap-keys-enable* t)
-            (send-fake-key window key)
-            (send-fake-key window raw-key)))
+        (send-fake-key window (if *remapped-keys-enabled-p*
+                                  key
+                                  raw-key)))
       t)))
 
 (defun define-remapped-keys (specs)

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -30,7 +30,7 @@
 (defvar *remap-keys-window-match-list* nil)
 
 (defvar *remapped-keys-enabled-p* t
-  "Bool to toggle remapped-keys on/off ")
+  "Bool to toggle remapped-keys on/off. Defaults to t ")
 
 (defun find-remap-keys-by-window (window)
   (first

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -25,7 +25,7 @@
 
 (in-package #:stumpwm)
 
-(export '(define-remapped-keys remap-keys-enable))
+(export '(define-remapped-keys *remap-keys-enable*))
  
 (defvar *remap-keys-window-match-list* nil)
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1102,9 +1102,13 @@ would prompt asking for ``Press a key to send''. Pressing @kbd{C-n} at
 the prompt will send the keystroke as-is to Firefox, causing it to
 open a new window.
 
-### *remapped-keys-enabled-p*
+If more than a single key needs to be passed to the application as-is,
+the variable @var{*remapped-keys-enabled-p*} may be used.
+Set to nil it will disable all remapped keys.
 
 !!! send-raw-key
+
+### *remapped-keys-enabled-p*
 
 @node Commands, Message and Input Bar, Key Bindings, Top
 @chapter Commands

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1102,6 +1102,8 @@ would prompt asking for ``Press a key to send''. Pressing @kbd{C-n} at
 the prompt will send the keystroke as-is to Firefox, causing it to
 open a new window.
 
+### *remapped-keys-enabled-p*
+
 !!! send-raw-key
 
 @node Commands, Message and Input Bar, Key Bindings, Top


### PR DESCRIPTION
As a former EXWM user I really appreciated the feature to disable
remapping of keys temporarily. As far as I know stumpwm provides
`send-raw-key` to temporarily ignore remapping for a single key.

This pull request introduces a toggle behavior to temporarily disable
remapped-keys for more than a single key

## Usecase

```lisp
  (defun remap-keys-allow (win)
    (every (lambda(w) (string-not-equal w (window-class win)))
           '(list "jetbrains-idea"
             "Emacs"
             "jetbrains-pycharm"
             "jetbrains-studio"
             "android-studio2")))

  (define-remapped-keys
      `((,(lambda (win) (remap-keys-allow win))
          ("C-a"   . "Home")
          ("C-e"   . "End")
          ("C-n"   . "Down")
          ("C-p"   . "Up")
          ("C-f"   . "Right")
          ("C-b"   . "Left")
          ("M-b"   . "C-Left")
          ("M-f"   . "C-Right")
          ("M-v"   . "Prior") 
          ("M-w"   . "C-c")
          ("C-w"   . "C-x")
          ("C-y"   . "C-v")
          ("C-_"   . "C-z")
          ("M-<"   . "C-Home")
          ("M->"   . "C-End")
          ("C-M-b" . "M-Left")
          ("C-M-f" . "M-Right")
          ("C-k"   . ("S-End" "C-x"))
          ("M-a"   . ("C-Home" "C-S-End"))
          ("M-k"   . "C-k")
          ("C-d"   . "Delete"))))

  (defcommand toggle-remapped-keys () ()
              (if (eq *remap-keys-enable* t)
                  (progn
                    (setq *remap-keys-enable* nil)
                    (message "disable remapped-keys"))
                  (progn
                    (setq *remap-keys-enable* t)
                    (message "enable remapped-keys"))))

  (define-key *top-map* (kbd "s-i") "toggle-remapped-keys")

```

What do you think about this? Thanks for your awesome project :)