### PR TITLE
Add program-op to build StumpWM using only ASDF

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -1,0 +1,30 @@
+;; Copyright (C) 2020 Javier Olaechea
+;;
+;;  This file is part of stumpwm.
+;;
+;; stumpwm is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; stumpwm is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this software; see the file COPYING.  If not, see
+;; <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This file contains the entry-point for the StumpWM executable.
+;;
+;;; Code:
+
+(in-package #:stumpwm)
+
+(export '(main))
+
+(defun main ()
+  (stumpwm))

--- a/main.lisp
+++ b/main.lisp
@@ -27,4 +27,7 @@
 (export '(main))
 
 (defun main ()
-  (stumpwm))
+  (let ((argv (uiop:command-line-arguments)))
+    (if (find "--generate-manual" argv :test #'string-equal)
+        (generate-manual)
+        (stumpwm))))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -60,6 +60,7 @@
                (:file "wse")
                (:file "dynamic-window")
                (:file "remap-keys")
+               (:file "manual")
                ;; keep this last so it always gets recompiled if
                ;; anything changes
                (:file "version"))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -64,3 +64,10 @@
                ;; anything changes
                (:file "version"))
   :in-order-to ((test-op (test-op "stumpwm-tests"))))
+
+(defsystem "stumpwm/build"
+  :depends-on ("stumpwm")
+  :build-operation program-op
+  :build-pathname "stumpwm"
+  :entry-point "stumpwm:main"
+  :components ((:file "main")))


### PR DESCRIPTION
This is a starting point for my suggestion in https://github.com/stumpwm/stumpwm/pull/813

To generate the executable in a REPL evaluate:

  (asdf:make "stumpwm/build")

This creates an executable named stumpwm on the current directory.

Before we could merge this we would still need to use `(uiop:command-line-arguments)` to have a CLI option to extract the manual instead. With this change we could simplify the stumpwm rule in the Makefile to be just stumpwm, the file.

### TODO

- [ ] Add CLI option to extract the docstrings to build the manual
- [ ] Update Makefile