### PR TITLE
Fix invalid use of makunbound

### DIFF
--- a/debug.lisp
+++ b/debug.lisp
@@ -87,4 +87,4 @@ do:
 (defun close-log ()
   (when (boundp '*debug-stream*)
     (close *debug-stream*)
-    (makunbound *debug-stream*)))
+    (makunbound '*debug-stream*)))


### PR DESCRIPTION
This prevents TYPE-ERROR during StumpWM shutdown process.