### PR TITLE
Add Emacs-esq completion when inputing commands via colon

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -592,8 +592,15 @@ String arguments with spaces may be passed to the command by
 delimiting them with double quotes. A backslash can be used to escape
 double quotes or backslashes inside the string. This does not apply to
 commands taking :REST or :SHELL type arguments."
-  (let ((cmd (completing-read (current-screen) ": " (all-commands) :initial-input (or initial-input ""))))
-    (unless cmd
-      (throw 'error :abort))
-    (when (plusp (length cmd))
-      (eval-command cmd t))))
+  (let ((*input-map* (copy-structure *input-map*)))
+    (define-key *input-map* (kbd "SPC") 'input-insert-hyphen-or-space)
+    (define-key *input-map* (kbd "M-SPC") 'input-insert-space)
+    (define-key *input-map* (kbd "RET") 'input-complete-and-submit)
+    (let ((cmd (completing-read (current-screen)
+				": "
+				#'emacs-style-command-complete
+				:initial-input (or initial-input ""))))
+      (unless cmd
+	(throw 'error :abort))
+      (when (plusp (length cmd))
+	(eval-command cmd t)))))

--- a/input.lisp
+++ b/input.lisp
@@ -791,7 +791,7 @@ functions are passed this structure as their first argument."
 	(completion
 	  (emacs-style-command-complete
 	   (car (split-seq (input-line-string input) " ")))))
-    (if (and toggle (= 1 (length completion)))
+    (if (and (not toggle) (= 1 (length completion)))
 	(progn
 	  (input-replace-line input (car completion))
 	  (input-insert-char input #\space))

--- a/input.lisp
+++ b/input.lisp
@@ -791,7 +791,7 @@ functions are passed this structure as their first argument."
 	(completion
 	  (emacs-style-command-complete
 	   (car (split-seq (input-line-string input) " ")))))
-    (if (and (= 1 (length completion)))
+    (if (and toggle (= 1 (length completion)))
 	(progn
 	  (input-replace-line input (car completion))
 	  (input-insert-char input #\space))

--- a/input.lisp
+++ b/input.lisp
@@ -404,15 +404,14 @@ with t, second with a, and third with o."
       (multiple-value-bind (completions more)
           (take *maximum-completions*
                 (remove-duplicates
-                  (remove-if
-                    (lambda (str)
-                      (or (string= str "")
-                          (< (length str) (length input-line))
-                          (string/= input-line
-                                    (subseq str 0 (length input-line)))))
-                    all-completions)
-                  :test #'string=))
-        (if more
+		 (remove-if
+		  (lambda (str)
+		    (or (string= str "")
+			(< (length str) (length input-line))
+			(not (potential-string-expansion input-line str))))
+		  all-completions)
+		 :test #'string=))
+	(if more
             (append (butlast completions)
                     (list (format nil "... and ~D more" (1+ (length more)))))
             completions))))

--- a/input.lisp
+++ b/input.lisp
@@ -378,6 +378,25 @@ match with an element of the completions."
      (* (font-height font) index)
      (font-ascent font)))
 
+(defun potential-string-expansion (string expansion)
+  "This takes a string and a possible expansion and checks to see if it could be, 
+treating hyphens as delimiters between words. This attempts to emulate emacs. 
+For example the string \"t-a-o\" would match any string whose first word begins
+with t, second with a, and third with o."
+  (let ((word-list-one (cl-ppcre:split "-" string))
+	(word-list-two (cl-ppcre:split "-" expansion)))
+    (when (<= (length word-list-one) (length word-list-two))
+      (not (member :impossible (mapcar (lambda (w1 w2)
+					 (if (uiop:string-prefix-p w1 w2)
+					     :possible
+					     :impossible))
+				       word-list-one
+				       word-list-two))))))
+
+(defun emacs-style-command-complete (string)
+  (loop for completion in (all-commands)
+	when (potential-string-expansion string completion)
+	  collect completion))
 
 (defun get-completion-preview-list (input-line all-completions)
   (if (string= "" input-line)
@@ -534,6 +553,17 @@ match with an element of the completions."
   (declare (ignore input key))
   :done)
 
+(defun input-complete-and-submit (input key)
+  (declare (ignore key))
+  (let* ((split (split-seq (input-line-string input) " "))
+	 (c (emacs-style-command-complete (car split))))
+    (when (and (= 1 (length split))
+	         (= 1 (length c)))
+      (input-replace-line input (car c)))
+    (define-key *input-map* (kbd "SPC") 'input-self-insert)
+    (define-key *input-map* (kbd "RET") 'input-submit)
+    :done))
+
 (defun input-abort (input key)
   (declare (ignore input key))
   (throw :abort nil))
@@ -550,6 +580,13 @@ functions are passed this structure as their first argument."
   (check-type string string)
   (loop for c across string
         do (input-insert-char input c)))
+
+(defun input-replace-line (input new)
+  (let ((replace-with (if (listp new) (coerce new 'string) new)))
+    (setf (input-line-position input) 0) ; set position to kill from
+    (input-kill-line input nil)
+    (loop for c across replace-with
+	  do (input-insert-char input c))))
 
 (defun input-point (input)
   "Return the position of the cursor."
@@ -740,6 +777,22 @@ functions are passed this structure as their first argument."
             (not (characterp char)))
         :error
         (input-insert-char input char))))
+
+(defun input-insert-hyphen-or-space (input key)
+  (declare (ignore key))
+  (let ((toggle (member #\space (coerce (input-line-string input) 'list)))
+	;; toggle relies on the fact that there can be no spaces in a command
+	(completion
+	  (emacs-style-command-complete
+	   (car (split-seq (input-line-string input) " ")))))
+    (if (and (= 1 (length completion)))
+	(progn
+	  (input-replace-line input (car completion))
+	  (input-insert-char input #\space))
+	(let ((char (if toggle #\space #\-)))
+	  (if (or (not (characterp char)) (null char))
+	      :error
+	      (input-insert-char input char))))))
 
 (defun input-yank-selection (input key)
   (declare (ignore key))

--- a/input.lisp
+++ b/input.lisp
@@ -629,6 +629,13 @@ functions are passed this structure as their first argument."
   "Return a the substring in INPUT bounded by START and END."
   (subseq (input-line-string input) start end))
 
+(defun input-insert-space (input key)
+  (declare (ignore key))
+  (let ((char (xlib:keysym->character *display* (key-keysym (kbd "SPC")))))
+    (if (or (not (characterp char)) (null char))
+	:error
+	(input-insert-char input char))))
+
 
 ;;; "interactive" input functions
 


### PR DESCRIPTION
This request adds Emacs style completion to the colon command. I'm unsure if this is wanted, but I figured that since StumpWM and Emacs are so similar it might be. The new behavior of colon changes SPC to insert either a hyphen or a space, depending on whether the current input line either 

A) can be expanded into a command (in which case it is)
or 
B) contains a space (because it has already expanded a command)

It also changes RET to expand an input line if applicable and then return `:done`, as well as M-SPC to insert a space. 
once a line is submitted, the keys are rebound back to their original bindings to prevent this behavior when not inputting a command. 

Does this seem like something the community would like? I've attached a picture of it in use, to clear up any misunderstandings about how i've explained it. 

![vlcsnap-2020-03-07-19h17m09s757](https://user-images.githubusercontent.com/39150985/76150240-7449fe80-60a8-11ea-9034-6049e767710a.png)


EDIT: ~~I have found an issue with how this is implemented. specifically in the function `input-insert-hyphen-or-space`. the output gets overwritten every time space is pressed. I'll work on this now.~~ this has been solved. 