### PR TITLE
Make colon have pretty select-from-menu regex completion

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -591,8 +591,14 @@ String arguments with spaces may be passed to the command by
 delimiting them with double quotes. A backslash can be used to escape
 double quotes or backslashes inside the string. This does not apply to
 commands taking :REST or :SHELL type arguments."
-  (let ((cmd (completing-read (current-screen) ": " (all-commands) :initial-input (or initial-input ""))))
-    (unless cmd
-      (throw 'error :abort))
-    (when (plusp (length cmd))
-      (eval-command cmd t))))
+  (let* ((commands (all-commands))
+         (cmd (select-from-menu (current-screen)
+                                (mapcar #'list commands)
+                                ": "
+                                (or (position initial-input
+                                              commands
+                                              :test #'string-equal)
+                                    0))))
+    (if cmd
+        (eval-command (car cmd) t)
+        (throw 'error :abort))))

--- a/command.lisp
+++ b/command.lisp
@@ -363,9 +363,10 @@ then describes the symbol."
 
 (define-stumpwm-type :command (input prompt)
   (or (argument-pop input)
-      (completing-read (current-screen)
-                       prompt
-                       (all-commands))))
+      (select-from-menu (current-screen)
+                        (mapcar #'list (all-commands))
+                        prompt
+                        0)))
 
 (define-stumpwm-type :key-seq (input prompt)
   (labels ((update (seq)


### PR DESCRIPTION
Fuzzy regex completion here is superior to invisible completing read.

Addresses #690

[Screenshot of this thing in action](https://spensertruex.com/static/fuzzy-colon.png).

I'd like to show the lambda-lists of these, and to make them less emphasized than the name (since completion should only be on the command name, not the lambda-list). [The second line in this screenshot of the new describe-key shows the how I'd like it to be](https://spensertruex.com/static/describe-command-short.png). But that is a much bigger change to the UI than just adding completion