### PR TITLE
Minor cleanups

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -288,8 +288,8 @@ ratpoison sends the rp_command_request window in 8 byte chunks."
   "Handle a StumpWM style command request."
   (let* ((win root)
          (screen (find-screen root))
-         (data (xlib:get-property win :stumpwm_command :delete-p t))
-         (cmd (bytes-to-string data)))
+         (data (xlib:get-property win :stumpwm_command :delete-p t :result-type '(vector (unsigned-byte 8))))
+         (cmd (utf8-to-string data)))
     (let ((msgs (screen-last-msg screen))
           (hlts (screen-last-msg-highlights screen))
           (*executing-stumpwm-command* t))

--- a/user.lisp
+++ b/user.lisp
@@ -388,7 +388,7 @@ like xprop."
                     (:atom (format nil "~{~a~^, ~}"
                                    (mapcar (lambda (v) (xlib:atom-name *display* v)) values)))
                     (:string (format nil "~{~s~^, ~}"
-                                     (mapcar (lambda (x) (coerce (mapcar 'xlib:card8->char x) 'string))
+                                     (mapcar (lambda (x) (map 'string 'xlib:card8->char x))
                                              (split-seq values '(0)))))
                     (:utf8_string (format nil "~{~s~^, ~}"
                                           (mapcar 'utf8-to-string

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -99,7 +99,7 @@
     (handler-bind
         ((sb-impl::octet-decoding-error #'(lambda (c)
                                             (declare (ignore c))
-                                            (invoke-restart 'use-value "?"))))
+                                            (invoke-restart 'use-value (string #\replacement_character)))))
       (sb-ext:octets-to-string octets :external-format :utf-8))))
 
 (defun directory-no-deref (pathspec)

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -93,15 +93,6 @@
   "print a backtrace of FRAMES number of frames to standard-output"
   (sb-debug:print-backtrace :count frames :stream *standard-output*))
 
-(defun bytes-to-string (data)
-  "Convert a list of bytes into a string."
-  (handler-bind
-      ((sb-impl::octet-decoding-error #'(lambda (c)
-                                          (declare (ignore c))
-                                          (invoke-restart 'use-value "?"))))
-    (sb-ext:octets-to-string
-     (make-array (length data) :element-type '(unsigned-byte 8) :initial-contents data))))
-
 (defun utf8-to-string (octets)
   "Convert the list of octets to a string."
   (let ((octets (coerce octets '(vector (unsigned-byte 8)))))


### PR DESCRIPTION
This is a first step towards avoiding the coercion at the beginning of `utf8-to-string`.