### PR TITLE
Fix bug in GMOVE-AND-FOLLOW command

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -526,7 +526,7 @@ the default group formatting and window formatting, respectively."
   "Move the current window to the specified group, and switch to it."
   (let ((window (current-window)))
     (gmove to-group)
-    (gselect to-group)
+    (switch-to-group to-group)
     (when window (really-raise-window window))))
 
 (defcommand gmove-marked (to-group) ((:group "To Group: "))


### PR DESCRIPTION
GSELECT command doesn't accept a group as argument. So
GMOVE-AND-FOLLOW needs to call SWITCH-TO-GROUP function.

Fix #731