### PR TITLE
Documentation: Miscellaneous items, Advanced Configuration.

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -148,7 +148,7 @@ out, an element can just be the argument type."
                              :args ',interactive-args))))))
 
 (defmacro define-stumpwm-command (name (&rest args) &body body)
-  "Deprecated. use `defcommand' instead."
+  "Deprecated. Use `defcommand' instead."
   (check-type name string)
   (setf name (intern1 name))
   `(progn

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1436,6 +1436,8 @@ return a ``nil'' value in those cases, and let the command handle that.
 @node Common Built-in Commands, , Writing Commands, Commands
 @section Common Built-in Commands
 
+!!! emacs
+!!! version
 !!! banish
 !!! ratwarp
 !!! ratrelwarp
@@ -1445,14 +1447,15 @@ return a ``nil'' value in those cases, and let the command handle that.
 !!! lastmsg
 !!! commands
 !!! keyboard-quit
-!!! reload
 !!! quit
+!!! reload
 !!! echo-date
 !!! eval-line
 !!! command-mode
 !!! list-window-properties
 !!! show-window-properties
 !!! time
+
 @node Message and Input Bar, Windows, Commands, Top
 @chapter Message and Input Bar
 
@@ -2137,6 +2140,7 @@ multiplexer to actually run it.
 !!! getsel
 !!! putsel
 !!! copy-unhandled-error
+@@@ define-stumpwm-command
 
 @node Interacting With Unix, Interacting With X11, Screens, Top
 @chapter Interacting With Unix

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -252,6 +252,8 @@ message pop up in the upper, right corner. At this point, you have
 successfully started StumpWM.
 @end enumerate
 
+@@@ stumpwm
+
 @node Basic Usage, Basic Concepts, Starting StumpWM, Introduction
 @section Basic Usage
 Once you have StumpWM up and running, the first thing you might want
@@ -1284,7 +1286,7 @@ and @code{*baz*} are true.
 %%% define-interactive-keymap
 !!! call-and-exit-kmap
 
-@node StumpWM Types,  , Writing Commands, Commands
+@node StumpWM Types, , Writing Commands, Commands
 @section StumpWM Types
 All command arguments must be of a defined ``StumpWM type''. The
 following types are pre-defined:
@@ -1626,6 +1628,7 @@ An input function takes 2 arguments: the input structure and the key pressed.
 @@@ window-head
 @@@ window-sync
 @@@ window-visible-p
+@@@ raise-window
 
 ### *xwin-to-window*
 ### *window-format*
@@ -1796,6 +1799,8 @@ window pool, where windows and frames are not so tightly connected.
 !!! echo-frame-windows
 !!! exchange-direction
 !!! expose
+
+@@@ run-or-pull
 
 ### *min-frame-width*
 ### *min-frame-height*
@@ -1982,6 +1987,8 @@ Groups in StumpWM are more commonly known as @dfn{virtual desktops} or
 @@@ group-sync-head
 @@@ group-wake-up
 
+@@@ really-raise-window
+### *run-or-raise-all-groups*
 
 @menu
 * Customizing Groups::
@@ -2002,6 +2009,9 @@ StumpWM handles multiple screens.
 !!! snext
 !!! sprev
 !!! sother
+
+
+### *run-or-raise-all-screens*
 
 @menu
 * External Monitors::
@@ -2038,9 +2048,10 @@ the head configuration.
 @chapter Internals
 @menu
 * IO Loop::
+* Internal Functions Documentation::
 @end menu
 
-@node IO Loop, , , Internals
+@node IO Loop, Internal Functions Documentation, , Internals
 @section IO Loop
 
 StumpWM's internal loop is implemented by a generic multiplexing I/O
@@ -2101,6 +2112,16 @@ multiplexer to actually run it.
 @@@ io-loop-update
 @@@ io-loop
 
+@node Internal Functions Documentation, , IO Loop, Internals
+@section Internal Functions Documentation
+
+### *executing-stumpwm-command*
+### *suppress-abort-messages*
+!!! refresh-time-zone
+!!! getsel
+!!! putsel
+!!! copy-unhandled-error
+
 @node Interacting With Unix, Interacting With X11, Screens, Top
 @chapter Interacting With Unix
 
@@ -2110,6 +2131,8 @@ multiplexer to actually run it.
 @@@ pathname-is-executable-p
 @@@ pathname-as-directory
 
+
+@@@ run-or-raise
 ### *shell-program*
 
 @@@ getenv
@@ -2127,12 +2150,8 @@ multiplexer to actually run it.
 The following is a list of commands that don't really fit in any other
 section.
 
-!!! refresh-time-zone
 !!! window-send-string
 !!! loadrc
-!!! getsel
-!!! putsel
-!!! copy-unhandled-error
 @@@ argument-line-end-p
 @@@ argument-pop
 @@@ argument-pop-rest
@@ -2164,7 +2183,6 @@ section.
 %%% save-frame-excursion
 @@@ set-module-dir
 @@@ split-string
-@@@ stumpwm
 ### *suppress-frame-indicator*
 ### *suppress-window-placement-indicator*
 ### *text-color*
@@ -2174,22 +2192,9 @@ section.
 @@@ update-decoration
 
 
-### *executing-stumpwm-command*
-
-@@@ run-or-raise
-@@@ raise-window
-@@@ really-raise-window
-
-@@@ run-or-pull
-
-### *run-or-raise-all-groups*
-### *run-or-raise-all-screens*
-
 @@@ restarts-menu
 
 %%% with-restarts-menu
-
-### *suppress-abort-messages*
 @menu
 * Menus::
 * StumpWM's Data Directory::

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -885,6 +885,7 @@ Describe the specified command.
 ### *root-map*
 ### *top-map*
 ### *groups-map*
+### *group-top-maps*
 ### *exchange-window-map*
 
 !!! bind
@@ -2140,7 +2141,9 @@ multiplexer to actually run it.
 !!! getsel
 !!! putsel
 !!! copy-unhandled-error
+@@@ read-line-from-sysfs
 @@@ define-stumpwm-command
+!!! set-contrib-dir
 
 @node Interacting With Unix, Interacting With X11, Screens, Top
 @chapter Interacting With Unix
@@ -2533,6 +2536,8 @@ $$$ *new-frame-hook*
 $$$ *message-hook*
 $$$ *top-level-error-hook*
 $$$ *focus-group-hook*
+$$$ *hooks-enabled-p*
+$$$ *remove-split-hook*
 $$$ *key-press-hook*
 $$$ *root-click-hook*
 $$$ *click-hook*
@@ -2945,9 +2950,11 @@ sending them as one.
 @node Advanced Configuration, Command and Function Index, Hacking, Top
 @chapter Advanced Configuration
 
+### *default-package*
+### *default-bg-color*
 @@@ run-commands
 ### *startup-message*
-### *default-package*
+### *list-hidden-groups*
 %%% defprogram-shortcut
 ### *initializing*
 !!! loadrc

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1425,6 +1425,8 @@ return a ``nil'' value in those cases, and let the command handle that.
 (define-key *root-map* (kbd "R") "smarty right")
 @end example
 
+%%% define-stumpwm-type
+
 @node Common Built-in Commands, , Writing Commands, Commands
 @section Common Built-in Commands
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1281,6 +1281,8 @@ the command exits; We've added SPC as an exit key with custom exit
 keys. Also, the command executes only if the variables @code{*bar*}
 and @code{*baz*} are true.
 
+%%% define-interactive-keymap
+!!! call-and-exit-kmap
 
 @node StumpWM Types,  , Writing Commands, Commands
 @section StumpWM Types
@@ -2169,7 +2171,6 @@ section.
 ### *toplevel-io*
 @@@ update-decoration
 
-!!! call-and-exit-kmap
 
 ### *executing-stumpwm-command*
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2139,7 +2139,6 @@ section.
 ### *frame-indicator-timer*
 ### *frame-number-map*
 @@@ gravity-coords
-### *help-map*
 ### *honor-window-moves*
 ### *ignore-wm-inc-hints*
 @@@ input-delete-region
@@ -2147,7 +2146,6 @@ section.
 @@@ input-point
 @@@ input-substring
 @@@ input-validate-region
-### *last-command*
 @@@ list-directory
 @@@ lookup-command
 ### *max-last-message-size*
@@ -2375,6 +2373,8 @@ Return T if TIMER is a timer structure.
 !!! describe-command
 !!! where-is
 !!! modifiers
+!!! which-key-mode
+### *help-map*
 
 @node Colors, Hooks, Miscellaneous Commands, Top
 @chapter Colors

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -102,6 +102,7 @@ This document explains how to use The Stump Window Manager.
 * Hooks::
 * Modules::
 * Hacking::
+* Advanced Configuration::
 * Command and Function Index::
 * Variable Index::
 
@@ -2170,7 +2171,6 @@ section.
 ### *toplevel-io*
 @@@ update-decoration
 
-@@@ run-commands
 !!! call-and-exit-kmap
 
 ### *executing-stumpwm-command*
@@ -2188,14 +2188,7 @@ section.
 
 %%% with-restarts-menu
 
-### *startup-message*
 ### *suppress-abort-messages*
-### *default-package*
-
-%%% defprogram-shortcut
-
-### *initializing*
-
 @menu
 * Menus::
 * StumpWM's Data Directory::
@@ -2654,7 +2647,7 @@ the StumpWM devs to maintain it (and they agree), you can have your
 module merged with the stumpwm-contrib repository on github, just open
 a pull request to start the discussion.
 
-@node Hacking, Command and Function Index, Modules, Top
+@node Hacking, Advanced Configuration, Modules, Top
 @chapter Hacking
 
 @menu
@@ -2947,9 +2940,16 @@ sending them as one.
 
 @end itemize
 
+@node Advanced Configuration, Command and Function Index, Hacking, Top
+@chapter Advanced Configuration
 
+@@@ run-commands
+### *startup-message*
+### *default-package*
+%%% defprogram-shortcut
+### *initializing*
 
-@node Command and Function Index, Variable Index, Hacking, Top
+@node Command and Function Index, Variable Index, Advanced Configuration, Top
 @unnumbered Command and Function Index
 @printindex fn
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1163,6 +1163,7 @@ StumpWM does not implement the Emacs concept of prefix arguments.
 @menu
 * Writing Commands::
 * StumpWM Types::
+* Common Built-in Commands::
 @end menu
 
 @node Writing Commands, StumpWM Types, Commands, Commands
@@ -1218,6 +1219,10 @@ which only functions in tile groups, is defined this way:
 @example
 (defcommand (next tile-group) @dots{})
 @end example
+
+%%% defcommand
+%%% defcommand-alias
+### *last-command*
 
 @section Interactive Keymaps
 
@@ -1417,6 +1422,26 @@ return a ``nil'' value in those cases, and let the command handle that.
 (define-key *root-map* (kbd "R") "smarty right")
 @end example
 
+@node Common Built-in Commands, , Writing Commands, Commands
+@section Common Built-in Commands
+
+!!! banish
+!!! ratwarp
+!!! ratrelwarp
+!!! ratclick
+!!! restart-hard
+!!! restart-soft
+!!! lastmsg
+!!! commands
+!!! keyboard-quit
+!!! reload
+!!! quit
+!!! echo-date
+!!! eval-line
+!!! command-mode
+!!! list-window-properties
+!!! show-window-properties
+!!! time
 @node Message and Input Bar, Windows, Commands, Top
 @chapter Message and Input Bar
 
@@ -2097,31 +2122,12 @@ multiplexer to actually run it.
 The following is a list of commands that don't really fit in any other
 section.
 
-!!! emacs
-!!! banish
-!!! ratwarp
-!!! ratrelwarp
-!!! ratclick
-!!! echo-date
 !!! refresh-time-zone
-!!! eval-line
 !!! window-send-string
-!!! reload
 !!! loadrc
-!!! keyboard-quit
-!!! quit
-!!! restart-hard
-!!! restart-soft
 !!! getsel
 !!! putsel
-!!! command-mode
 !!! copy-unhandled-error
-!!! commands
-!!! lastmsg
-!!! list-window-properties
-!!! show-window-properties
-!!! version
-!!! which-key-mode
 @@@ argument-line-end-p
 @@@ argument-pop
 @@@ argument-pop-rest
@@ -2159,7 +2165,6 @@ section.
 ### *suppress-frame-indicator*
 ### *suppress-window-placement-indicator*
 ### *text-color*
-!!! time
 ### *timeout-frame-indicator-wait*
 ### *top-level-error-action*
 ### *toplevel-io*
@@ -2168,11 +2173,6 @@ section.
 @@@ run-commands
 !!! call-and-exit-kmap
 
-%%% defcommand
-%%% define-interactive-keymap
-%%% define-stumpwm-type
-%%% defcommand-alias
-%%% define-stumpwm-command
 ### *executing-stumpwm-command*
 
 @@@ run-or-raise

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -893,6 +893,10 @@ Describe the specified command.
 @@@ ungrab-pointer
 ### *banish-pointer-to*
 
+### *editor-bindings*
+### *numpad-map*
+
+
 @node Modifiers, Remapped Keys, Binding Keys, Key Bindings
 @section Modifiers
 
@@ -1457,7 +1461,8 @@ return a ``nil'' value in those cases, and let the command handle that.
 @@@ err
 !!! colon
 
-
+%%% with-restarts-menu
+@@@ restarts-menu
 
 @menu
 * Customizing The Bar::
@@ -1625,10 +1630,14 @@ An input function takes 2 arguments: the input structure and the key pressed.
 !!! unmaximize
 !!! toggle-always-on-top
 !!! toggle-always-show
+!!! window-send-string
+
 @@@ window-head
 @@@ window-sync
 @@@ window-visible-p
 @@@ raise-window
+@@@ focus-window
+
 
 ### *xwin-to-window*
 ### *window-format*
@@ -1637,6 +1646,7 @@ An input function takes 2 arguments: the input structure and the key pressed.
 ### *new-window-preferred-frame*
 ### *hidden-window-color*
 
+### *honor-window-moves*
 @menu
 * Window Marks::
 * Customizing Window Appearance::
@@ -1676,6 +1686,7 @@ variables.
 @@@ set-transient-gravity
 
 !!! gravity
+@@@ gravity-coords
 
 @node Controlling Raise And Map Requests, Programming With Windows, Customizing Window Appearance, Windows
 @section Controlling Raise And Map Requests
@@ -1800,6 +1811,8 @@ window pool, where windows and frames are not so tightly connected.
 !!! exchange-direction
 !!! expose
 
+%%% save-frame-excursion
+
 @@@ run-or-pull
 
 ### *min-frame-width*
@@ -1807,6 +1820,9 @@ window pool, where windows and frames are not so tightly connected.
 ### *new-frame-action*
 ### *expose-auto-tile-fn*
 ### *expose-n-max*
+### *frame-indicator-text*
+### *frame-indicator-timer*
+### *frame-number-map*
 
 @menu
 * Interactively Resizing Frames::
@@ -2138,63 +2154,34 @@ multiplexer to actually run it.
 @@@ getenv
 @@@ (setf getenv)
 
-@node Interacting With X11, Miscellaneous Commands, Interacting With Unix, Top
-@chapter Interacting With X11
+@@@ split-string
 
-@@@ set-x-selection
-@@@ get-x-selection
-### *x-selection*
-
-@node Miscellaneous Commands, Colors, Interacting With X11, Top
-@chapter Miscellaneous Commands
-The following is a list of commands that don't really fit in any other
-section.
-
-!!! window-send-string
-!!! loadrc
 @@@ argument-line-end-p
 @@@ argument-pop
 @@@ argument-pop-rest
 ### *display*
-### *editor-bindings*
-@@@ focus-window
-### *frame-indicator-text*
-### *frame-indicator-timer*
-### *frame-number-map*
-@@@ gravity-coords
-### *honor-window-moves*
-### *ignore-wm-inc-hints*
 @@@ input-delete-region
 @@@ input-goto-char
 @@@ input-point
 @@@ input-substring
 @@@ input-validate-region
 @@@ list-directory
-@@@ lookup-command
-### *max-last-message-size*
-### *module-dir*
-### *mouse-focus-policy*
 %%% move-to-head
 @@@ no-focus
-### *numpad-map*
 ### *record-last-msg-override*
-### *resize-hides-windows*
-### *root-click-focuses-frame*
-%%% save-frame-excursion
-@@@ set-module-dir
-@@@ split-string
-### *suppress-frame-indicator*
-### *suppress-window-placement-indicator*
-### *text-color*
-### *timeout-frame-indicator-wait*
-### *top-level-error-action*
 ### *toplevel-io*
+
+@node Interacting With X11, Miscellaneous Commands, Interacting With Unix, Top
+@chapter Interacting With X11
+
+@@@ set-x-selection
+@@@ get-x-selection
+### *x-selection*
 @@@ update-decoration
 
+@node Miscellaneous Commands, Colors, Interacting With X11, Top
+@chapter Miscellaneous Commands
 
-@@@ restarts-menu
-
-%%% with-restarts-menu
 @menu
 * Menus::
 * StumpWM's Data Directory::
@@ -2382,6 +2369,9 @@ Return T if TIMER is a timer structure.
 !!! where-is
 !!! modifiers
 !!! which-key-mode
+
+@@@ lookup-command
+
 ### *help-map*
 
 @node Colors, Hooks, Miscellaneous Commands, Top
@@ -2956,6 +2946,20 @@ sending them as one.
 ### *default-package*
 %%% defprogram-shortcut
 ### *initializing*
+!!! loadrc
+### *ignore-wm-inc-hints*
+### *max-last-message-size*
+### *module-dir*
+@@@ set-module-dir
+### *mouse-focus-policy*
+### *resize-hides-windows*
+### *root-click-focuses-frame*
+### *suppress-frame-indicator*
+### *suppress-window-placement-indicator*
+### *text-color*
+### *timeout-frame-indicator-wait*
+### *top-level-error-action*
+
 
 @node Command and Function Index, Variable Index, Advanced Configuration, Top
 @unnumbered Command and Function Index

--- a/user.lisp
+++ b/user.lisp
@@ -208,8 +208,7 @@ such a case, kill the shell command to resume StumpWM."
       (message "rc file loaded successfully."))))
 
 (defcommand keyboard-quit () ()
-    ""
-  ;; This way you can exit from command mode
+  "This way you can exit from command mode. Also aliased as abort."
   (let ((in-command-mode (eq *top-map* *root-map*)))
     (when (pop-top-map)
       (if in-command-mode


### PR DESCRIPTION
Meant to address https://github.com/stumpwm/stumpwm/issues/501, where the goal is to shunt all these "miscellaneous" things into useful sections. What I've done:
- Add as few sections as possible, but do so where necessary
- Add "Advanced Configuration" section for things that are too esoteric to go in the Introduction, but are useful for configuration purposes.
- Fix any obvious documentation-related problems I come across as I do this (typos in docstrings, document undocumented things, comments where docstrings belong, etc.).
- No uncategorized items.