### PR TITLE
Whitespace not meaningful in documentation macroexpander

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -33,7 +33,7 @@
   )
 
 (defun generate-function-doc (s line)
-  (ppcre:register-groups-bind (name) ("^@@@ (.*)" line)
+  (ppcre:register-groups-bind (name) ("^@@@\\W*(.*)" line)
                               (dprint 'func name)
                               (let ((fn (if (find #\( name :test 'char=)
                                             ;; handle (setf <symbol>) functions
@@ -49,7 +49,7 @@
                                 t)))
 
 (defun generate-macro-doc (s line)
-  (ppcre:register-groups-bind (name) ("^%%% (.*)" line)
+  (ppcre:register-groups-bind (name) ("^%%%\\W*(.*)" line)
                               (dprint 'macro name)
                               (let* ((symbol (find-symbol (string-upcase name) :stumpwm))
                                      (*print-pretty* nil))
@@ -60,7 +60,7 @@
                                 t)))
 
 (defun generate-variable-doc (s line)
-  (ppcre:register-groups-bind (name) ("^### (.*)" line)
+  (ppcre:register-groups-bind (name) ("^###\\W*(.*)" line)
                               (dprint 'var name)
                               (let ((sym (find-symbol (string-upcase name) :stumpwm)))
                                 (format s "@defvar ~a~%~a~&@end defvar~%~%"
@@ -68,7 +68,7 @@
                                 t)))
 
 (defun generate-hook-doc (s line)
-  (ppcre:register-groups-bind (name) ("^\\$\\$\\$ (.*)" line)
+  (ppcre:register-groups-bind (name) ("^\\$\\$\\$\\W*(.*)" line)
                               (dprint 'hook name)
                               (let ((sym (find-symbol (string-upcase name) :stumpwm)))
                                 (format s "@defvr {Hook} ~a~%~a~&@end defvr~%~%"
@@ -76,7 +76,7 @@
                                 t)))
 
 (defun generate-command-doc (s line)
-  (ppcre:register-groups-bind (name) ("^!!! (.*)" line)
+  (ppcre:register-groups-bind (name) ("^!!!\\W*(.*)" line)
     (dprint 'cmd name)
     (if-let (symbol (find-symbol (string-upcase name) :stumpwm))
       (let ((cmd (symbol-function symbol))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -197,6 +197,7 @@ Modules
 Hacking
 
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 
@@ -2664,11 +2665,12 @@ a pull request to start the discussion.
 
 @menu
 * General Advice::
+* Adding Documentation and Editing This Manual::
 * Using git with StumpWM::
 * Sending Patches::
 @end menu
 
-@node General Advice, Using git with StumpWM, Hacking, Hacking
+@node General Advice, Adding Documentation and Editing This Manual, Hacking, Hacking
 @section Hacking:  General Advice
 
 @enumerate
@@ -2743,7 +2745,32 @@ or might be willing to offer suggestions on how to improve the code.
 
 @end enumerate
 
-@node Using git with StumpWM, Sending Patches, General Advice, Hacking
+@node Adding Documentation and Editing This Manual, Using git with StumpWM, General Advice, Hacking
+@section Hacking: Adding Documentation and Editing This Manual
+
+The manual is written in @command{texinfo}, so you may want to read
+that manual. The @file{stumpwm.texi.in} is processed by StumpWM with
+some additional markup in the form of three letter character entries
+@c need to double up the at-signs in the @code{@@@ function} to escape
+@c them.
+at the beginning of a line. @code{@@@@@@ function} defines functions,
+@code{%%% some-macro} expands to that macro and its docstring, etc.
+Contributors are strongly encouraged to add these items to this manual
+whenever something new is defined in a patch. You can test if your
+texinfo edits are valid by generating them with
+@command{make stumpwm.info}, and viewing the new @file{stumpwm.info} with
+@command{info -f /path/to/stumpwm.info}, or @command{make
+stumpwm.texi} for the raw stuff.
+
+@table @asis
+@item %%% macro
+@item @@@@@@ function
+@item ### variable
+@item $$$ hook
+@item !!! StumpWM command
+@end table
+
+@node Using git with StumpWM, Sending Patches, Adding Documentation and Editing This Manual, Hacking
 @section Hacking:  Using git with StumpWM
 
 For quite a while now, StumpWM has been using the git version control


### PR DESCRIPTION
Makes the macros in the doc not depend on whitespace, so these lines are all the same:
```
@@@ format @c the old way
@@@format @c no space required
@@@      format @c any whitespace accepeted
```
If desired, it is possible to issue a `STYLE-WARNING` when there is anything but a single space.

Was a part of https://github.com/stumpwm/stumpwm/pull/682