### PR TITLE
Initialize the data dir with 0700 permissions

### DIFF
--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -223,7 +223,7 @@ further up. "
            (t :internet)))))
 
 (defun ensure-data-dir ()
-  (ensure-directories-exist (data-dir) :mode #o611))
+  (ensure-directories-exist (data-dir) :mode #o700))
 
 (defun data-dir ()
   (merge-pathnames ".stumpwm.d/" (user-homedir-pathname)))


### PR DESCRIPTION
The previous permissions were missing the executable bit so `stumwm.log` couldn't be created since it's parent directory was missing the required permission to contain files.

Set the group and other permission to `0` as I think only giving them execute permissions won't enable those entities to access this directory.