### PR TITLE
print debug level in dformat

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -834,7 +834,7 @@ output directly to a file.")
 (defun dformat (level fmt &rest args)
   (when (>= *debug-level* level)
     (multiple-value-bind (sec m h) (get-decoded-system-time)
-      (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d " h m sec))
+      (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d ~2,' d " h m sec level))
     ;; strip out non base-char chars quick-n-dirty like
     (write-string (map 'string (lambda (ch)
                                  (if (typep ch 'standard-char)


### PR DESCRIPTION
I like dformat also to print the debug level of a message.

Do you find this useful as well?