### PR TITLE
Change `commands` function to fuzzy search on 3 columns

### DIFF
--- a/menu-declarations.lisp
+++ b/menu-declarations.lisp
@@ -93,7 +93,11 @@
              :initform 0)
    (keymap :accessor menu-keymap
            :initform nil
-           :documentation "Keymap used for navigating the menu." ))
+           :documentation "Keymap used for navigating the menu." )
+   (columns :accessor menu-columns
+            :initarg :columns
+            :initform 1
+            :documentation "How many columns to show in the output."))
   (:documentation "Base class for holding the state of a menu"))
 
 (defmethod initialize-instance :after ((m menu) &key additional-keymap)

--- a/menu-definitions.lisp
+++ b/menu-definitions.lisp
@@ -291,17 +291,18 @@ more spaces; ARGUMENT-POP is used to split the string)."
                        (len (length (menu-table menu)))
                        (prompt-line (menu-prompt-line menu))
                        (strings (get-menu-items menu))
-                       (highlight (- sel start)))
+                       (highlight (- sel start))
+                       (columns (menu-columns menu)))
                   (unless (zerop start)
                     (setf strings (cons "..." strings))
                     (incf highlight))
                   (unless (= len end)
                     (setf strings (nconc strings '("..."))))
                   (when prompt-line
-                    (push prompt-line strings)
                     (incf highlight))
                   (run-hook-with-args *menu-selection-hook* menu)
-                  (echo-string-list screen strings highlight))
+                  (echo-string-list-columns screen prompt-line
+                                            strings columns highlight))
                 (multiple-value-bind (action key-seq) (read-from-keymap (menu-keymap menu))
                   (if action
                       (progn (funcall action menu)
@@ -313,7 +314,8 @@ more spaces; ARGUMENT-POP is used to split the string)."
 (defun select-from-menu (screen table &optional (prompt "Search:")
                                         (initial-selection 0)
                                         extra-keymap
-                                        (filter-pred #'menu-item-matches-regexp))
+                                        (filter-pred #'menu-item-matches-regexp)
+                                        (columns 1))
   "Prompt the user to select from a menu on SCREEN. TABLE can be
 a list of values or a nested list. If it's a nested list, the first
 element in the sublist is displayed in the menu. What is displayed
@@ -344,7 +346,8 @@ Returns the selected element in TABLE or nil if aborted. "
                                :view-start 0
                                :view-end 0
                                :additional-keymap extra-keymap
-                               :FILTER-PRED filter-pred)))
+                               :FILTER-PRED filter-pred
+                               :columns columns)))
       (run-menu screen menu))))
 
 (defun select-from-batch-menu (screen table &key (prompt "Select:")

--- a/message-window.lisp
+++ b/message-window.lisp
@@ -289,6 +289,20 @@ When NEW-ON-BOTTOM-P is non-nil, new messages are queued at the bottom."
     (dformat 5 "Outputting a message:~%~{        ~a~%~}" strings)
     (apply 'run-hook-with-args *message-hook* strings)))
 
+(defun echo-string-list-columns (screen prompt strings columns
+                                 &rest highlights)
+  "Echo a list of strings with a prompt.
+Use a NIL prompt for no prompt."
+  (let ((columized (columnize strings
+                    (if (< columns (length strings))
+                        columns
+                        1))))
+    (apply #'echo-string-list screen
+           (if prompt
+               (cons prompt columized)
+               columized)
+           highlights)))
+
 (defun echo-string (screen msg)
   "Display @var{string} in the message bar on @var{screen}. You almost always want to use @command{message}."
   (echo-string-list screen (split-string msg (string #\Newline))))


### PR DESCRIPTION
This makes `describe-command` and `commands` the same, except `commands` shows
more commands at once.

This makes `commands` a useful function. I felt inclined to allow selecting multiple commands somehow, then calling `describe-command` on all of them, but I think the UI for such a thing would be too complicated and clunky.

Alternatives to this:
- Alias `commands` to `describe-command`, abandoning the three column layout.
- Alias `describe-command` to `commands`, abandoning the single column layout.
-  Just remove `commands` entirely. If this is the choice, I think it would be a nice compromise to make `describe-command` use a two-column layout.
- I don't think leaving `commands` as-is is a very good alternative, since it is mostly useless as-is.

[screenshot](https://spensertruex.com/static/commands.png)