### PR TITLE
Regrab remapped keys when syncing keys

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -783,6 +783,8 @@ and bottom_end_x."
         do (loop for j in (screen-mapped-windows i)
                  do (xwin-grab-keys j (window-group (find-window j))))
         do (xwin-grab-keys (screen-focus-window i) (screen-current-group i)))
+  (when (current-window)
+    (remap-keys-grab-keys (current-window)))
   (xlib:display-finish-output *display*))
 
 (defun netwm-remove-window (window)


### PR DESCRIPTION
The remap-keys functionality allows separate key mappings for different
windows by regrabbing the keys in a focus-window-hook every time the
window focus changes:

https://github.com/stumpwm/stumpwm/blob/5e1abc5c6ab4db051c058f83487b72b385814707/remap-keys.lisp#L66-L69

Separately: when a :mapping-notify event arrives, all key mappings are
resynced with sync-keys, which ungrabs everything and regrabs the keys
Stump cares about:

https://github.com/stumpwm/stumpwm/blob/5e1abc5c6ab4db051c058f83487b72b385814707/events.lisp#L380-L385

This means that if a :mapping-notify event arrives, any keys remapped
with remap-keys will no longer work until you unfocus and refocus the
window, which is annoying.  This patch makes sync-keys also run
remap-keys-grab-keys to restore those mappings.

The reason I ran into this bug was because I use [xcape][] to remap some
keys, and when I use those keys xcape generates the :mapping-notify
events (I'm not 100% sure why).  So as soon as I used any xcape-mapped
key it would kill my Stump remapped keys until I refocused the window.

[xcape]: https://github.com/alols/xcape