### PR TITLE
Update group-raised-window properly in geometry-hints (fixes #632) 

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -119,7 +119,8 @@ than the root window's width and height."
                y (frame-y head)
                width (frame-width head)
                height (frame-height head)
-               (xlib:window-priority (window-parent win)) :above))
+               (xlib:window-priority (window-parent win)) :above
+               (group-raised-window (window-group win)) win))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -114,12 +114,16 @@ than the root window's width and height."
     (cond
       ;; handle specially fullscreen windows.
       ((window-fullscreen win)
-       (let ((head (frame-head (window-group win) f)))
+       (let* ((win-group (window-group win))
+              (head (frame-head win-group f)))
          (setf x (frame-x head)
                y (frame-y head)
                width (frame-width head)
                height (frame-height head)
-               (xlib:window-priority (window-parent win)) :above
+               (xlib:window-priority
+                (window-parent win)
+                (window-parent
+                 (group-raised-window win-group))) :above
                (group-raised-window (window-group win)) win))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.


### PR DESCRIPTION
The reason the issue occurs is because `geometry-hints` raises fullscreen windows manually rather than using `raise-window`, so the `group-raised-window` never got updated, which then confuses `raise-window`, as it raises windows to the "top" by placing them above a window which isn't actually the top window. These commits make `geometry-hints` behave similarly to `raise-window`, in that it updates `group-raised-window` and raises the fullscreen window above the old `group-raised-window` rather than to the top of the window stack.