### PR TITLE
Bugfix: describe-key for binding with args

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -109,7 +109,11 @@
                       for cmd = (lookup-key-sequence map keys)
                       when cmd return cmd))
            (printed-key (mapcar 'print-key keys)))
-    (message-no-timeout (describe-command-to-stream cmd nil))
+    (let ((cmd-without-args (argument-pop
+                              (make-argument-line :string cmd :start 0))))
+      (message-no-timeout "~{~A~^ ~} is bound to \"~A\".~%~A"
+                          printed-key cmd
+                          (describe-command-to-stream cmd-without-args nil)))
     (cond ((and (help-key-p keys)
                 (cdr printed-key))
            (message "~{~A~^ ~} shows the bindings for the prefix map under ~{~A~^ ~}."


### PR DESCRIPTION
Since commit afe8d38 _describe-key_ fails for a key that is bound to a command with arguments.

Example: `C-t h k C-t F1` gives the error message
_Error In Command 'describe-key': The value
NIL
is not of type
STUMPWM::COMMAND_

This patch restores the old message (binding with arguments) and adds the details introduced by commit afe8d38 for the underlying command:
_C-t F1 is bound to "gselect 1".
"gselect" is on C-t g quoteright.
GSELECT &OPTIONAL TO-GROUP
Accepts numbers to select a group, otherwise grouplist selects._