### PR TITLE
Add input line completion with fuzzy complete

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -363,10 +363,11 @@ then describes the symbol."
 
 (define-stumpwm-type :command (input prompt)
   (or (argument-pop input)
-      (car (select-from-menu (current-screen)
-                             (all-commands)
-                             prompt
-                             0))))
+      (car-safe (select-from-menu (current-screen)
+                                  (all-commands)
+                                  prompt
+                                  0))
+      (throw 'error :abort)))
 
 (define-stumpwm-type :key-seq (input prompt)
   (labels ((update (seq)
@@ -601,5 +602,5 @@ commands taking :REST or :SHELL type arguments."
                                               :test #'string-equal)
                                     0))))
     (if cmd
-        (eval-command (car cmd) t)
+        (eval-command cmd t)
         (throw 'error :abort))))

--- a/menu-declarations.lisp
+++ b/menu-declarations.lisp
@@ -149,6 +149,9 @@ If nil, then all chars are allowed"))
       (setf table (mapcar #'process-entry table)))
     (push *batch-menu-map* keymap)))
 
+(defgeneric menu-clear (menu)
+  (:documentation "Empty the input line."))
+
 (defgeneric menu-up (menu)
   (:documentation "Move menu cursor up"))
 
@@ -176,6 +179,10 @@ Must signal :menu-quit with the result."))
 Must signal :menu-quit with the result."))
 
 ;; here for single-menu
+
+(defgeneric menu-complete (menu)
+  (:documentation "Action to complete the current input on the top item."))
+
 (defgeneric menu-backspace (menu)
   (:documentation "What occurs when backspace is pressed in a menu"))
 


### PR DESCRIPTION
* Set the input line for scrolling one element at a time.
* Tab-complete on the top item.
* safe-car in describe-command (bugfix).
* Add deletion command C-DEL to clear the prompt line.
#713

The intended way to use this is to type a partial command, move to a completion with `C-n` and `C-p`, using `C-TAB` to complete and `RET` to just run it.
