### PR TITLE
Improve describe-function and variable with pretty emacs-like output

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -357,7 +357,7 @@ then describes the symbol."
   (multiple-value-bind (sym pkg var)
       (lookup-symbol (argument-pop-or-read input prompt))
     (if (fboundp sym)
-        (symbol-function sym)
+        sym
         (throw 'error (format nil "The symbol ~A::~A is not bound to any function."
                               (package-name pkg) var)))))
 

--- a/help.lisp
+++ b/help.lisp
@@ -24,6 +24,7 @@
 
 (in-package #:stumpwm)
 
+(export '(*help-max-height* *message-max-width*))
 (defvar *message-max-width* 80
   "The maximum width of a message before it wraps.")
 (defvar *help-max-height* 10

--- a/help.lisp
+++ b/help.lisp
@@ -26,6 +26,8 @@
 
 (defvar *message-max-width* 80
   "The maximum width of a message before it wraps.")
+(defvar *help-max-height* 10
+  "Maximum number of lines for help to display.")
 
 (defun columnize (list columns &key col-aligns (pad 1) (char #\Space) (align :left))
   ;; only somewhat nasty
@@ -116,17 +118,39 @@
                     (lastcar printed-key)))
           (t (message "~{~A~^ ~} is not bound." printed-key)))))
 
+(defun describe-variable-to-stream (var stream)
+  "Write the help for the variable to the stream."
+  (format stream "variable:^5 ~a^n~%~a~%Its value is:~%~a."
+          var
+          (documentation var 'variable)
+          (let* ((value (format nil "~a" (symbol-value var)))
+                 (split (split-string value (format nil "~%"))))
+            (if (> (1+ *help-max-height*)
+                   (length split))
+                value
+                (format nil "~a.."
+                        (wrap (format nil "~{~a~^~%~}"
+                                      (take *help-max-height* split))))))))
+
 (defcommand describe-variable (var) ((:variable "Describe Variable: "))
 "Print the online help associated with the specified variable."
   (message-no-timeout "~a"
                       (with-output-to-string (s)
-                        (describe var s))))
+                        (describe-variable-to-stream var s))))
+
+(defun describe-function-to-stream (fn stream)
+  "Write the help for the function to the stream."
+  (format stream "function:^5 ~a^n~%" (string-downcase (symbol-name fn)))
+  (when-let ((lambda-list (sb-introspect:function-lambda-list
+                           (symbol-function fn))))
+    (format stream "(^5~a ^B~{~a~^ ~}^b^n)~&~%" (string-downcase (symbol-name fn)) lambda-list))
+  (format stream "~&~a"(documentation fn 'function)))
 
 (defcommand describe-function (fn) ((:function "Describe Function: "))
 "Print the online help associated with the specified function."
   (message-no-timeout "~a"
                       (with-output-to-string (s)
-                        (describe fn s))))
+                        (describe-function-to-stream fn s))))
 
 (defun describe-command-to-stream (com stream)
   "Write the help for the command to the stream."

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1473,6 +1473,7 @@ return a ``nil'' value in those cases, and let the command handle that.
 @@@ err
 @@@ wrap
 ### *message-max-width*
+### *help-max-height*
 !!! colon
 
 %%% with-restarts-menu


### PR DESCRIPTION
* Using SBCL's `describe` for this purpose has some problems, and is much uglier than this. For example, it is possible to color the function/variable names, control width and height, remove unhelpful information (for a StumpWM user) and add an elipsis to the current value if it is too large.
* describe-var shows the value of the variable, but limits it to `*help-max-height*` lines, when it makes an elipsis (see screenshot).

Mandatory screenshots:
- [describe-function](https://spensertruex.com/static/describe-function.png)
- [describe-variable](https://spensertruex.com/static/describe-variable.png)