### PR TITLE
Log to a file by default

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -821,51 +821,6 @@ string which is split to obtain the individual regexps. "
          (post (subseq list nth)))
     (nconc pre (list item) post)))
 
-(defvar *debug-level* 0
-  "Set this variable to a number > 0 to turn on debugging. The greater the number the more debugging output.")
-
-(defvar *debug-expose-events* nil
-  "Set this variable for a visual indication of expose events on internal StumpWM windows.")
-
-(defvar *debug-stream* (make-synonym-stream '*error-output*)
-  "This is the stream debugging output is sent to. It defaults to
-*error-output*. It may be more convenient for you to pipe debugging
-output directly to a file.")
-
-(defun dformat (level fmt &rest args)
-  (when (>= *debug-level* level)
-    (multiple-value-bind (sec m h) (get-decoded-system-time)
-      (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d ~2,' d " h m sec level))
-    ;; strip out non base-char chars quick-n-dirty like
-    (write-string (map 'string (lambda (ch)
-                                 (if (typep ch 'standard-char)
-                                     ch #\?))
-                       (apply 'format nil fmt args))
-                  *debug-stream*)
-    (force-output *debug-stream*)))
-
-(defvar *redirect-stream* nil
-  "This variable Keeps track of the stream all output is sent to when
-`redirect-all-output' is called so if it changes we can close it
-before reopening.")
-
-(defun redirect-all-output (file)
-  "Elect to redirect all output to the specified file. For instance,
-if you want everything to go to ~/.stumpwm.d/debug-output.txt you would
-do:
-
-@example
-(redirect-all-output (data-dir-file \"debug-output\" \"txt\"))
-@end example
-"
-  (when (typep *redirect-stream* 'file-stream)
-    (close *redirect-stream*))
-  (setf *redirect-stream* (open file :direction :output :if-exists :append :if-does-not-exist :create)
-        *error-output*    *redirect-stream*
-        *standard-output* *redirect-stream*
-        *trace-output*    *redirect-stream*
-        *debug-stream*    *redirect-stream*))
-
 ;;; 
 ;;; formatting routines
 (defun format-expand (fmt-alist fmt &rest args)

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -18,6 +18,9 @@
                #:sb-posix
                #:sb-introspect)
   :components ((:file "package")
+               (:module "support"
+                :components ((:file "xdg-base-dirs")
+                             (:file "debug")))
                (:file "primitives")
                (:file "wrappers")
                (:file "pathnames")

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -222,6 +222,12 @@ further up. "
             :local)
            (t :internet)))))
 
+(defun ensure-data-dir ()
+  (ensure-directories-exist (data-dir) :mode #o511))
+
+(defun data-dir ()
+  (merge-pathnames ".stumpwm.d/" (user-homedir-pathname)))
+
 (defun stumpwm-internal (display-str)
   (multiple-value-bind (host display screen protocol) (parse-display-string display-str)
     (declare (ignore screen))
@@ -232,6 +238,8 @@ further up. "
       (unwind-protect
            (progn
              (let ((*initializing* t))
+               (ensure-data-dir)
+               (open-log)
                ;; Start hashing the user's PATH so completion is quick
                ;; the first time they try to run a command.
                (sb-thread:make-thread #'rehash)
@@ -273,7 +281,9 @@ further up. "
              (let ((*package* (find-package *default-package*)))
                (run-hook *start-hook*)
                (stumpwm-internal-loop)))
-        (xlib:close-display *display*))))
+        (progn
+          (xlib:close-display *display*)
+          (close-log)))))
   ;; what should the top level loop do?
   :quit)
 

--- a/support/debug.lisp
+++ b/support/debug.lisp
@@ -1,0 +1,90 @@
+;; Copyright (C) 2003-2008 Shawn Betts
+;;
+;;  This file is part of stumpwm.
+;;
+;; stumpwm is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; stumpwm is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this software; see the file COPYING.  If not, see
+;; <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This file contains the code for debugging stumpwm.
+;;
+;;; Code:
+
+(in-package #:stumpwm)
+
+(defvar *debug-level* 0
+  "Set this variable to a number > 0 to turn on debugging. The greater the number the more debugging output.")
+
+(defvar *debug-expose-events* nil
+  "Set this variable for a visual indication of expose events on internal StumpWM windows.")
+
+(defvar *debug-stream* (make-synonym-stream '*error-output*)
+  "This is the stream debugging output is sent to. It defaults to
+*error-output*. It may be more convenient for you to pipe debugging
+output directly to a file.")
+
+(defun dformat (level fmt &rest args)
+  (when (>= *debug-level* level)
+    (multiple-value-bind (sec m h) (get-decoded-system-time)
+      (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d ~2,' d " h m sec level))
+    ;; strip out non base-char chars quick-n-dirty like
+    (write-string (map 'string (lambda (ch)
+                                 (if (typep ch 'standard-char)
+                                     ch #\?))
+                       (apply 'format nil fmt args))
+                  *debug-stream*)
+    (force-output *debug-stream*)))
+
+(defvar *redirect-stream* nil
+  "This variable Keeps track of the stream all output is sent to when
+`redirect-all-output' is called so if it changes we can close it
+before reopening.")
+
+(defun redirect-all-output (file)
+  "Elect to redirect all output to the specified file. For instance,
+if you want everything to go to ~/.stumpwm.d/debug-output.txt you would
+do:
+
+@example
+(redirect-all-output (data-dir-file \"debug-output\" \"txt\"))
+@end example
+"
+  (when (typep *redirect-stream* 'file-stream)
+    (close *redirect-stream*))
+  (setf *redirect-stream* (open file :direction :output :if-exists :append :if-does-not-exist :create)
+        *error-output*    *redirect-stream*
+        *standard-output* *redirect-stream*
+        *trace-output*    *redirect-stream*
+        *debug-stream*    *redirect-stream*))
+
+(defun rotate-log ()
+  (let ((log-filename (merge-pathnames "stumpwm.log"
+                                      (data-dir)))
+        (bkp-log-filename (merge-pathnames "stumpwm.log.1"
+                                          (data-dir))))
+    (when (probe-file log-filename)
+      (rename-file log-filename bkp-log-filename))))
+
+(defun open-log ()
+  (rotate-log)
+  (let ((log-filename (merge-pathnames "stumpwm.log"
+                                      (data-dir))))
+    (setf *debug-stream* (open log-filename :direction :output
+                                            :if-exists :supersede
+                                            :if-does-not-exist :create))))
+(defun close-log ()
+  (when (boundp '*debug-stream*)
+    (close *debug-stream*)
+    (makunbound *debug-stream*)))


### PR DESCRIPTION
The new mechanism logs to a file by default. It also keeps the two oldest
log files. This way when a user wants to enable persistent logging all they have to do is `(setf *debug-level* X)`. The previous `redirect-all-output` approach still works.

Additionally this commit adds basic support for the XDG base directory
specification. We only use it for the location of the log file, but it
could be used in the future to place the configuration file according
to the XDG base directory specification.

I would also like to slowly move things that aren't directly related to window managing responsibilities to a module named support. If you are familiar with Rails think along the lines of active support. Things like auto-complete strategies or run-prog would go there. 