### PR TITLE
Keep mode line below other windows

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -244,6 +244,7 @@ timer.")
       (update-mode-line-color-context mode-line)
       (resize-mode-line mode-line)
       (xlib:map-window window)
+      (setf (xlib:window-priority window) :below)
       (redraw-mode-line mode-line)
       (dformat 3 "modeline: ~s~%" mode-line)
       (turn-on-mode-line-timer)
@@ -390,7 +391,8 @@ timer.")
           (:hidden
            ;; Show it.
            (setf (mode-line-mode ml) :visible)
-           (xlib:map-window (mode-line-window ml)))
+           (xlib:map-window (mode-line-window ml))
+           (setf (xlib:window-priority (mode-line-window ml)) :below))
           (:stump
            ;; Delete it
            (destroy-mode-line ml)))


### PR DESCRIPTION
This fixes an issue where the mode line will appear above full-screen windows in some circumstances. A way to trigger the bug is to have a window already open, then enable the mode line; if that window is made full-screen, the mode line will appear over top of the full-screen window.