### PR TITLE
Shell completion workaround *verbose-shell-completion* toggle

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -33,8 +33,12 @@
           defcommand-alias
           define-stumpwm-type
           run-commands
+          *verbose-shell-completion*
           %interactivep%))
 
+(defvar *verbose-shell-completion* nil
+  "When T, show very verbose shell completion. Known bug: Can cause problems
+losing character events.")
 (defstruct command-alias
   from to)
 
@@ -487,7 +491,9 @@ then describes the symbol."
         (*input-history* *input-shell-history*))
     (unwind-protect
          (or (argument-pop-rest input)
-             (completing-read (current-screen) prompt 'complete-program))
+             (completing-read (current-screen) prompt (if *verbose-shell-completion*
+                                                          'complete-program
+                                                          *input-history*)))
       (setf *input-shell-history* *input-history*))))
 
 (define-stumpwm-type :rest (input prompt)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2987,6 +2987,7 @@ sending them as one.
 @node Advanced Configuration, Command and Function Index, Hacking, Top
 @chapter Advanced Configuration
 
+### *verbose-shell-completion*
 ### *default-package*
 ### *default-bg-color*
 @@@ run-commands


### PR DESCRIPTION
It makes sense to only do historical completion, unless StumpWM was going to
implement full shell completion support.

Affects all `:shell` commands, like `run-shell-command` or its alias `exec`.

Addresses issue #747

>Proposed solution
>Make the new and fancy stuff optional and opt-in

# Completion 
Completion with `*verbose-shell-completion* t`.
![shell-progs](https://user-images.githubusercontent.com/13551856/76265056-beee8680-6220-11ea-954d-8f794199f23d.png)

With `*verbose-shell-completion nil` (history only)
![shell-hist](https://user-images.githubusercontent.com/13551856/76265063-c2820d80-6220-11ea-8db4-25eafe1f1ae3.png)
