### PR TITLE
&&& CONDITION and +++ GENERIC-FN manual markup character sets

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -70,6 +70,13 @@
         (sb-introspect:function-lambda-list fn)
         (documentation fn 'function)))))
 
+(defdoc (:generic-function (s line name fn) "\\+\\+\\+")
+  (let ((*print-pretty* nil))
+    (doc-fmt s "deffn" "{Generic Function} ~a ~{~a~^ ~}~%~a"
+      name
+      (sb-introspect:function-lambda-list fn)
+      (documentation fn 'function))))
+
 (defdoc (:macro (s line name macro) "%%%")
   (let ((*print-pretty* nil))
     (doc-fmt s "defmac" "{~a} ~{~a~^ ~}~%~a"

--- a/manual.lisp
+++ b/manual.lisp
@@ -29,6 +29,9 @@
 (defvar *debug-doc* nil
   "When T, will print extra debugging information from the doc generator.")
 
+(defvar *valid-doctypes* nil
+  "All the line-types that can be generated for the StumpWM documentation.")
+
 (defun dprint (type sym)
   "Handy for figuring out which symbol is borking the documentation."
   (declare (ignorable type sym))
@@ -42,17 +45,23 @@
                          "@" new-name " " body-format "~&@end " new-name "~%~%")
            ,@args))
 
-(defmacro defdoc (name ((out-stream-var line-var name-var)
-                        marker dprint-label)
-                  &body body)
-  "Define a document generating function."
-  `(defun ,name (,out-stream-var ,line-var)
-     (ppcre:register-groups-bind (,name-var)
-         (,(format nil "~@{~A~}" "^" marker "\\W(.*)") ,line-var)
-       (dprint ',dprint-label ,name-var)
-       ,@body)))
+(defgeneric generate (specializer out-stream line)
+  (:documentation "Generate a texi.in documentation line."))
 
-(defdoc generate-function-doc ((s line name) "@@@" func)
+(defmacro defdoc ((specializer
+                   (out-stream-var line-var name-var)
+                   marker dprint-label)
+                  &body body)
+  "Define a document generating method."
+  `(progn
+     (pushnew ,specializer *valid-doctypes*)
+     (defmethod generate ((,(gensym) (eql ,specializer)) ,out-stream-var ,line-var)
+       (ppcre:register-groups-bind (,name-var)
+           (,(format nil "~@{~A~}" "^" marker "\\W(.*)") ,line-var)
+         (dprint ',dprint-label ,name-var)
+         ,@body))))
+
+(defdoc (:function (s line name) "@@@" func)
   (let ((fn (if (find #\( name :test 'char=)
                 ;; handle (setf <symbol>) functions
                 (with-standard-io-syntax
@@ -65,7 +74,7 @@
         (documentation fn 'function)))
     t))
 
-(defdoc generate-macro-doc ((s line name) "%%%" macro)
+(defdoc (:macro (s line name) "%%%" macro)
   (let* ((symbol (find-symbol (string-upcase name) :stumpwm)))
     (let ((*print-pretty* nil))
       (doc-fmt s "defmac" "{~a} ~{~a~^ ~}~%~a"
@@ -74,19 +83,19 @@
         (documentation symbol 'function)))
     t))
 
-(defdoc generate-variable-doc ((s line name) "###" var)
+(defdoc (:variable (s line name) "###" var)
   (let ((sym (find-symbol (string-upcase name) :stumpwm)))
     (doc-fmt s "defvar" "~a~%~a"
       name (documentation sym 'variable))
     t))
 
-(defdoc generate-hook-doc ((s line name) "$$$" hook)
+(defdoc (:hook (s line name) "$$$" hook)
   (let ((sym (find-symbol (string-upcase name) :stumpwm)))
     (doc-fmt s "defvr" "{Hook} ~a~%~a"
       name (documentation sym 'variable))
     t))
 
-(defdoc generate-command-doc ((s line name) "!!!" cmd)
+(defdoc (:command (s line name) "!!!" cmd)
   (if-let (symbol (find-symbol (string-upcase name) :stumpwm))
     (let ((cmd (symbol-function symbol))
           (*print-pretty* nil))
@@ -97,16 +106,17 @@
       t)
     (warn "Symbol ~A not found in package STUMPWM" name)))
 
+(defmethod generate ((specializer null) os line)
+  (mapc (lambda (spec)
+          (when (generate spec os line)
+            (return-from generate)))
+        *valid-doctypes*)
+  (write-line line os))
+
 (defun generate-manual (&key (in #p"stumpwm.texi.in") (out #p"stumpwm.texi"))
   "Generate the texinfo manual from the template texi.in file."
   (let ((*print-case* :downcase))
     (with-open-file (os out :direction :output :if-exists :supersede)
       (with-open-file (is in :direction :input)
         (loop for line = (read-line is nil is)
-              until (eq line is) do
-              (or (generate-function-doc os line)
-                  (generate-macro-doc os line)
-                  (generate-hook-doc os line)
-                  (generate-variable-doc os line)
-                  (generate-command-doc os line)
-                  (write-line line os)))))))
+              until (eq line is) do (generate nil os line))))))

--- a/manual.lisp
+++ b/manual.lisp
@@ -81,7 +81,7 @@
   (doc-fmt s "defvar" "~a~%~a"
     name (documentation var 'variable)))
 
-(defdoc (:hook (s line name hook) "$$$")
+(defdoc (:hook (s line name hook) "\\$\\$\\$")
   (doc-fmt s "defvr" "{Hook} ~a~%~a"
     name (documentation hook 'variable)))
 

--- a/manual.lisp
+++ b/manual.lisp
@@ -28,17 +28,8 @@
 ;; FIXME: Why does SBCL not know how to REQUIRE sb-mop?
 ;; (require :sb-mop); Class slots lists.
 
-(defvar *debug-doc* nil
-  "When T, will print extra debugging information from the doc generator.")
-
 (defvar *valid-doctypes* nil
   "All the line-types that can be generated for the StumpWM documentation.")
-
-(defun dprint (type sym)
-  "Handy for figuring out which symbol is borking the documentation."
-  (declare (ignorable type sym))
-  (when *debug-doc*
-    (format t "~&Doing ~a ~a..." type sym)))
 
 (defmacro doc-fmt (stream new-name body-format &body args)
   "Fill in a texinfo template."
@@ -52,7 +43,7 @@
 
 (defmacro defdoc ((specializer
                    (out-stream-var line-var name-var symbol-var)
-                   marker dprint-label)
+                   marker)
                   &body body)
   "Define a document generating method."
   `(progn
@@ -61,7 +52,8 @@
        (ppcre:register-groups-bind (,name-var)
            (,(format nil "~@{~A~}" "^" marker "\\W(.*)") ,line-var)
          (let ((,symbol-var (find-symbol (string-upcase ,name-var) :stumpwm)))
-           (dprint ',dprint-label ,name-var)
+           (format *debug-io* "~&Formatting manual for the ~a ~a...~&"
+                   specializer ',name-var)
            ,@body
            t)))))
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2172,6 +2172,7 @@ multiplexer to actually run it.
 %%% defdoc
 %%% doc-fmt
 ### *valid-doctypes*
++++ generate
 
 
 @node Interacting With Unix, Interacting With X11, Screens, Top

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2159,13 +2159,20 @@ multiplexer to actually run it.
 
 ### *executing-stumpwm-command*
 ### *suppress-abort-messages*
+
 !!! refresh-time-zone
 !!! getsel
 !!! putsel
 !!! copy-unhandled-error
+!!! set-contrib-dir
+
 @@@ read-line-from-sysfs
 @@@ define-stumpwm-command
-!!! set-contrib-dir
+
+%%% defdoc
+%%% doc-fmt
+### *valid-doctypes*
+
 
 @node Interacting With Unix, Interacting With X11, Screens, Top
 @chapter Interacting With Unix

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1478,6 +1478,7 @@ return a ``nil'' value in those cases, and let the command handle that.
 * Using The Input Bar::
 * Programming The Message Bar::
 * Programming the Input Bar::
+* Conditions and Restarts::
 @end menu
 
 @node Customizing The Bar, Using The Input Bar, Message and Input Bar, Message and Input Bar
@@ -1604,6 +1605,22 @@ An input function takes 2 arguments: the input structure and the key pressed.
 @@@ input-insert-char
 
 ### *input-map*
+
+@node Conditions and Restarts, , Programming the Input Bar, Message and Input Bar
+@section Conditions and Restarts
+Conditions and restarts are for exceptional situations. They can be
+used to abort processing (errors), prompt the user for input
+(restarts), warn, or do a non-local transfer of control. StumpWM
+provides some facilities for this.
+
+%%% with-restarts-menu
+@@@ restarts-menu
+&&& stumpwm-condition
+&&& stumpwm-error
+&&& stumpwm-warning
+&&& kbd-parse-error
+&&& not-implemented
+&&& command-docstring-warning
 
 @node Windows, Frames, Message and Input Bar, Top
 @chapter Windows

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -197,6 +197,7 @@ Modules
 Hacking
 
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 
@@ -2169,12 +2170,6 @@ multiplexer to actually run it.
 @@@ read-line-from-sysfs
 @@@ define-stumpwm-command
 
-%%% defdoc
-%%% doc-fmt
-### *valid-doctypes*
-+++ generate
-
-
 @node Interacting With Unix, Interacting With X11, Screens, Top
 @chapter Interacting With Unix
 
@@ -2689,11 +2684,12 @@ a pull request to start the discussion.
 
 @menu
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 @end menu
 
-@node General Advice, Using git with StumpWM, Hacking, Hacking
+@node General Advice, Adding Documentation and Editing This Manual, Hacking, Hacking
 @section Hacking:  General Advice
 
 @enumerate
@@ -2768,7 +2764,31 @@ or might be willing to offer suggestions on how to improve the code.
 
 @end enumerate
 
-@node Using git with StumpWM, Sending Patches, General Advice, Hacking
+@node Adding Documentation and Editing This Manual, Using git with StumpWM, General Advice, Hacking
+@section Hacking: Adding Documentation and Editing This Manual
+
+The manual is written in @command{texinfo}, so you may want to read
+that manual. The @file{stumpwm.texi.in} is processed by StumpWM with
+some additional markup in the form of three letter character entries
+at the beginning of a line. @code{@@@ function} defines functions,
+@code{%%% some-macro} expands to that macro and its docstring, etc.
+Contributors are strongly encouraged to add these items to this manual
+whenever something new is defined in a patch. You can test if your
+texinfo edits are valid by generating them with
+@command{make stumpwm.info}, and viewing the new @file{stumpwm.info} with
+@command{info}, or @command{make stumpwm.texi} for the raw stuff.
+
+@enumerate
+@item %%% macros
+@item +++ generic functions
+@item @@@ functions
+@item ### variables
+@item $$$ hooks
+@item &&& conditions
+@item !!! StumpWM commands
+@end enumerate
+
+@node Using git with StumpWM, Sending Patches, Adding Documentation and Editing This Manual, Hacking
 @section Hacking:  Using git with StumpWM
 
 For quite a while now, StumpWM has been using the git version control


### PR DESCRIPTION
I wanted to have `&&& CONDITION` in the manual. To do this I wrote the `defdoc` macro. This required writing `manual.lisp`, but I think it is worth it since it reduces lots of code duplication. All that needs to be done to add a new documentation form is adding a `defdoc` for it (~5 lines) and nothing else.

I tried to make the history as clean as possible for review purposes.

- Whitespace is not meaningful on line items, so `@@@func` is the same as `@@@      func` now.
- print progress on `*debug-io*`, so generating the documentation is less prone to error.
- Added a new documentation section "Conditions and restarts" which uses the new `&&&` line item.
- `+++ generate` is used to document itself.
- Added new documentation section `17.2 Adding Documentation and Editing This Manual` which gives some basic information about how the `texi` is generated, and how to write new documentation with the macro-expanders.
