### PR TITLE
Fix export selection as utf8

### DIFF
--- a/selection.lisp
+++ b/selection.lisp
@@ -39,7 +39,7 @@
     (xlib:change-property root
                           :cut-buffer0
                           (sb-ext:string-to-octets
-                           (getf *x-selection* :clipboard)
+                           (getf *x-selection* selection)
                            :external-format :utf-8)
                           :utf8_string 8
                           :mode :replace)))

--- a/selection.lisp
+++ b/selection.lisp
@@ -36,9 +36,13 @@
       (error "Can't set selection owner"))
     ;; also set the cut buffer for completeness. Note that this always sets cut
     ;; buffer 0.
-    (xlib:change-property root :cut-buffer0 (getf *x-selection* selection)
-                               :string 8 :transform #'xlib:char->card8
-                               :mode :replace)))
+    (xlib:change-property root
+                          :cut-buffer0
+                          (sb-ext:string-to-octets
+                           (getf *x-selection* :clipboard)
+                           :external-format :utf-8)
+                          :utf8_string 8
+                          :mode :replace)))
 
 (defun set-x-selection (text &optional (selection :primary))
   "Set the X11 selection string to @var{string}."


### PR DESCRIPTION
This PR fixes an issue where StumpWM tries exporting X selection text with extended characters as simple strings, which causes CLX to raise an exception. The fix is to canonicalize selection text into UTF8 octets before exporting.

Related to issue #656 