### PR TITLE
Use color to emphasise the confirm-quit prompt

### DIFF
--- a/user.lisp
+++ b/user.lisp
@@ -217,8 +217,12 @@ such a case, kill the shell command to resume StumpWM."
 
 (defcommand-alias abort keyboard-quit)
 
-(defcommand quit-confirm (&optional (confirm t)) ((:y-or-n "Really close StumpWM? "))
-  (when confirm (quit)))
+(defcommand quit-confirm () ()
+  (when (y-or-n-p (format nil "~@{~a~^~%~}"
+                          "You are about to quit the window manager to TTY."
+                          "Really ^1^Bquit^b^n ^B^2StumpWM^n^b?"
+                          "^B^6Confirm?^n "))
+      (quit)))
 
 (defcommand quit () ()
 "Quit StumpWM."


### PR DESCRIPTION
The rationale is that it could be *really bad* to quit accidentally.
Modeled on the `gkill` color scheme when closing a non-empty group. [Here is an image of this prompt](https://spensertruex.com/static/really-quit-or-die.png).

I'm against flashy colours in most cases, but this one is special.