### PR TITLE
add restart to abort debugging when *top-level-error-action* is :break

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -98,7 +98,11 @@ further up. "
        (write-line s)
        (print-backtrace)
        (message "^1*^B~a" s)))
-    (:break (invoke-debugger c))
+    (:break (restart-case
+                (invoke-debugger c)
+              (:abort-debugging ()
+                :report (lambda (stream) (format stream "abort debugging"))
+                (throw :top-level (list c (backtrace-string))))))
     (:abort
      (throw :top-level (list c (backtrace-string))))))
 


### PR DESCRIPTION
Even when I am debugging an error I want to be able to abort debugging again as if *top-level-error-action* were set to :break.