### PR TITLE
Fix which-key-mode when discrepancies exist between top maps

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -223,8 +223,9 @@
   (dereference-kmaps
    (reduce
     (lambda (result map)
-      (let* ((binding (find key (kmap-bindings map)
-                            :key 'binding-key :test 'equalp))
+      (let* ((binding (handler-case (find key (kmap-bindings map)
+                                          :key 'binding-key :test 'equalp)
+                        (type-error () nil)))
              (command (when binding (binding-command binding))))
         (if command
             (setf result (cons command result))
@@ -246,8 +247,8 @@ KMAPS are enabled"
   (when (not (eq *top-map* *resize-map*))
     (let* ((oriented-key-seq (reverse key-seq))
            (maps (get-kmaps-at-key-seq (dereference-kmaps (top-maps)) oriented-key-seq)))
-      (when (remove-if-not 'kmap-p maps)
-        (apply 'display-bindings-for-keymaps oriented-key-seq maps)))))
+      (when-let ((only-maps (remove-if-not 'kmap-p maps)))
+        (apply 'display-bindings-for-keymaps oriented-key-seq only-maps)))))
 
 (defcommand which-key-mode () ()
   "Toggle which-key-mode"


### PR DESCRIPTION
This addresses issue #784 by checking if a keymap is really a keymap in the functions `get-kmaps-at-key` and `which-key-mode-key-press-hook`. The problem occurs when a key is bound to both a keymap and a command in separate maps (eg. in `*top-map*` and `*group-top-map*`)¹. At that point the function `get-kmaps-at-key-seq` returns both the keymap and the command, causing an error when one tries to display the bindings for the command (in `which-key-mode-key-press-hook`) or tries to get the keymap bindings of the command (in `get-kmaps-at-key`). 

¹We can see this by binding a keymap in `*root-map*` to a key which is bound to a command in `*group-root-map*`.