### PR TITLE
Where-is alias keybindings support

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -192,7 +192,7 @@
               (mapcar 'print-key-seq bindings))
       (format stream "Command \"~a\" is not currently bound." cmd))))
 
-(defcommand where-is (cmd) ((:rest "Where is command: "))
+(defcommand where-is (cmd) ((:command "Where is command: "))
   "Print the key sequences bound to the specified command."
   (message-no-timeout "~A" (where-is-to-stream cmd nil)))
 

--- a/help.lisp
+++ b/help.lisp
@@ -207,7 +207,7 @@
                         (when (not (eql sym (sym v #'command-alias-to)))
                           (cons sym #1#)))))
        (when-let ((aliases (gethash (intern (string-upcase cmd)) reverse-hash)))
-         (format stream "~%\"~a\" is aliased on ~{\"~a\"~^, ~}."
+         (format stream "~%\"~a\" is aliased to ~{\"~a\"~^, ~}."
                  cmd (mapcar #'string-downcase aliases))
          (loop for a in aliases
                for k = #2=(keys (string-downcase (symbol-name a))) then #2#

--- a/help.lisp
+++ b/help.lisp
@@ -186,15 +186,38 @@
       (message-no-timeout "~a" (describe-command-to-stream com nil))))
 
 (defun where-is-to-stream (cmd stream)
-  (let ((cmd (string-downcase cmd)))
-    (if-let ((bindings (loop for map in (top-maps) append (search-kmap cmd map))))
-      (format stream "\"~a\" is on ~{~a~^, ~}." cmd
-              (mapcar 'print-key-seq bindings))
-      (format stream "Command \"~a\" is not currently bound." cmd))))
+  (labels ((keys (cmd)
+             (loop for map in (top-maps) append (search-kmap cmd map)))
+           (sym (comm alias-accessor)
+             (typecase comm
+               (command-alias (sym (funcall alias-accessor comm) alias-accessor))
+               (command (command-name comm))
+               (string (intern (string-upcase comm)))
+               (symbol comm))))
+    (let ((cmd (string-downcase cmd)))
+     (if-let ((bindings (keys cmd)))
+       (format stream "\"~a\" is on ~{~a~^, ~}." cmd
+               (mapcar 'print-key-seq bindings))
+       (format stream "Command \"~a\" is not currently bound." cmd))
+     (let ((reverse-hash (make-hash-table :size (hash-table-size *command-hash*)
+                                          :test 'eq)))
+       (loop for k being each hash-key of *command-hash* using (hash-value v)
+             do (setf #1=(gethash (sym v #'command-alias-to) reverse-hash)
+                      (let ((sym (sym v #'command-alias-from)))
+                        (when (not (eql sym (sym v #'command-alias-to)))
+                          (cons sym #1#)))))
+       (when-let ((aliases (gethash (intern (string-upcase cmd)) reverse-hash)))
+         (format stream "~%\"~a\" is aliased on ~{\"~a\"~^, ~}."
+                 cmd (mapcar #'string-downcase aliases))
+         (loop for a in aliases
+               for k = #2=(keys (string-downcase (symbol-name a))) then #2#
+               when k do (format stream "~%\"~a\" is on ~{~a~^, ~}." (string-downcase a) (mapcar 'print-key-seq k))))))))
 
 (defcommand where-is (cmd) ((:command "Where is command: "))
   "Print the key sequences bound to the specified command."
-  (message-no-timeout "~A" (where-is-to-stream cmd nil)))
+  (let ((stream (make-string-output-stream)))
+    (where-is-to-stream cmd stream)
+    (message-no-timeout "~A" (get-output-stream-string stream))))
 
 (defun get-kmaps-at-key (kmaps key)
   (dereference-kmaps


### PR DESCRIPTION
This builds on the following PR: #750 which is tagged 19.11-doc-v1
whereas this PR is tagged 19.11-doc-v2

Where-is is made more useful by showing aliased names and keys

Displays the aliases to a command, even if it is not itself bound to any keys.
This makes for a much more useful where-is message for tracking down the
relationship between a particular action and a key.

This makes for a more verbose message, but in my experience I usually wanted
that extra information, since that is why I did a where-is in the first place.
In most cases it makes no difference (since most commands are not aliased), and
it normally just adds a few lines, and the messages are still small and
non-obtrusive.


# Old behaviour
![where-is-old](https://user-images.githubusercontent.com/13551856/76270784-a471d880-6233-11ea-80e5-a4dd0bd15f6c.png)

# New behaviour

![where-is-new](https://user-images.githubusercontent.com/13551856/76270791-ae93d700-6233-11ea-9432-7a8d9a271e5f.png)

