### PR TITLE
No warning when calling expose

### DIFF
--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -37,7 +37,7 @@ area."
   (declare (ignore win))
   (let* ((windows (group-windows group))
          (num-win (length windows)))
-    (only)
+    (only :warn-one nil)
     (recursive-tile (min *expose-n-max* num-win) group)))
 
 

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1071,7 +1071,7 @@ space."
 
 (defcommand-alias remove remove-split)
 
-(defcommand (only tile-group) () ()
+(defcommand (only tile-group) (&key (warn-one t)) ()
   "Delete all the frames but the current one and grow it to take up the entire head."
   (let* ((screen (current-screen))
          (group (screen-current-group screen))
@@ -1079,7 +1079,7 @@ space."
          (head (current-head group))
          (frame (copy-frame head)))
     (if (atom (tile-group-frame-head group head))
-        (message "There's only one frame.")
+        (when warn-one (message "There's only one frame."))
         (progn
           (mapc (lambda (w)
                   ;; windows in other frames disappear


### PR DESCRIPTION
Fix bug where the `expose` command warns "There's only one frame." This can be
distracting, since there are likely to be multiple frames.

Now it only warns when `expose` is called on a single window.

# Expose Bug Reproduction:
- Open a few terminal emulators
- `C-t Q` (only)
- `C-t ; expose`
- See warning on the top-right corner.