### PR TITLE
Helpful output while generating the documentation (dprint).

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -26,11 +26,9 @@
 
 (require :sb-introspect)
 
-;; handy for figuring out which symbol is borking the documentation
 (defun dprint (type sym)
-  (declare (ignorable type sym))
-  ;(format t "~&Doing ~a ~a..." type sym)
-  )
+  "Handy for figuring out which symbol is borking the documentation."
+  (format *debug-io* "~&Formatting manual for the ~a ~a...~&" type sym))
 
 (defun generate-function-doc (s line)
   (ppcre:register-groups-bind (name) ("^@@@ (.*)" line)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2137,6 +2137,7 @@ multiplexer to actually run it.
 @@@ io-loop-remove
 @@@ io-loop-update
 @@@ io-loop
+@@@ dprint
 
 @node Internal Functions Documentation, , IO Loop, Internals
 @section Internal Functions Documentation

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -197,6 +197,7 @@ Modules
 Hacking
 
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 
@@ -2664,11 +2665,12 @@ a pull request to start the discussion.
 
 @menu
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 @end menu
 
-@node General Advice, Using git with StumpWM, Hacking, Hacking
+@node General Advice, Adding Documentation and Editing This Manual, Hacking, Hacking
 @section Hacking:  General Advice
 
 @enumerate
@@ -2743,7 +2745,32 @@ or might be willing to offer suggestions on how to improve the code.
 
 @end enumerate
 
-@node Using git with StumpWM, Sending Patches, General Advice, Hacking
+@node Adding Documentation and Editing This Manual, Using git with StumpWM, General Advice, Hacking
+@section Hacking: Adding Documentation and Editing This Manual
+
+The manual is written in @command{texinfo}, so you may want to read
+that manual. The @file{stumpwm.texi.in} is processed by StumpWM with
+some additional markup in the form of three letter character entries
+@c need to double up the at-signs in the @code{@@@ function} to escape
+@c them.
+at the beginning of a line. @code{@@@@@@ function} defines functions,
+@code{%%% some-macro} expands to that macro and its docstring, etc.
+Contributors are strongly encouraged to add these items to this manual
+whenever something new is defined in a patch. You can test if your
+texinfo edits are valid by generating them with
+@command{make stumpwm.info}, and viewing the new @file{stumpwm.info} with
+@command{info -f /path/to/stumpwm.info}, or @command{make
+stumpwm.texi} for the raw stuff.
+
+@table @asis
+@item %%% macro
+@item @@@@@@ function
+@item ### variable
+@item $$$ hook
+@item !!! StumpWM command
+@end table
+
+@node Using git with StumpWM, Sending Patches, Adding Documentation and Editing This Manual, Hacking
 @section Hacking:  Using git with StumpWM
 
 For quite a while now, StumpWM has been using the git version control


### PR DESCRIPTION
This implements `dprint` (which was already defined, but with the implementation commented out). It sends everything to debug-io, and does a freshline afterward (which looks nice, since otherwise it says `Formatting manual for the var *top-level-error-action*...stumpwm.texi`. 

Since this is only ran at compile-time, there is not much of a use case for turning it off.

Was a part of (closed) https://github.com/stumpwm/stumpwm/pull/682