### PR TITLE
fix a small typo in sample rc file macro.

### DIFF
--- a/sample-stumpwmrc.lisp
+++ b/sample-stumpwmrc.lisp
@@ -26,7 +26,7 @@
 ;; Web jump (works for Google and Imdb)
 (defmacro make-web-jump (name prefix)
   `(defcommand ,(intern name) (search) ((:rest ,(concatenate 'string name " search: ")))
-    (substitute #\+ #\Space search)
+    (nsubstitute #\+ #\Space search)
     (run-shell-command (concatenate 'string ,prefix search))))
 
 (make-web-jump "google" "firefox http://www.google.fr/search?q=")


### PR DESCRIPTION
Need to use `nsubstitute' to mutate the string.