### PR TITLE
add recursively-add-to-load-path

### DIFF
--- a/module.lisp
+++ b/module.lisp
@@ -32,7 +32,8 @@
           init-load-path
           set-module-dir
           find-module
-          add-to-load-path))
+          add-to-load-path
+          recursively-add-to-load-path))
 
 (defvar *module-dir*
   (pathname-as-directory (concat (getenv "HOME") "/.stumpwm.d/modules"))
@@ -115,6 +116,11 @@ an asdf system, and if so add it to the central registry"
                  (append (list (ensure-pathname path)) asdf:*central-registry*))
            (setf *load-path* (append (list (ensure-pathname path)) *load-path*)))
           (T *load-path*))))
+
+(defun recursively-add-to-load-path (path)
+  "like INIT-LOAD-PATH first recursively build a list of paths
+that contain modules, then add them to the load path"
+  (mapcar #'add-to-load-path (stumpwm::build-load-path path)))
 
 (defcommand load-module (name) ((:module "Load Module: "))
   "Loads the contributed module with the given NAME."

--- a/module.lisp
+++ b/module.lisp
@@ -117,7 +117,7 @@ an asdf system, and if so add it to the central registry"
            (setf *load-path* (append (list (ensure-pathname path)) *load-path*)))
           (T *load-path*))))
 
-(defun recursively-add-to-load-path (path)
+(defcommand recursively-add-to-load-path (path)
   "like INIT-LOAD-PATH first recursively build a list of paths
 that contain modules, then add them to the load path"
   (mapcar #'add-to-load-path (stumpwm::build-load-path path)))


### PR DESCRIPTION
  "like INIT-LOAD-PATH first recursively build a list of paths
that contain modules, then add them to the load path"

Open for suggestions to rename it or refactor it in a different way. But I just want to be able to add another modules directory that is handled just like the default modules directory by INIT-LOAD-PATH.