### PR TITLE
Fix frame switching for multi-head setups

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1131,7 +1131,7 @@ This can be used around a the \"only\" command to avoid the warning message."
   "Given a list of frames focus the next one in the list after
 the current frame."
   (let ((rest (cdr (member (tile-group-current-frame group) frames :test 'eq))))
-    (if (only-one-frame-p)
+    (if (= (length frames) 1)
         (message "No other frames.")
         (focus-frame group
                      (if (null rest)


### PR DESCRIPTION
As per documentation `only-one-frame-p` verifies if the **current head** has a single frame. `focus-frame-after` also works with multiple heads, so [this change](https://github.com/stumpwm/stumpwm/commit/29d4490f3a84f6e7cac96df5c11600e4d9645893#diff-4576d6a1869074a91fd1368f290a9279R1134) breaks frame switching on multi-head setups (where there can be one frame maximized on one head, yet there being multiple frames in total). I'm not sure if my proposed change shows the message as intended, because I only have multi-head setups where there are always multiple frames in total. Could someone please try if this is a suitable replacement for the original change? Thanks!