### PR TITLE
Dump/restore configurations on XDG base dir file locations

### DIFF
--- a/fdump.lisp
+++ b/fdump.lisp
@@ -98,7 +98,12 @@
               :current (screen-id (current-screen))))
 
 (defun dump-to-file (foo name)
-  (with-open-file (fp name :direction :output :if-exists :supersede)
+  (with-open-file (fp (merge-pathnames (ensure-directories-exist (uiop:xdg-data-home #p"stumpwm/"))
+                                       (make-pathname :type "dump"
+                                                      :name name))
+                      :direction :output
+                      :if-exists :supersede
+                      :if-does-not-exist :create)
     (with-standard-io-syntax
       (let ((*package* (find-package :stumpwm))
             (*print-pretty* t))
@@ -203,8 +208,12 @@
         (restore-screen screen sdump)))))
 
 (defcommand restore-from-file (file) ((:rest "Restore From File: "))
-  "Restores screen, groups, or frames from named file, depending on file's contents."
-  (let ((dump (read-dump-from-file file)))
+  "Restores screen, groups, or frames from named file, depending on file's
+contents. Defaults to the XDG_DATA_HOME location with .dump file types."
+  (let ((dump (read-dump-from-file
+               (merge-pathnames (uiop:xdg-data-home #p"stumpwm/")
+                                (make-pathname :name file
+                                               :type "dump")))))
     (typecase dump
       (gdump
        (restore-group (current-group) dump)

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -39,17 +39,12 @@ doesn't exist. Returns a values list: whether the file loaded (t if no
 rc files exist), the error if it didn't, and the rc file that was
 loaded. When CATCH-ERRORS is nil, errors are left to be handled
 further up. "
-  (let* ((xdg-config-dir
-           (let ((dir (getenv "XDG_CONFIG_HOME")))
-             (if (or (not dir) (string= dir ""))
-                 (merge-pathnames  #p".config/" (user-homedir-pathname))
-                 (concatenate 'string dir "/"))))
-         (user-rc
+  (let* ((user-rc
            (probe-file (merge-pathnames #p".stumpwmrc" (user-homedir-pathname))))
          (dir-rc
            (probe-file (merge-pathnames #p".stumpwm.d/init.lisp" (user-homedir-pathname))))
          (conf-rc
-           (probe-file (merge-pathnames #p"stumpwm/config" xdg-config-dir)))
+           (probe-file (uiop:xdg-config-home #p"stumpwm/config/")))
          (etc-rc (probe-file #p"/etc/stumpwmrc"))
          (rc (or user-rc dir-rc conf-rc etc-rc)))
     (if rc


### PR DESCRIPTION
Use UIOP's `XDG_*_*` functions where needed, and save file dumps in the `XDG_DATA_HOME` with a `.dump` file ending.

Previously the dumps were saved in the home directory. This new way is better because it does not dirty the home directory, and it opens the door for listing all the available dumps in the directory to choose from when restoring.

Resolves https://github.com/stumpwm/stumpwm/issues/746