### PR TITLE
Improve default font selection

### DIFF
--- a/screen.lisp
+++ b/screen.lisp
@@ -399,9 +399,12 @@ FOCUS-WINDOW is an extra window used for _NET_SUPPORTING_WM_CHECK."
            (float-focus-color (ac +default-float-focus-color+))
            (float-unfocus-color (ac +default-float-unfocus-color+))
            (font (open-font *display*
-                            (if (font-exists-p +default-font-name+)
-                                +default-font-name+
-                                "*")))
+                            (cond ((font-exists-p +default-font-name+)
+                                   +default-font-name+)
+                                  ((font-exists-p "fixed")
+                                   "fixed")
+                                  (t
+                                   "*"))))
            (message-window (xlib:create-window :parent screen-root
                                                :x 0 :y 0 :width 1 :height 1
                                                :colormap default-colormap


### PR DESCRIPTION
The default font is set to be `9x15`. If that font can't be found, StumpWM gets a list of all fonts and picks the first one. Choosing the fist font is rarely the right thing to do, and a better default is to use `fixed`.

This change updates StumpWM to choose `fixed` in this case, and only reverts back to the first available font if it `fixed` cannot be found (which should be a very unlikely scenario).