### PR TITLE
Add generate-condition-doc `&&&`

### DIFF
--- a/manual.lisp
+++ b/manual.lisp
@@ -88,6 +88,16 @@
         t)
       (warn "Symbol ~A not found in package STUMPWM" name))))
 
+(defun generate-condition-doc (s line)
+  (ppcre:register-groups-bind (name) ("^&&& (.*)" line)
+    (dprint 'condition name)
+    (let ((condition (find-symbol (string-upcase name) :stumpwm)))
+      (format s "@deffn {Condition} ~a ~{~a~^ ~}~%~a~&@end deffn~%~%"
+              name
+              (sb-mop:class-slots (class-of condition))
+              (documentation condition 'type))
+      t)))
+
 (defun generate-manual (&key (in #p"stumpwm.texi.in") (out #p"stumpwm.texi"))
   (let ((*print-case* :downcase))
     (with-open-file (os out :direction :output :if-exists :supersede)
@@ -99,4 +109,5 @@
                   (generate-hook-doc os line)
                   (generate-variable-doc os line)
                   (generate-command-doc os line)
+                  (generate-condition-doc os line)
                   (write-line line os)))))))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2769,6 +2769,7 @@ stumpwm.texi} for the raw stuff.
 @item ### variable
 @item $$$ hook
 @item !!! StumpWM command
+@item &&& condition
 @end table
 
 @node Using git with StumpWM, Sending Patches, Adding Documentation and Editing This Manual, Hacking


### PR DESCRIPTION
Adds `&&&` and documents it in the manual. Does not actually document any conditions, just implements the functionality.

[Here is an image showing the condition `stumpwm-error`](https://spensertruex.com/static/condition-example.png). Note that `stumpwm-error` has no slots, so none are shown (but it is implemented).

Need this merged to write a docs section for conditions, thanks.