### PR TITLE
Make get-x-selection and set-x-selection have configuration choices for clipboard vs. primary selections #673

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2090,6 +2090,7 @@ multiplexer to actually run it.
 
 @@@ set-x-selection
 @@@ get-x-selection
+### *default-selections*
 ### *x-selection*
 
 @node Miscellaneous Commands, Colors, Interacting With X11, Top


### PR DESCRIPTION
One may desire to use the `clipboard` instead of the `primary` selection, or even clobber both.

Addresses https://github.com/stumpwm/stumpwm/issues/673