### PR TITLE
bind and document *movement-map*

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -26,7 +26,6 @@
 
 (export '(*groups-map*
           *group-top-maps*
-          *movement-map*
           *help-map*
           set-prefix-key))
 

--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -37,7 +37,9 @@ area."
   (declare (ignore win))
   (let* ((windows (group-windows group))
          (num-win (length windows)))
-    (only)
+    ;; Only try to make this the only frame if it isn't already.
+    (unless (only-one-frame-p)
+      (only))
     (recursive-tile (min *expose-n-max* num-win) group)))
 
 
@@ -46,9 +48,10 @@ area."
 that window the focus. Set the variable `*expose-auto-tile-fn*' to another
 tiling function if a different layout is desired. Set `*expose-n-max*' to the
 maximum number of windows to be displayed for choosing."
-  (funcall *expose-auto-tile-fn* nil 
+  (funcall *expose-auto-tile-fn* nil
            (current-group (current-screen)))
   ;; have the user select a window
-  (run-commands "fselect")
+  (unless (only-one-frame-p)
+    (run-commands "fselect"))
   ;; maximize that window
   (only))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1824,6 +1824,7 @@ window pool, where windows and frames are not so tightly connected.
 %%% save-frame-excursion
 
 @@@ run-or-pull
+@@@ only-one-frame-p
 
 ### *min-frame-width*
 ### *min-frame-height*

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1071,6 +1071,13 @@ space."
 
 (defcommand-alias remove remove-split)
 
+(defun only-one-frame-p ()
+  "T if there is only one maximized frame in the current head.
+This can be used around a the \"only\" command to avoid the warning message."
+  (let* ((group (screen-current-group (current-screen)))
+         (head (current-head group)))
+    (atom (tile-group-frame-head group head))))
+
 (defcommand (only tile-group) () ()
   "Delete all the frames but the current one and grow it to take up the entire head."
   (let* ((screen (current-screen))
@@ -1078,7 +1085,7 @@ space."
          (win (group-current-window group))
          (head (current-head group))
          (frame (copy-frame head)))
-    (if (atom (tile-group-frame-head group head))
+    (if (only-one-frame-p)
         (message "There's only one frame.")
         (progn
           (mapc (lambda (w)


### PR DESCRIPTION
This symbol was exported, but not bound or documented. I think it is best to try to make use of it at some point.