### PR TITLE
FRAME-RAISE-WINDOW with W as NIL HIDE-WINDOW in their access order

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -338,7 +338,8 @@ T (default) then also focus the frame."
     (unless (and w (eq oldw w))
       (if w
           (raise-window w)
-          (mapc 'hide-window (frame-windows g f))))
+          (mapc 'hide-window
+                (reverse (frame-windows g f)))))
     ;; If raising a window in the current frame we must focus it or
     ;; the group and screen will get out of sync.
     (when (or focus


### PR DESCRIPTION
Presently FRAME-RAISE-WINDOW with W as NIL is hiding FRAME-WINDOW's in wrong
order where active focused window hidden first then its previous and so on which
put active focused window in between, rather than on head So after running
FCLEAR when PULL-OTHER-HIDDEN-WINDOW called it is not pull last active focused
window.