### PR TITLE
Change `commands` and `describe-command` to fuzzy search on 2 cols

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -64,14 +64,21 @@
                         (or (columnize data cols) '("(EMPTY MAP)")))))
 
 (defcommand commands () ()
-"List all available commands."
+  "Print the online help associated with the specified command."
   (let* ((screen (current-screen))
          (data (all-commands))
          (cols (ceiling (length data)
                         (truncate (- (head-height (current-head)) (* 2 (screen-msg-border-width screen)))
-                                  (font-height (screen-font screen))))))
-    (message-no-timeout "~{~a~^~%~}"
-                        (columnize data cols))))
+                                  (font-height (screen-font screen)))))
+         (selection (select-from-menu screen
+                                      data
+                                      "Describe Command:"
+                                      0
+                                      nil
+                                      #'stumpwm::menu-item-matches-regexp
+                                      2)))
+    (when selection
+      (message-no-timeout "~a" (describe-command-to-stream (car selection) nil)))))
 
 (defun wrap (words &optional (max-col *message-max-width*) stream)
   "Word wrap at the MAX-COL."
@@ -130,31 +137,31 @@
 
 (defun describe-command-to-stream (com stream)
   "Write the help for the command to the stream."
-  (let* ((deref (dereference-command-symbol com))
-         (struct (get-command-structure com nil))
-         (name (command-name struct)))
-    (wrap (concat
-           (unless (eq deref struct)
-             (format nil "\"~a\" is an alias for the command \"~a\":~%"
-                     (command-alias-from deref)
-                     name))
-           (when-let ((message (where-is-to-stream name nil)))
-             (format nil "~&~A~&" message))
-           (when-let ((lambda-list (sb-introspect:function-lambda-list
-                                  (symbol-function name))))
-             (format nil "~%^5~a ^B~{~a~^ ~}^b^n~&~%"
-                     name
-                     lambda-list))
-           (format nil "~&~a"(documentation name 'function)))
-          *message-max-width*
-          stream)))
+  (if (null com)
+      (message "Abort.")
+      (let* ((deref (dereference-command-symbol com))
+             (struct (get-command-structure com nil))
+             (name (command-name struct)))
+        (if (null struct)
+            (format stream "Error: Command \"~a\" not found."
+                    (command-name com))
+            (wrap (concat
+                   (unless (eq deref struct)
+                     (format nil "\"~a\" is an alias for the command \"~a\":~%"
+                             (command-alias-from deref)
+                             name))
+                   (when-let ((message (where-is-to-stream name nil)))
+                     (format nil "~&~A~&" message))
+                   (when-let ((lambda-list (sb-introspect:function-lambda-list
+                                            (symbol-function name))))
+                     (format nil "~%^5~a ^B~{~a~^ ~}^b^n~&~%"
+                             name
+                             lambda-list))
+                   (format nil "~&~a"(documentation name 'function)))
+                  *message-max-width*
+                  stream)))))
 
-(defcommand describe-command (com) ((:command "Describe Command: "))
-  "Print the online help associated with the specified command."
-  (if (null (get-command-structure com nil))
-      (message-no-timeout "Error: Command \"~a\" not found."
-                          (command-name com))
-      (message-no-timeout "~a" (describe-command-to-stream com nil))))
+(defcommand-alias describe-command commands)
 
 (defun where-is-to-stream (cmd stream)
   (let ((cmd (string-downcase cmd)))

--- a/menu-declarations.lisp
+++ b/menu-declarations.lisp
@@ -93,7 +93,11 @@
              :initform 0)
    (keymap :accessor menu-keymap
            :initform nil
-           :documentation "Keymap used for navigating the menu." ))
+           :documentation "Keymap used for navigating the menu." )
+   (columns :accessor menu-columns
+            :initarg :columns
+            :initform 1
+            :documentation "How many columns to show in the output."))
   (:documentation "Base class for holding the state of a menu"))
 
 (defmethod initialize-instance :after ((m menu) &key additional-keymap)

--- a/menu-definitions.lisp
+++ b/menu-definitions.lisp
@@ -291,17 +291,18 @@ more spaces; ARGUMENT-POP is used to split the string)."
                        (len (length (menu-table menu)))
                        (prompt-line (menu-prompt-line menu))
                        (strings (get-menu-items menu))
-                       (highlight (- sel start)))
+                       (highlight (- sel start))
+                       (columns (menu-columns menu)))
                   (unless (zerop start)
                     (setf strings (cons "..." strings))
                     (incf highlight))
                   (unless (= len end)
                     (setf strings (nconc strings '("..."))))
                   (when prompt-line
-                    (push prompt-line strings)
                     (incf highlight))
                   (run-hook-with-args *menu-selection-hook* menu)
-                  (echo-string-list screen strings highlight))
+                  (echo-string-list-columns screen prompt-line
+                                            strings columns highlight))
                 (multiple-value-bind (action key-seq) (read-from-keymap (menu-keymap menu))
                   (if action
                       (progn (funcall action menu)
@@ -313,7 +314,8 @@ more spaces; ARGUMENT-POP is used to split the string)."
 (defun select-from-menu (screen table &optional (prompt "Search:")
                                         (initial-selection 0)
                                         extra-keymap
-                                        (filter-pred #'menu-item-matches-regexp))
+                                        (filter-pred #'menu-item-matches-regexp)
+                                        (columns 1))
   "Prompt the user to select from a menu on SCREEN. TABLE can be
 a list of values or a nested list. If it's a nested list, the first
 element in the sublist is displayed in the menu. What is displayed
@@ -344,7 +346,8 @@ Returns the selected element in TABLE or nil if aborted. "
                                :view-start 0
                                :view-end 0
                                :additional-keymap extra-keymap
-                               :FILTER-PRED filter-pred)))
+                               :FILTER-PRED filter-pred
+                               :columns columns)))
       (run-menu screen menu))))
 
 (defun select-from-batch-menu (screen table &key (prompt "Select:")

--- a/message-window.lisp
+++ b/message-window.lisp
@@ -289,6 +289,20 @@ When NEW-ON-BOTTOM-P is non-nil, new messages are queued at the bottom."
     (dformat 5 "Outputting a message:~%~{        ~a~%~}" strings)
     (apply 'run-hook-with-args *message-hook* strings)))
 
+(defun echo-string-list-columns (screen prompt strings columns
+                                 &rest highlights)
+  "Echo a list of strings with a prompt.
+Use a NIL prompt for no prompt."
+  (let ((columized (columnize strings
+                    (if (< columns (length strings))
+                        columns
+                        1))))
+    (apply #'echo-string-list screen
+           (if prompt
+               (cons prompt columized)
+               columized)
+           highlights)))
+
 (defun echo-string (screen msg)
   "Display @var{string} in the message bar on @var{screen}. You almost always want to use @command{message}."
   (echo-string-list screen (split-string msg (string #\Newline))))


### PR DESCRIPTION
This makes `describe-command` and `commands` the same function, and
`commands` more useful.
[screenshot](https://spensertruex.com/static/commands-2col.png)
Since `columns` is now a menu-entry, it should be easier to use this for changing the `C-t ?` display to also use completion (since it is a 4 column thing).