### PR TITLE
Debug prompts for describe-* commands

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -370,7 +370,7 @@ then describes the symbol."
 
 (define-stumpwm-type :key-seq (input prompt)
   (labels ((update (seq)
-             (message "~a: ~{~a ~}"
+             (message "~a ~{~a ~}"
                       prompt
                       (mapcar 'print-key (reverse seq)))))
     (let ((rest (argument-pop-rest input)))
@@ -595,7 +595,7 @@ commands taking :REST or :SHELL type arguments."
   (let* ((commands (all-commands))
          (cmd (select-from-menu (current-screen)
                                 (mapcar #'list commands)
-                                ": "
+                                ":"
                                 (or (position initial-input
                                               commands
                                               :test #'string-equal)

--- a/help.lisp
+++ b/help.lisp
@@ -99,7 +99,7 @@
   "If a key is the cancelling key binding."
   (final-key-p keys '("C-g")))
 
-(defcommand describe-key (keys) ((:key-seq "Describe Key: "))
+(defcommand describe-key (keys) ((:key-seq "Describe Key:"))
   "Either interactively type the key sequence or supply it as text. This
   command prints the command bound to the specified key sequence."
   (if-let ((cmd (loop for map in (top-maps)
@@ -116,13 +116,13 @@
                     (lastcar printed-key)))
           (t (message "~{~A~^ ~} is not bound." printed-key)))))
 
-(defcommand describe-variable (var) ((:variable "Describe Variable: "))
+(defcommand describe-variable (var) ((:variable "Describe Variable:"))
 "Print the online help associated with the specified variable."
   (message-no-timeout "~a"
                       (with-output-to-string (s)
                         (describe var s))))
 
-(defcommand describe-function (fn) ((:function "Describe Function: "))
+(defcommand describe-function (fn) ((:function "Describe Function:"))
 "Print the online help associated with the specified function."
   (message-no-timeout "~a"
                       (with-output-to-string (s)
@@ -149,7 +149,7 @@
           *message-max-width*
           stream)))
 
-(defcommand describe-command (com) ((:command "Describe Command: "))
+(defcommand describe-command (com) ((:command "Describe Command:"))
   "Print the online help associated with the specified command."
   (if (null (get-command-structure com nil))
       (message-no-timeout "Error: Command \"~a\" not found."


### PR DESCRIPTION
Remove extra spaces, and extra colon ':' from describe-key.