### PR TITLE
Add quit keybinding, ask to quit, and use sb-ext on SBCL (#675)

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -183,6 +183,7 @@ is a tile group.")
   (kbd "F")       "curframe"
   (kbd "-")       "fclear"
   (kbd "Q")       "only"
+  (kbd "q")       "quit-confirm"
   (kbd "Up")      "move-focus up"
   (kbd "Down")    "move-focus down"
   (kbd "Left")    "move-focus left"

--- a/user.lisp
+++ b/user.lisp
@@ -217,6 +217,8 @@ such a case, kill the shell command to resume StumpWM."
 
 (defcommand-alias abort keyboard-quit)
 
+(defcommand quit-confirm (&optional (confirm t)) ((:y-or-n "Really close StumpWM? "))
+  (when confirm (quit)))
 
 (defcommand quit () ()
 "Quit StumpWM."


### PR DESCRIPTION
(sb-ext:exit) provides a sure-fire way to quit everything on SBCL.

Running `C-t : quit` only closes the mode line, but does not totally close everything. Also, adding the keybinding `C-t q` is helpful, since many users of StumpWM cannot use it as their only window manager yet. Since it is easy to accidentally hit it (thereby closing all your windows and possibly losing a lot of work) it asks a one-character prompt: `Really close StumpWM? (y or n)`.