### PR TITLE
Make describe-key show more helpful information

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,3 +73,4 @@ Herbert Jones       jones dot herbert at gmail.com
 Daniel Oliveira     drdo at drdo.eu
 Panji Kusuma        epanji at gmail dot com
 Andrin Bertschi     hi at abertschi dot ch
+Spenser Max Truex   web ate spensertruex.com

--- a/help.lisp
+++ b/help.lisp
@@ -70,6 +70,18 @@
     (message-no-timeout "~{~a~^~%~}"
                         (columnize data cols))))
 
+(defun final-key-p (keys class)
+  "Determine if the key is a memeber of a class"
+  (member (lastcar keys) (mapcar #'parse-key class) :test #'equalp))
+
+(defun help-key-p (keys)
+  "If the key is for the help command."
+  (final-key-p keys '("?" "C-h")))
+
+(defun cancel-key-p (keys)
+  "If a key is the cancelling key binding."
+  (final-key-p keys '("C-g")))
+
 (defcommand describe-key (keys) ((:key-seq "Describe Key: "))
   "Either interactively type the key sequence or supply it as text. This
   command prints the command bound to the specified key sequence."
@@ -77,8 +89,15 @@
                       for cmd = (lookup-key-sequence map keys)
                       when cmd return cmd))
            (printed-key (mapcar 'print-key keys)))
-    (message "~{~A~^ ~} is bound to \"~A\"." printed-key cmd)
-    (message "~{~A~^ ~} is not bound." printed-key)))
+    (progn (message "~{~A~^ ~} is bound to \"~A\".~%~A"
+                    printed-key cmd (describe-command-string cmd)))
+    (cond ((and (help-key-p keys)
+                (cdr printed-key))
+           (message "~{~A~^ ~} shows the bindings for the prefix map under ~{~A~^ ~}."
+                    printed-key (butlast printed-key)))
+          ((cancel-key-p keys)
+           (message "Any command ending in ~A is meant to cancel any command in progress \"ABORT\"." (lastcar printed-key)))
+          (t (message "~{~A~^ ~} is not bound." printed-key)))))
 
 (defcommand describe-variable (var) ((:variable "Describe Variable: "))
 "Print the online help associated with the specified variable."

--- a/help.lisp
+++ b/help.lisp
@@ -106,7 +106,7 @@
                       for cmd = (lookup-key-sequence map keys)
                       when cmd return cmd))
            (printed-key (mapcar 'print-key keys)))
-    (describe-command-to-stream cmd nil)
+    (message-no-timeout (describe-command-to-stream cmd nil))
     (cond ((and (help-key-p keys)
                 (cdr printed-key))
            (message "~{~A~^ ~} shows the bindings for the prefix map under ~{~A~^ ~}.~%"
@@ -151,13 +151,10 @@
 
 (defcommand describe-command (com) ((:command "Describe Command: "))
   "Print the online help associated with the specified command."
-  (let ((*suppress-echo-timeout* t))
-    (echo-string
-     (current-screen)
-     (if (null (get-command-structure com nil))
-         (format nil "Error: Command \"~a\" not found."
-                 (command-name com))
-         (describe-command-to-stream com nil)))))
+  (if (null (get-command-structure com nil))
+      (message-no-timeout "Error: Command \"~a\" not found."
+                          (command-name com))
+      (message-no-timeout "~a" (describe-command-to-stream com nil))))
 
 (defun where-is-to-stream (cmd stream)
   (let ((cmd (string-downcase cmd)))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -15,7 +15,8 @@
   :depends-on (#:alexandria
                #:cl-ppcre
                #:clx
-               #:sb-posix)
+               #:sb-posix
+               #:sb-introspect)
   :components ((:file "package")
                (:file "primitives")
                (:file "wrappers")

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -890,6 +890,10 @@ Describe the specified command.
 @@@ ungrab-pointer
 ### *banish-pointer-to*
 
+@@@ final-key-p
+@@@ help-key-p
+@@@ cancel-key-p
+
 @node Modifiers, Remapped Keys, Binding Keys, Key Bindings
 @section Modifiers
 
@@ -1423,6 +1427,8 @@ return a ``nil'' value in those cases, and let the command handle that.
 ### *suppress-echo-timeout*
 !!! echo
 @@@ err
+@@@ wrap
+### *message-max-width*
 !!! colon
 
 


### PR DESCRIPTION
Try: C-t h k C-i ? which will pop out: 
"? shows the bindings for the prefix map under C-t."

Previously describing a key would only show what command it ran, but now it provides the docstring also:
https://drive.google.com/file/d/1ibdQmd2BXBThWqPAhh_-SXNc5AjHo-rQ/view
