### PR TITLE
Grab all mouse buttons

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -762,7 +762,7 @@ and bottom_end_x."
   ;; FIXME: Why doesn't grabbing button :any work? We have to
   ;; grab them one by one instead.
   (xwin-ungrab-buttons win)
-  (loop for i from 1 to 7
+  (loop for i from 1 to 32
         do (xlib:grab-button win i '(:button-press)
                              :modifiers :any
                              :owner-p nil


### PR DESCRIPTION
At present, the hack to work around a button argument of `:any` to `grab-button` not working only grabs the first 7 mouse buttons, but there can technically be up to 32 buttons on a mouse. This PR just grabs all 32.

Additionally, `:any` appears to work on my machine now, so perhaps we should just use that instead, unless it is still broken for other people.