### PR TITLE
Add an UNBIND command to undo a BIND command

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -281,6 +281,10 @@ great example."
   "Hang a key binding off the escape key."
   (define-key *root-map* (kbd key) command))
 
+(defcommand unbind (key) ((:string "Key Chord: "))
+  "Remove a key binding from the escape key."
+  (undefine-key *root-map* (kbd key)))
+
 (defcommand send-escape () ()
   "Send the escape key to the current window."
   (send-meta-key (current-screen) *escape-key*))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -895,6 +895,7 @@ Describe the specified command.
 ### *exchange-window-map*
 
 !!! bind
+!!! unbind
 !!! send-escape
 @@@ grab-pointer
 @@@ ungrab-pointer


### PR DESCRIPTION
Someone in IRC was asking how to undo a `bind` command.  After
grovelling around in the source I see there's no corresponding `unbind`
command and you'd have to do some kind of `undefine-key` incantation.
This adds `unbind` so you can do it more easily.