### PR TITLE
add signal handler for POSIX signal SIGHUP to force a hard stumpwm restart

### DIFF
--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -16,7 +16,8 @@
                #:cl-ppcre
                #:clx
                #:sb-posix
-               #:sb-introspect)
+               #:sb-introspect
+               #:cffi)
   :components ((:file "package")
                (:file "primitives")
                (:file "wrappers")

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -277,9 +277,25 @@ further up. "
   ;; what should the top level loop do?
   :quit)
 
+(defun force-stumpwm-restart (&key (close-display t))
+  (when close-display
+    (xlib:close-display *display*))
+  (apply 'execv (first sb-ext:*posix-argv*) sb-ext:*posix-argv*))
+
+(defmacro set-signal-handler (signo &body body) ;; from Andrew Lyon at https://stackoverflow.com/a/10442062
+  (let ((handler (gensym "HANDLER")))
+    `(progn
+       (cffi:defcallback ,handler :void ((signo :int))
+         (declare (ignore signo))
+         ,@body)
+       (cffi:foreign-funcall "signal" :int ,signo :pointer (cffi:callback ,handler)))))
+
 ;; Usage: (stumpwm)
 (defun stumpwm (&optional (display-str (or (getenv "DISPLAY") ":0")))
   "Start the stump window manager."
+  (set-signal-handler sb-posix:sighup
+    (dformat 0 "SIGHUP received: forcing immediate restart of stumpwm~%") ;; debug level 0 to "force" logging
+    (force-stumpwm-restart))
   (let ((*in-main-thread* t))
     (setf *data-dir*
           (make-pathname :directory (append (pathname-directory (user-homedir-pathname))
@@ -298,7 +314,7 @@ further up. "
               ;; the process because otherwise we get errors.
               ((eq ret :hup-process)
                (run-hook *restart-hook*)
-               (apply 'execv (first sb-ext:*posix-argv*) sb-ext:*posix-argv*))
+               (force-stumpwm-restart :close-display nil))
               ((eq ret :restart)
                (run-hook *restart-hook*))
               (t


### PR DESCRIPTION
_I gather this will be slightly more controversial... but I still suggest as it gives a means to salvage your X session on heavy problems._


FORCE-STUMPWM-RESTART will immediately force a restart outside stumpwm's
loops and is kind of harsh.

Sometimes when debugging I cannot invoke the command RESTART-HARD anymore.
But you cannot call RESTART-HARD from a swank as it needs to be in the
context of the CATCH :TOP-LEVEL.

The :HUP-PROCESS in function STUMPWM gave me the idea that stumpwm should
even do this when receiving SIGHUP and this is kind of nice so that you
can restart stumpwm even when you cannot invoke commands properly and you
do not have a running swank server anymore (which sometimes happens for me).