### PR TITLE
Don't lose focus when fetching completions

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -337,20 +337,20 @@ match with an element of the completions."
                                       (caar compls)
                                       (car compls))))))
              (key-loop ()
-               (loop for key = (with-focus (screen-input-window screen)
-                                 (read-key-or-selection))
-                     do
-                    (cond ((stringp key)
-                           ;; handle selection
-                           (input-insert-string input key)
-                           (draw-input-bucket screen prompt input))
-                          ;; skip modifiers
-                          ((is-modifier (car key)))
-                          ((process-input screen prompt input (car key) (cdr key))
-                           (if (or (not require-match)
-                                   (match-input))
-                               (return (input-line-string input))
-                               (draw-input-bucket screen prompt input "[No match]" t)))))))
+               (with-focus (screen-input-window screen)
+                 (loop for key = (read-key-or-selection)
+                    do
+                      (cond ((stringp key)
+                             ;; handle selection
+                             (input-insert-string input key)
+                             (draw-input-bucket screen prompt input))
+                            ;; skip modifiers
+                            ((is-modifier (car key)))
+                            ((process-input screen prompt input (car key) (cdr key))
+                             (if (or (not require-match)
+                                     (match-input))
+                                 (return (input-line-string input))
+                                 (draw-input-bucket screen prompt input "[No match]" t))))))))
       (draw-input-bucket screen prompt input)
       (setup-input-window screen prompt input)
       (catch :abort


### PR DESCRIPTION
There's this really annoying issue when you have a lot of completions:
while it's displaying them, the focus is lost to the underlying
window. So if you type "fi" for firefox (in `<prefix>-!`), the "i" is
sent to the underlying window.

It may be due to me using a truetype font which is slower to render,
or the fact that a single letter will yield a lot of completion
candidates.

Either way, making sure we keep the focus during the whole insertion
solves this issue.