### PR TITLE
Suppress displaying completions of "" and note truncated completion list

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -42,10 +42,12 @@
 ;;; General Utilities
 
 (defun take (n list)
-  "Returns a list with the first n elements of the given list."
-  (loop repeat n
-        for x in list
-        collect x))
+  "Returns a list with the first n elements of the given list, and the
+remaining tail of the list as a second value."
+  (loop for l on list
+        repeat n
+        collect (car l) into result
+        finally (return (values result l))))
 
 ;; This could use a much more efficient algorithm.
 ;; But for our purposes with small lists it's likely ok.
@@ -376,6 +378,26 @@ match with an element of the completions."
      (* (font-height font) index)
      (font-ascent font)))
 
+
+(defun get-completion-preview-list (input-line all-completions)
+  (if (string= "" input-line)
+      '()
+      (multiple-value-bind (completions more)
+          (take *maximum-completions*
+                (remove-duplicates
+                  (remove-if
+                    (lambda (str)
+                      (or (string= str "")
+                          (< (length str) (length input-line))
+                          (string/= input-line
+                                    (subseq str 0 (length input-line)))))
+                    all-completions)
+                  :test #'string=))
+        (if more
+            (append (butlast completions)
+                    (list (format nil "... and ~D more" (1+ (length more)))))
+            completions))))
+
 (defun draw-input-bucket (screen prompt input &optional (tail "") errorp)
   "Draw to the screen's input window the contents of input."
   (let* ((gcontext (screen-message-gc screen))
@@ -384,16 +406,7 @@ match with an element of the completions."
          (prompt-lines (ppcre:split #\Newline prompt))
          (prompt-lines-length (length prompt-lines))
          (input-line (input-line-string input))
-         (completions (remove-duplicates
-                       (take *maximum-completions*
-                             (remove-if
-                              (lambda (str)
-                                (or (string= str "")
-                                    (< (length str) (length input-line))
-                                    (string/= input-line
-                                              (subseq str 0 (length input-line)))))
-                              *input-completions*))
-                       :test #'string=))
+         (completions (get-completion-preview-list input-line *input-completions*))
          (completions-length (length completions))
          (prompt-offset (text-line-width font
                                          (first (last prompt-lines))


### PR DESCRIPTION
This patch does two (possibly controversial) things:

1. Suppress showing *all* possible completions when the user hasn't typed anything at all yet.
2. If the completion list is truncated to fit `*maximum-completions*`, replace the last completion with `... and N more`.

I added item 1 is because I find it very disconcerting to immediately have a giant list of words immediately thrown at me when I open a prompt.  It *is* cut down to fit `*maximum-completions*`, but that means what I end up seeing is the first N alphabetical items every single time, which doesn't seem super helpful.  This patch delays showing the list of completions until the user has at least typed *something*.

I added item 2 because if I get a list of completions that looks roughly like it's around the maximum length I've set, I can't be sure whether I'm seeing *all* my options or whether there are some I'm not seeing because they were truncated off.
