### PR TITLE
Don't call xlib:wm-size-hints-*-inc when hints are empty

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -620,13 +620,15 @@ and bottom_end_x."
 (defun window-width-inc (window)
   "Find out what is the correct step to change window width"
   (or
-    (xlib:wm-size-hints-width-inc (window-normal-hints window))
+   (when-let ((window-hints (window-normal-hints window)))
+     (xlib:wm-size-hints-width-inc (window-normal-hints window)))
     1))
 
 (defun window-height-inc (window)
   "Find out what is the correct step to change window height"
   (or
-    (xlib:wm-size-hints-height-inc (window-normal-hints window))
+   (when-let ((window-hints (window-normal-hints window)))
+     (xlib:wm-size-hints-height-inc (window-normal-hints window)))
     1))
 
 (defun set-window-geometry (win &key x y width height border-width)


### PR DESCRIPTION
Instead let them default to the default value of one. This fixes the
bug that occurs when (window-normal-hints window) return nil, which
results in the following error.

There is no applicable method for the generic function
   #<STANDARD-GENERIC-FUNCTION XLIB:WM-SIZE-HINTS-WIDTH-INC (1)>
   when called with arguments
   (NIL).

Fixes #775 