### PR TITLE
Make messages punctuation more uniform

### DIFF
--- a/fdump.lisp
+++ b/fdump.lisp
@@ -107,21 +107,21 @@
 (defcommand dump-group-to-file (file) ((:rest "Dump To File: "))
   "Dumps the frames of the current group of the current screen to the named file."
   (dump-to-file (dump-group (current-group)) file)
-  (message "Group dumped"))
+  (message "Group dumped."))
 
 (defcommand-alias dump-group dump-group-to-file)
 
 (defcommand dump-screen-to-file (file) ((:rest "Dump To File: "))
   "Dumps the frames of all groups of the current screen to the named file"
   (dump-to-file (dump-screen (current-screen)) file)
-  (message "Screen dumped"))
+  (message "Screen dumped."))
 
 (defcommand-alias dump-screen dump-screen-to-file)
 
 (defcommand dump-desktop-to-file (file) ((:rest "Dump To File: "))
   "Dumps the frames of all groups of all screens to the named file"
   (dump-to-file (dump-desktop) file)
-  (message "Desktop dumped"))
+  (message "Desktop dumped."))
 
 (defcommand-alias dump-desktop dump-desktop-to-file)
 
@@ -216,7 +216,7 @@
        (restore-desktop dump)
        (message "Desktop restored."))
       (t
-       (message "Don't know how to restore ~a" dump)))))
+       (message "Don't know how to restore ~a." dump)))))
 
 (defcommand-alias restore restore-from-file)
 

--- a/group.lisp
+++ b/group.lisp
@@ -460,10 +460,10 @@ window along."
 (defcommand grename (name) ((:string "New name for group: "))
   "Rename the current group."
   (cond ((find-group (current-screen) name)
-         (message "^1*^BError: Name already exists"))
+         (message "^1*^BError: Name already exists."))
         ((or (zerop (length name))
              (string= name "."))
-         (message "^1*^BError: Name cannot be empty name"))
+         (message "^1*^BError: Name cannot be empty name."))
         (t (%grename name (current-group)))))
 
 (defun echo-groups (screen fmt &optional verbose (wfmt *window-format*))
@@ -551,9 +551,9 @@ The windows will be moved to group \"^B^2*~a^n\"
             (progn
               (switch-to-group to-group)
               (kill-group dead-group to-group)
-              (message "Deleted"))
-            (message "Canceled"))
-        (message "There's only one group left"))))
+              (message "Deleted."))
+            (message "Canceled."))
+        (message "There's only one group left."))))
 
 (defcommand gkill-other () ()
 "Kill other groups. All windows in other groups are migrated

--- a/help.lisp
+++ b/help.lisp
@@ -109,7 +109,7 @@
     (message-no-timeout (describe-command-to-stream cmd nil))
     (cond ((and (help-key-p keys)
                 (cdr printed-key))
-           (message "~{~A~^ ~} shows the bindings for the prefix map under ~{~A~^ ~}.~%"
+           (message "~{~A~^ ~} shows the bindings for the prefix map under ~{~A~^ ~}."
                     printed-key (butlast printed-key)))
           ((cancel-key-p keys)
            (message "Any command ending in ~A is meant to cancel any command in progress \"ABORT\".~%"
@@ -159,9 +159,9 @@
 (defun where-is-to-stream (cmd stream)
   (let ((cmd (string-downcase cmd)))
     (if-let ((bindings (loop for map in (top-maps) append (search-kmap cmd map))))
-      (format stream "\"~a\" is on ~{~a~^, ~}" cmd
+      (format stream "\"~a\" is on ~{~a~^, ~}." cmd
               (mapcar 'print-key-seq bindings))
-      (format stream "Command \"~a\" is not currently bound" cmd))))
+      (format stream "Command \"~a\" is not currently bound." cmd))))
 
 (defcommand where-is (cmd) ((:rest "Where is command: "))
   "Print the key sequences bound to the specified command."

--- a/input.lisp
+++ b/input.lisp
@@ -810,7 +810,7 @@ input (pressing Return), nil otherwise."
 ;;     mod))
 
 (defun mod->string (state)
-  "Convert a stump modifier list to a string"
+  "Convert a stump modifier list to a string."
   (let ((alist '((:alt . "A-") (:meta . "M-") (:hyper . "H-") (:super . "S-"))))
     (apply #'concatenate 'string (mapcar (lambda (x) (cdr (assoc x alist))) state))))
 
@@ -824,8 +824,8 @@ input (pressing Return), nil otherwise."
 ;;   (values (xlib:keycode->keysym *display* code 0) (x11mod->stumpmod state)))
 
 (defun y-or-n-p (message)
-  "ask a \"y or n\" question on the current screen and return T if the
-user presses 'y'"
+  "Ask a \"y or n\" question on the current screen and return T if the
+user presses 'y'."
   (message "~a(y or n) " message)
   (char= (read-one-char (current-screen))
         #\y))
@@ -840,6 +840,6 @@ user presses 'yes'"
                                    :completions
                                    '("yes" "no")))
         until (find line '("yes" "no") :test 'string-equal)
-        do (message "Please answer yes or no")
+        do (message "Please answer yes or no.")
            (sleep 1)
         finally (return (string-equal line "yes"))))

--- a/interactive-keymap.lisp
+++ b/interactive-keymap.lisp
@@ -28,12 +28,12 @@
 
 (defun enter-interactive-keymap (kmap name)
   "Enter interactive mode"
-  (message "~S started" name)
+  (message "~S started." name)
   (push-top-map kmap))
 
 (defun exit-interactive-keymap (name)
   "Exits interactive mode"
-  (message "~S finished" name)
+  (message "~S finished." name)
   (pop-top-map))
 
 (defcommand call-and-exit-kmap (command exit-command) ((:command "command to run: ")

--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -110,7 +110,7 @@ EXAMPLE:
 
 (defcommand send-raw-key () ()
   "Prompts for a key and forwards it to the CURRENT-WINDOW."
-  (message "Press a key to send")
+  (message "Press a key to send: ")
   (let* ((screen (current-screen))
          (win (screen-current-window screen))
          (k (with-focus (screen-key-window screen)

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -74,7 +74,7 @@ further up. "
      (throw :top-level :quit))
      ;; all other asynchronous errors are printed.
      (asynchronous
-      (message "Caught Asynchronous X Error: ~s ~s" error-key key-vals))
+      (message "Caught Asynchronous X Error: ~s ~s." error-key key-vals))
      (t
       (apply 'error error-key :display display :error-key error-key key-vals))))
 
@@ -250,9 +250,9 @@ further up. "
                  (multiple-value-bind (success err rc) (load-rc-file)
                    (if success
                        (and *startup-message* (message *startup-message* (print-key *escape-key*)))
-                       (message "^B^1*Error loading ^b~A^B: ^n~A" rc err))))
+                       (message "^B^1*Error loading ^b~A^B: ^n~A." rc err))))
                (when *last-unhandled-error*
-                 (message-no-timeout "^B^1*StumpWM Crashed With An Unhandled Error!~%Copy the error to the clipboard with the 'copy-unhandled-error' command.~%^b~a^B^n~%~%~a"
+                 (message-no-timeout "^B^1*StumpWM Crashed With An Unhandled Error!~%Copy the error to the clipboard with the 'copy-unhandled-error' command.~%^b~a^B^n~%~%~a."
                           (first *last-unhandled-error*) (second *last-unhandled-error*)))
                (mapc 'process-existing-windows *screen-list*)
                ;; We need to setup each screen with its current window. Go

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -417,8 +417,8 @@ frame. Possible values are:
     (if match
         (progn
           (setf *window-placement-rules* (delete match *window-placement-rules*))
-          (message "Rule forgotten"))
-        (message "No matching rule"))))
+          (message "Rule forgotten."))
+        (message "No matching rule."))))
 
 (defcommand (dump-window-placement-rules tile-group) (file) ((:rest "Filename: "))
   "Dump *window-placement-rules* to FILE."
@@ -473,7 +473,7 @@ specified to override the default window formatting."
   (let* ((group (current-group))
          (frame (tile-group-current-frame group)))
     (if (null (frame-windows group frame))
-        (message "No Managed Windows")
+        (message "No Managed Windows.")
         (let ((window (select-window-from-menu (frame-sort-windows group frame) fmt)))
           (if window
               (group-focus-window group window)

--- a/user.lisp
+++ b/user.lisp
@@ -312,7 +312,7 @@ current frame instead of switching to the window."
   (message "Reloading StumpWM...")
   #+asdf (with-restarts-menu
              (asdf:operate 'asdf:load-op :stumpwm))
-  #-asdf (message "^B^1*Sorry, StumpWM can only be reloaded with asdf (for now.)")
+  #-asdf (message "^B^1*Sorry, StumpWM can only be reloaded with asdf (for now).")
   #+asdf (message "Reloading StumpWM...^B^2*Done^n."))
 
 (defcommand emacs () ()

--- a/window.lisp
+++ b/window.lisp
@@ -812,7 +812,7 @@ needed."
         (if (getf placement-data :raise)
           (switch-to-group (window-group window))
           (unless *suppress-window-placement-indicator*
-            (message "Placing window ~a in group ~a" (window-name window) (group-name (window-group window)))))
+            (message "Placing window ~a in group ~a." (window-name window) (group-name (window-group window)))))
         (apply 'run-hook-with-args *place-window-hook* window (window-group window) placement-data)))
     ;; must call this after the group slot is set for the window.
     (grab-keys-on-window window)
@@ -1049,7 +1049,7 @@ window. Default to the current window. if
   "Override the current window's title."
   (if (current-window)
       (setf (window-user-title (current-window)) title)
-      (message "No Focused Window")))
+      (message "No Focused Window.")))
 
 (defcommand select-window (query) ((:window-name "Select: "))
   "Switch to the first window that starts with @var{query}."
@@ -1259,7 +1259,7 @@ be used to override the default window formatting."
   "Display information about the current window."
   (if (current-window)
       (message "~a" (format-expand *window-formatters* fmt (current-window)))
-      (message "No Current Window")))
+      (message "No Current Window.")))
 
 (defcommand refresh () ()
   "Refresh current window without changing its size."


### PR DESCRIPTION
* Message should end in a period, just like the ANSI spec for errors.
* Also should not end in a fresh line.
* When prompting for user input a colon is best.

Just trying to improve the consistency of the UI. I'd also be happy if none of them had periods, so long as it was consistent. I wouldn't want to be distracted by said inconsistency.