### PR TITLE
Bugfix merges: describe-command, manual section duplication, gselect

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -363,10 +363,10 @@ then describes the symbol."
 
 (define-stumpwm-type :command (input prompt)
   (or (argument-pop input)
-      (select-from-menu (current-screen)
-                        (mapcar #'list (all-commands))
-                        prompt
-                        0)))
+      (car (select-from-menu (current-screen)
+                             (all-commands)
+                             prompt
+                             0))))
 
 (define-stumpwm-type :key-seq (input prompt)
   (labels ((update (seq)

--- a/group.lisp
+++ b/group.lisp
@@ -496,7 +496,12 @@ the default group formatting and window formatting, respectively."
                (or gfmt *group-format*)
                t (or wfmt *window-format*)))
 
-(defcommand-alias gselect grouplist)
+(defcommand gselect (&optional to-group) (:rest)
+  "Accepts numbers to select a group, otherwise grouplist selects."
+  (if-let ((to-group (when to-group
+                       (select-group (current-screen) to-group))))
+    (switch-to-group to-group)
+    (grouplist)))
 
 (defcommand grouplist (&optional (fmt *group-format*)) (:rest)
   "Allow the user to select a group from a list, like windowlist for groups."

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2200,26 +2200,6 @@ The following is a list of commands that don't really fit in any other
 ### *record-last-msg-override*
 ### *toplevel-io*
 
-@node Interacting With X11, Miscellaneous Commands, Interacting With Unix, Top
-@chapter Interacting With X11
-
-@@@ set-x-selection
-@@@ get-x-selection
-### *x-selection*
-@@@ update-decoration
-
-@node Miscellaneous Commands, Colors, Interacting With X11, Top
-@chapter Miscellaneous Commands
-
-@menu
-* Menus::
-* StumpWM's Data Directory::
-* Debugging StumpWM::
-* Sending a Bug Report::
-* Timers::
-* Getting Help::
-@end menu
-
 @node Menus, StumpWM's Data Directory, Miscellaneous Commands
 @section Menus
 @section Menus


### PR DESCRIPTION
Fix these bugs. `gselect` had to be refactored a bit, since it still needs to support numerical arguments (but call `grouplist` otherwise`).

A couple sections of the manual were duplicated in the last few merges somewhere. This causes the build to fail.

`describe-command` had a bug where `("command")` was being returned from `select-from-menu` without being `car`'d into `"command"`.