### PR TITLE
Remove `commands` since `describe-command` does that already

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -63,16 +63,6 @@
                         (print-key-seq key-seq)
                         (or (columnize data cols) '("(EMPTY MAP)")))))
 
-(defcommand commands () ()
-"List all available commands."
-  (let* ((screen (current-screen))
-         (data (all-commands))
-         (cols (ceiling (length data)
-                        (truncate (- (head-height (current-head)) (* 2 (screen-msg-border-width screen)))
-                                  (font-height (screen-font screen))))))
-    (message-no-timeout "~{~a~^~%~}"
-                        (columnize data cols))))
-
 (defun wrap (words &optional (max-col *message-max-width*) stream)
   "Word wrap at the MAX-COL."
   ;; Format insanity edited from Gene Michael Stover's "Advanced Use of Lisp's

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1454,7 +1454,6 @@ return a ``nil'' value in those cases, and let the command handle that.
 !!! restart-hard
 !!! restart-soft
 !!! lastmsg
-!!! commands
 !!! keyboard-quit
 !!! quit
 !!! reload


### PR DESCRIPTION
`describe-command` has fuzzy completion of command names, so a command that does
a dumb display of all the commands available is not required.