### PR TITLE
Fix send-raw-key

### DIFF
--- a/remap-keys.lisp
+++ b/remap-keys.lisp
@@ -114,7 +114,7 @@ EXAMPLE:
   (let* ((screen (current-screen))
          (win (screen-current-window screen))
          (k (with-focus (screen-key-window screen)
-              (read-key)))
+              (read-key-no-modifiers)))
          (code (car k))
          (state (cdr k)))
     (unmap-message-window screen)


### PR DESCRIPTION
This appears to be a simple matter of switching out read-key
for read-key-no-modifiers so that it sends a full key chord
instead of a single keypress