### PR TITLE
Remove trailing whitespaces from everything.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,7 +54,7 @@ StumpWM now has a floating window group mode.
 
 ** define-key acts like undefine-key when nil is passed as the command
 
-** new command, show-window-properties 
+** new command, show-window-properties
 
 ** select-from-menu lets you type regex to match an item
 
@@ -213,7 +213,7 @@ Makefile to choose you lisp.
 ** New command, title, bound to C-t A
 title sets the window's name.
 
-** errors while reloading stumpwm 
+** errors while reloading stumpwm
 A restarts menu now appears that allows you to select a restart, if
 you want.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bars, or any of the other conventional GUI widgets.
 These design decisions reflect the growing popularity of productive,
 customizable lisp based systems.
 
-## Philosophy 
+## Philosophy
 
 Stumpwm is a "everything-and-the-kitchen-sink WM" or "the emacs of
 WMs."
@@ -21,7 +21,7 @@ WMs."
   * Hackable
   * Written in Common Lisp
   * A multi paradigm window manager
-  * A Superior window managing experience 
+  * A Superior window managing experience
 * StumpWM is *not*
   * Minimalist
   * Narrow Scope
@@ -48,7 +48,7 @@ hackable desktop experience, look no further.
 
 The recommended way to install the dependencies is using Quicklisp.
 Follow the instructions at http://www.quicklisp.org/ to install it.
-In short: 
+In short:
 
 ```
 $ curl -O https://beta.quicklisp.org/quicklisp.lisp
@@ -125,9 +125,9 @@ examples.
 # Contributing
 
 Pull requests are always welcome! Here are some guidelines to ensure
-that your contribution gets merged in a timely manner: 
-* Do's 
-  * Add your name to the list of AUTHORS with your pull request.  
+that your contribution gets merged in a timely manner:
+* Do's
+  * Add your name to the list of AUTHORS with your pull request.
   * Preserve comments or docstrings explaining what code does, and
     update them if your patch changes them in a significant way
   * Try to follow an "80 column rule." The current code base does not
@@ -139,14 +139,14 @@ that your contribution gets merged in a timely manner:
     changes are made and then incrementally applied to the codebase in
     order to avoid introducing show-stopping bugs.
 * Do not's
-  * Include emacs local variables 
-  * Change whitespace 
+  * Include emacs local variables
+  * Change whitespace
   * Write lots of code without supporting comments/documentation
   * Delete comments or docstrings (yes this is a duplicate of above!)
   * Export symbols from packages that aren't widely useful (many times
     a little more thought will reveal how to implement your internal
     change without having to export/break encapsulation)
-  * Make stylistic changes that suit your coding style/way of thinking 
+  * Make stylistic changes that suit your coding style/way of thinking
 
 Our wiki has fallen into disarray/disrepair, but it is shaping up.  If
 you aren't a lisp hacker, you can contribute in the form of
@@ -154,7 +154,7 @@ documenting and organizing the wiki. There's a lot of information
 floating around, if you find it where you didn't expect it, move or
 link to it in a more logical place.
 
-# Wishlist 
+# Wishlist
 
 Fancy yourself a lisp hacker? Here's a wishlist of features for the
 StumpWM universe (in no particular order):
@@ -170,7 +170,7 @@ StumpWM universe (in no particular order):
   * Deleting/adding groups
   * Import data from stumpwm to emacs, use an emacs minor mode to
     implement the above features, then export the data back to stumpwm
-    and let stumpwm perform the appropriate actions 
+    and let stumpwm perform the appropriate actions
 * Emacs' completing-read-multiple function
 * Dynamic tiling
 * Lock Screen (with support for leaving notes, bonus points if emacs
@@ -179,13 +179,13 @@ StumpWM universe (in no particular order):
   timers, and other hacky features)
 * Shutdown, restart, suspend, and hibernate functions that don't
   require root access
-* Revamped, mouse-friendly mode-line. 
+* Revamped, mouse-friendly mode-line.
   * Support fixed number of chars for window titles
   * Dynamically trim window titles to fit them all on the mode-line
   * Split the mode-line into multiple cells for containing different information
   * Implement widget icons to indicate system status (new mail, low
     battery, network etc)
-  * Support raising windows when left-clicked, closing/killing when right-clicked  
+  * Support raising windows when left-clicked, closing/killing when right-clicked
 
 # Help
 

--- a/bindings.lisp
+++ b/bindings.lisp
@@ -224,18 +224,18 @@ is a tile group.")
   (kbd "9")     "gselect 9"
   (kbd "0")     "gselect 10")
 (fill-keymap *exchange-window-map*
-             (kbd "Up")    "exchange-direction up"   
-             (kbd "Down")  "exchange-direction down" 
-             (kbd "Left")  "exchange-direction left" 
+             (kbd "Up")    "exchange-direction up"
+             (kbd "Down")  "exchange-direction down"
+             (kbd "Left")  "exchange-direction left"
              (kbd "Right") "exchange-direction right"
-             (kbd "p")     "exchange-direction up"   
-             (kbd "n")     "exchange-direction down" 
-             (kbd "b")     "exchange-direction left" 
+             (kbd "p")     "exchange-direction up"
+             (kbd "n")     "exchange-direction down"
+             (kbd "b")     "exchange-direction left"
              (kbd "f")     "exchange-direction right"
-             (kbd "k")     "exchange-direction up"   
-             (kbd "j")     "exchange-direction down" 
-             (kbd "h")     "exchange-direction left" 
-             (kbd "l")     "exchange-direction right")    
+             (kbd "k")     "exchange-direction up"
+             (kbd "j")     "exchange-direction down"
+             (kbd "h")     "exchange-direction left"
+             (kbd "l")     "exchange-direction right")
 (fill-keymap *help-map*
   (kbd "v") "describe-variable"
   (kbd "f") "describe-function"

--- a/color.lisp
+++ b/color.lisp
@@ -106,7 +106,7 @@ then call (update-color-map).")
                           color))))
 
 (defun alloc-color (screen color)
-  (xlib:alloc-color 
+  (xlib:alloc-color
    (xlib:screen-default-colormap (screen-number screen))
    (lookup-color screen color)))
 

--- a/core.lisp
+++ b/core.lisp
@@ -64,7 +64,7 @@
       (mapc (lambda (btn)
               (xlib:send-event xwin (first btn) (xlib:make-event-mask (first btn))
                                :display *display*
-                               :root root-win 
+                               :root root-win
                                :window xwin :event-window xwin
                                :code button
                                :state (second btn)

--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -1,6 +1,6 @@
 (in-package :stumpwm)
 
-(defvar *expose-n-max* 26 
+(defvar *expose-n-max* 26
   "Maximum number of windows to display in the expose")
 
 (defvar *expose-auto-tile-fn* 'expose-tile
@@ -46,7 +46,7 @@ area."
 that window the focus. Set the variable `*expose-auto-tile-fn*' to another
 tiling function if a different layout is desired. Set `*expose-n-max*' to the
 maximum number of windows to be displayed for choosing."
-  (funcall *expose-auto-tile-fn* nil 
+  (funcall *expose-auto-tile-fn* nil
            (current-group (current-screen)))
   ;; have the user select a window
   (run-commands "fselect")

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -245,7 +245,7 @@
        (* 2 *normal-border-width*)
        *float-window-border*
        *float-window-title-height*)))
-  
+
 (defun maximize-float (window &key horizontal vertical)
   (let* ((head (window-head window))
          (ml (head-mode-line head))
@@ -256,7 +256,7 @@
                (* 2 *float-window-border*)))
          (h (window-display-height window)))
     (when horizontal
-      (float-window-move-resize window :width w)) 
+      (float-window-move-resize window :width w))
     (when vertical
       (float-window-move-resize window :y hy :height h))
     (when (and horizontal vertical)
@@ -270,7 +270,7 @@
         (xwin (window-xwin window)))
     (when (member *mouse-focus-policy* '(:click :sloppy))
       (group-focus-window group window))
-    
+
     ;; When in border
     (multiple-value-bind (relx rely same-screen-p child state-mask)
         (xlib:query-pointer (window-parent window))
@@ -290,12 +290,12 @@
                  (win-focused-p (eq window (screen-focus screen))))
             (setf *last-click-time* current-time)
             (when (< delta-t 0.25)
-              (cond ((and (not (eq (window-height window) 
-                                   (window-display-height window))) 
-                          win-focused-p) 
+              (cond ((and (not (eq (window-height window)
+                                   (window-display-height window)))
+                          win-focused-p)
                      (maximize-float window :vertical t))
                     (win-focused-p (maximize-float window :vertical t :horizontal t))
-                    (t (focus-window window t))))))  
+                    (t (focus-window window t))))))
         ;; When resizing warp pointer to left-right corner
         (when (find :button-3 (xlib:make-state-keys state-mask))
           (xlib:warp-pointer (window-parent window) initial-width initial-height))
@@ -318,7 +318,7 @@
                                ;; if button-1 on the sides (left,
                                ;; right, bottom) then we resize that
                                ;; direction
-                               
+
                                ;; if button-1 on the top, then we move the window
                                (setf (xlib:drawable-x parent) (- (getf event-slots :x) relx)
                                      (xlib:drawable-y parent) (- (getf event-slots :y) rely)))

--- a/group.lisp
+++ b/group.lisp
@@ -407,7 +407,7 @@ current group. If @var{name} begins with a dot (``.'') the group new
 group will be created in the hidden state. Hidden groups have group
 numbers less than one and are invisible to from gprev, gnext, and, optionally,
 groups and vgroups commands."
-  (unless name 
+  (unless name
     (throw 'error :abort))
   (add-group (current-screen) name))
 

--- a/interactive-keymap.lisp
+++ b/interactive-keymap.lisp
@@ -59,7 +59,7 @@ keymap will only be activated if calling ABORT-IF returns true.
 
 KEY-BINDINGS is a list of the following form: ((KEY COMMAND) (KEY COMMAND) ...)
 If one appends t to the end of a binding like so: ((kbd \"n\") \"cmd\" t) then
-the keymap is immediately exited after running the command. 
+the keymap is immediately exited after running the command.
 
 Each element in KEY-BINDINGS declares a command inside the interactive keymap.
 Be aware that these commands won't require a prefix to run."

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -38,8 +38,8 @@
 @dfn{prefix map}.")
 
 (defvar *root-map* nil
-  "This is the keymap by default bound to @kbd{C-t} (along with 
- *group-root-map* and either *tile-group-root-map* or 
+  "This is the keymap by default bound to @kbd{C-t} (along with
+ *group-root-map* and either *tile-group-root-map* or
  *float-group-root-map*). It is known as the @dfn{prefix map}.")
 
 (defstruct key

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,4 @@
-;; package.lisp -- 
+;; package.lisp --
 ;; Copyright (C) 2003-2008 Shawn Betts
 ;;
 ;;  This file is part of stumpwm.

--- a/pathnames.lisp
+++ b/pathnames.lisp
@@ -62,7 +62,7 @@ all files within the directory named by the non-wild pathname
 designator DIRNAME.  The pathnames of sub-directories are returned in
 directory form - see PATHNAME-AS-DIRECTORY."
   (when (wild-pathname-p dirname)
-    (error "Can only list concrete directory names.")) 
+    (error "Can only list concrete directory names."))
   (let ((wildcard (directory-wildcard dirname)))
     (directory wildcard)))
 

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -236,7 +236,7 @@ further up. "
                ;; Start hashing the user's PATH so completion is quick
                ;; the first time they try to run a command.
                (sb-thread:make-thread #'rehash)
-               
+
                ;; we need to do this first because init-screen grabs
                ;; keys
                (update-modifier-map)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1232,7 +1232,7 @@ interactive keymap. The first argument is the same as
 configurations that can be used for controlling the command and the
 rest are the key bindings for the new command, optionally with a
 @code{t} appended; this tells @code{define-interactive-keymap} to
-exit the keymap upon use of that keybinding. 
+exit the keymap upon use of that keybinding.
 
 For instance, a simple interactive keymap:
 
@@ -1926,9 +1926,9 @@ Groups in StumpWM are more commonly known as @dfn{virtual desktops} or
 !!! grename
 !!! grouplist
 
-### *list-hidden-groups* 
-### *group-top-maps* 
-### *default-group-name* 
+### *list-hidden-groups*
+### *group-top-maps*
+### *default-group-name*
 
 @@@ add-group
 @@@ group-add-head

--- a/test-wm.lisp
+++ b/test-wm.lisp
@@ -102,7 +102,7 @@
              (let* ((dpy2 (xlib:open-default-display))
                     (window (make-win dpy2))
                     (pixmap (make-pixmap window)))
-               ;; make the pixmap the window's icon pixmap hint. 
+               ;; make the pixmap the window's icon pixmap hint.
                (setf (xlib:wm-hints window) (xlib:make-wm-hints :icon-pixmap pixmap))
                (format t "Window ID: ~s pixmap ID: ~s~%" (xlib:window-id window) (xlib:pixmap-id pixmap))
                (xlib:map-window window)

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1083,7 +1083,7 @@ space."
         (progn
           (mapc (lambda (w)
                   ;; windows in other frames disappear
-                  (unless (eq (window-frame w) 
+                  (unless (eq (window-frame w)
                               (tile-group-current-frame group))
                     (hide-window w))
                   (setf (window-frame w) frame))

--- a/user.lisp
+++ b/user.lisp
@@ -155,7 +155,7 @@ with base. Automagically update the cache."
                      (when (<= (length base) (length p))
                        (string= base p
                                 :end1 (length base)
-                                :end2 (length base)))) 
+                                :end2 (length base))))
                  (path-cache-programs *path-cache*)))
 
 (defcommand run-shell-command (cmd &optional collect-output-p) ((:shell "/bin/sh -c "))
@@ -199,7 +199,7 @@ such a case, kill the shell command to resume StumpWM."
 
 (defcommand loadrc () ()
 "Reload the @file{~/.stumpwmrc} file."
-  (handler-case 
+  (handler-case
       (with-restarts-menu (load-rc-file nil))
     (error (c)
       (message "^1*^BError loading rc file: ^n~A" c))


### PR DESCRIPTION
Like the great sage once said

> [So a language that makes source code ugly is maddening to an exacting programmer, as clay full of lumps would be to a sculptor](http://www.paulgraham.com/pypar.html)

And although the README does say 
> [do not] change whitespace

I think it is worth it in this case, as it is all that is done here.
