### PR TITLE
place window in closest frame when unfloating

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1358,7 +1358,7 @@ frame, then returns the frame with the shortest distance. "
       (cdr shortest))))
 
 (defun unfloat-window (window group)
-  (let ((frame (calculate-appropriate-frame-for-window window)))
+  (let ((frame (calculate-appropriate-frame-for-window window group)))
     (change-class window 'tile-window :frame frame)
     (setf (window-frame window) frame
           (frame-window frame) window


### PR DESCRIPTION
changes unfloat-window to utilize the new function calculate-appropriate-frame-for-window, which returns the frame closest to the window sent in. also adds two helper functions: calculate-window-centerpoint and calculate-frame-centerpoint.

This modifies the current behaviore of unfloat-window, which currently places an unfloated window into the first frame of the group.