### PR TITLE
Allow escaped symbols to be used as commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Daniel Oliveira     drdo at drdo.eu
 Panji Kusuma        epanji at gmail dot com
 Andrin Bertschi     hi at abertschi dot ch
 Spenser Max Truex   web ate spensertruex.com
+Eric Ihli           eihli at owoga com


### PR DESCRIPTION
The codebase allows commands to be symbols, but, for no reason I could
find, it did not support escaped symbols (|some symbol|).

Escaped symbols can sometimes make code more readable and with no good
reason to not support them it would be good for the code to not have
this hidden surprise.

There is also a small performance/clarity update where getting a value
from a hashmap by iterating the entries and checking equality is
replaced by `gethash`.