### PR TITLE
Add feedback messages to groups and frames

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -550,12 +550,12 @@ to the next group."
              (format nil "You are about to kill non-empty group \"^B^3*~a^n\"
 The windows will be moved to group \"^B^2*~a^n\"
 ^B^6*Confirm?^n " (group-name dead-group) (group-name to-group))))
-            (progn
+            (let ((dead-group-name (group-name dead-group)))
               (switch-to-group to-group)
               (kill-group dead-group to-group)
-              (message "Deleted"))
+              (message "Deleted ~a." dead-group-name))
             (message "Canceled"))
-        (message "There's only one group left"))))
+        (message "There's only one group left."))))
 
 (defcommand gkill-other () ()
 "Kill other groups. All windows in other groups are migrated

--- a/group.lisp
+++ b/group.lisp
@@ -565,8 +565,11 @@ to the current group."
   (let* ((current-group (current-group))
          (groups (remove current-group
                          (screen-groups (current-screen)))))
-    (dolist (dead-group groups)
-      (kill-group dead-group current-group))))
+    (if (null groups)
+        (message "No other groups.")
+        (progn (dolist (dead-group groups)
+                 (kill-group dead-group current-group))
+               (message "Killed other groups.")))))
 
 (defcommand gmerge (from) ((:group "From Group: "))
 "Merge @var{from} into the current group. @var{from} is not deleted."

--- a/group.lisp
+++ b/group.lisp
@@ -389,9 +389,10 @@ numbers."
 (defun group-forward (current list)
   "Switch to the next non-hidden-group in the list, if one
 exists. Returns the new group."
-  (when-let ((next (next-group current (non-hidden-groups list))))
-    (switch-to-group next)
-    next))
+  (if-let ((next (next-group current (non-hidden-groups list))))
+    (progn (switch-to-group next)
+           next)
+    (message "No other group.")))
 
 (defun group-forward-with-window (current list)
   "Switch to the next group in the list, if one exists, and moves the
@@ -442,8 +443,9 @@ window along."
 (defcommand gother () ()
   "Go back to the last group."
   (let ((groups (screen-groups (current-screen))))
-    (when (> (length groups) 1)
-      (switch-to-group (second groups)))))
+    (if (> (length groups) 1)
+        (switch-to-group (second groups))
+        (message "No other group."))))
 
 (defun %grename (name group)
   (let ((group-name (group-name group)))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1131,10 +1131,12 @@ This can be used around a the \"only\" command to avoid the warning message."
   "Given a list of frames focus the next one in the list after
 the current frame."
   (let ((rest (cdr (member (tile-group-current-frame group) frames :test 'eq))))
-    (focus-frame group
-                 (if (null rest)
-                     (car frames)
-                     (car rest)))))
+    (if (only-one-frame-p)
+        (message "No other frames.")
+        (focus-frame group
+                     (if (null rest)
+                         (car frames)
+                         (car rest))))))
 
 (defun focus-next-frame (group)
   (focus-frame-after group (group-frames group)))


### PR DESCRIPTION
This is intended to provide some feedback for commands that silently do nothing in exceptional situations. This kind of thing can be done in a lot of ways, but the standard way in StumpWM is to display a very short message.

# Demo
Try these commands:
- With only one group (probably `Default`). `gnext`. Sends message `No other group.`
- `gkill` your new group. Messages now have periods, and `Deleted` is now `Deleted GROUP-NAME.`.
- `gkill-other` also has the messages `No other groups.` and `Killed other groups.`
- Open an application, focus it, and run `gmove`. Select the current group (ie. "move" it to the current group). The new message `That window is already in the group GROUP-NAME.` is shown. Previously this silently did nothing.
- Run `only`, then `fnext`. The new message `No other frames.` is shown where there was previously silently nothing.
