### PR TITLE
Removing Linux-only function reference from stumpwm.texi.in

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2153,7 +2153,6 @@ multiplexer to actually run it.
 !!! getsel
 !!! putsel
 !!! copy-unhandled-error
-@@@ read-line-from-sysfs
 @@@ define-stumpwm-command
 !!! set-contrib-dir
 


### PR DESCRIPTION
Since the read-line-from-sysfs function is 1) a temporary workaround for
GNU/Linux and 2) causing build problems outside of GNU/Linux, remove it from
stumpwm.texi.in. This solves issue #722.

Function documentation:

   On GNU/Linux some contribs use sysfs to figure out useful info for the
   user. SBCL up to at least 1.0.16 (but probably much later) has a problem
   handling files in sysfs caused by SBCL's slightly unusual handling of files
   in general and Linux' sysfs violating POSIX. When this situation is resolved,
   this function may be removed.