### PR TITLE
Fix redisplay on certain windows

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -619,15 +619,15 @@ and bottom_end_x."
 
 (defun window-width-inc (window)
   "Find out what is the correct step to change window width"
-  (or
-    (xlib:wm-size-hints-width-inc (window-normal-hints window))
-    1))
+  (if (window-normal-hints window)
+      (xlib:wm-size-hints-width-inc (window-normal-hints window))
+      1))
 
 (defun window-height-inc (window)
   "Find out what is the correct step to change window height"
-  (or
-    (xlib:wm-size-hints-height-inc (window-normal-hints window))
-    1))
+  (if (window-normal-hints window)
+      (xlib:wm-size-hints-height-inc (window-normal-hints window))
+      1))
 
 (defun set-window-geometry (win &key x y width height border-width)
   (macrolet ((update (xfn wfn v)


### PR DESCRIPTION
When redisplay is called on windows with a nil normal-hints, redisplay
throws an error. This modifies window-width-inc and window-height-inc
so they always return a number

Fixes #820 