### PR TITLE
Make SPLIT-SEQ work with a nil separator

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -771,7 +771,7 @@ positive direction."
             min))))
 
 (defun split-seq (seq separators &key test default-value)
-  "split a sequence into sub sequences given the list of seperators."
+  "Split a sequence into subsequences given the list of seperators."
   (let ((seps separators))
     (labels ((sep (c)
                (position c seps :test test)))

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -774,7 +774,7 @@ positive direction."
   "split a sequence into sub sequences given the list of seperators."
   (let ((seps separators))
     (labels ((sep (c)
-               (find c seps :test test)))
+               (position c seps :test test)))
       (or (loop for i = (position-if (complement #'sep) seq)
                 then (position-if (complement #'sep) seq :start j)
                 as j = (position-if #'sep seq :start (or i 0))


### PR DESCRIPTION
As far as I can tell, `split-seq` is never actually called with a nil argument currently, but the code at the moment will completely ignore `nil` as a separator due to using `find`, which is an undocumented potential footgun.