### PR TITLE
Add basic configuration system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ MAKEINFO=@MAKEINFO@
 
 sbcl_BUILDOPTS=--load ./make-image.lisp
 sbcl_INFOOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
-sbcl_TESTOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(in-package :stumpwm-tests)" --eval "(if (run-package-tests) (uiop:quit 0) (uiop:quit 1))"
+sbcl_TESTOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(if (fiasco:all-tests) (uiop:quit 0) (uiop:quit 1))"
 
 datarootdir = @datarootdir@
 prefix=@prefix@

--- a/config-system.lisp
+++ b/config-system.lisp
@@ -1,0 +1,214 @@
+(in-package #:config-system)
+
+(defparameter *config-vars* (make-hash-table)
+  "Map that holds all of the configuration variables for the system")
+
+(defstruct config-info
+  (name t :type symbol :read-only t)
+  (validator #'identity :type (function (*) boolean))
+  (default nil :read-only t)
+  (value nil)
+  (doc "" :type string :read-only t))
+
+(defun %full-symbol-string (symb)
+  "Get the full name of the symbol complete with the package name"
+  (declare (type symbol symb))
+  (let* ((pkg (symbol-package symb))
+         (pkg-name (package-name pkg))
+         (symb-name (symbol-name symb)))
+    (concatenate 'string pkg-name
+                 (multiple-value-bind (symb status) (find-symbol symb-name pkg-name)
+                   (declare (ignore symb))
+                   (if (eql status :internal)
+                       "::"
+                       ":"))
+                 symb-name)))
+
+(defun describe-config-info (info &optional (stream *standard-output*))
+  (declare (type config-info info))
+  (format stream "Setting Name: ~A~%  Documentation:~%    ~A~%  Default value: ~S~%Current value: ~S~%  Validator function: ~A~%"
+          (%full-symbol-string (config-info-name info))
+          (config-info-doc info)
+          (config-info-default info)
+          (config-info-value info)
+          (config-info-validator info)))
+
+(defun %make-match-readtable (str)
+  "Try to make the given string have the correct case for a symbol"
+  (declare (type string str))
+  (ccase (readtable-case *readtable*)
+    ;; we are missing :invert, but I don't feel like implementing that.
+    (:upcase (string-upcase str))
+    (:downcase (string-downcase str))
+    (:preserve string)))
+
+(defun %map-config-matching (name-matches package-matches function)
+  (let ((name-scanner (ppcre:create-scanner (%make-match-readtable name-matches)))
+        (pkg-scanner (ppcre:create-scanner (%make-match-readtable package-matches))))
+    (maphash (lambda (key value)
+               (declare (ignorable key))
+               (let ((pkg-name (package-name (symbol-package (config-info-name value))))
+                     (symb-name (symbol-name (config-info-name value))))
+                 (when (and (funcall name-scanner symb-name 0 (length symb-name))
+                            (funcall pkg-scanner pkg-name 0 (length pkg-name)))
+                   (funcall function value))))
+             *config-vars*)))
+
+(defun describe-all-config-info (&key (stream *standard-output*) (name-matches ".*") (package-matches ".*"))
+  (%map-config-matching name-matches package-matches
+                        (lambda (info)
+                          (describe-config-info info stream)
+                          (format stream "~%"))))
+
+(define-condition config-error (error) ())
+
+(define-condition invalid-datum-error (config-error)
+  ((place-symbol :initarg :place :initform nil
+		 :accessor invalid-datum-error-place
+                 :type symbol)
+   (value :initarg :value :initform nil
+	  :accessor invalid-datum-error-value))
+  (:report
+   (lambda (c s)
+     (with-slots (place-symbol value) c
+       (format s "The value ~S is invalid for variable ~S." value place-symbol)))))
+
+(define-condition config-not-found-error (config-error)
+  ((place-symbol :initarg :place :initform nil
+                 :accessor config-not-found-error-place
+                 :type symbol)
+   (alternatives :initarg :alternatives :initform nil
+                 :accessor config-not-found-alternatives
+                 :type list))
+  (:report
+   (lambda (c s)
+     (with-slots (place-symbol alternatives) c
+       (if alternatives
+        (format s  "Setting ~A not found. Did you mean one of these? ~A"
+                (%full-symbol-string place-symbol) alternatives)
+        (format s  "Setting ~A not found." (%full-symbol-string place-symbol)))))))
+
+(defun %generate-config-var-code (declare-type name default validator documentation)
+  ;; if we wanted to get fancy, we could define a special type for this enumeration at this point too
+  (check-type documentation string)
+  (check-type name symbol)
+  (with-gensyms (default-value is-valid func)
+    `(progn
+       (,declare-type ,name ,default ,documentation)
+       (let* ((,default-value ,name)
+              (,func ,validator)
+              (,is-valid (funcall ,func ,default-value)))
+         (if ,is-valid
+             (setf (gethash (quote ,name) *config-vars*)
+                   (make-config-info :name (quote ,name) :default ,default-value
+                                     :validator ,func :doc ,documentation))
+             (error 'invalid-datum-error :place (quote ,name) :value ,default-value))))))
+
+(defmacro define-config-parameter (name default validator documentation)
+  "Create and register a configurable variable with the given default value,
+validator function, and documentation using DEFPARAMETER"
+  (%generate-config-var-code 'defparameter name default validator documentation))
+
+(defmacro define-config-var (name default validator documentation)
+  "Create and register a configurable variable with the given default value,
+validator function, and documentation using DEFVAR"
+  (%generate-config-var-code 'defvar name default validator documentation))
+
+(defmacro define-config-enum (name default values documentation &key (test-fn #'equal))
+  "Same as DEFINE-CONFIG-PARAMETER, except the validation function
+is built by creating a function that checks if the set  value is in the VALUES list."
+  `(define-config-parameter ,name ,default (lambda (x) (member x ,values :test ,test-fn))
+                            ,documentation))
+
+(defun all-config-info (&key (name-matches ".*") (package-matches ".*"))
+  "List all of the available customizable settings matching the given criteria."
+  (let ((accumulate (list)))
+    (%map-config-matching name-matches package-matches
+                          (lambda (info)
+                            (push info accumulate)))
+    accumulate))
+
+(defun %find-possible-settings (setting-name table)
+  "Find the settings that have the same symbol name of SETTING-NAME but are in a different package"
+  (declare (type hash-table table)
+           (type symbol setting-name))
+  (let ((name (symbol-name setting-name)))
+    ;; for some reason, the package isn't always included with the symbol name even
+    ;; if the top level isn't in the symbol's package, so we need to manually get the symbol name.
+    (mapcar #'%full-symbol-string
+            (remove-if-not (lambda (x) (string-equal (symbol-name x) name))
+                           (mapcar #'config-info-name (hash-table-values table))))))
+
+(defun get-config-info (setting-name)
+  "Find the info for the config variable stored in the symbol SETTING-NAME."
+  (declare (type symbol setting-name))
+  (if-let ((info (gethash setting-name *config-vars*)))
+    (progn
+      ;; Since the setting values can be changed outside of the API,
+      ;; we need to update the value of the varible here.
+      (setf (config-info-value info) (symbol-value setting-name))
+      info)))
+
+(defmacro %set-config (setting-name value)
+  (with-gensyms (actual-value info)
+    `(let ((,actual-value ,value))
+       (if-let ((,info (get-configuration-info (quote ,setting-name))))
+         (if (funcall (config-info-validator ,info) ,actual-value)
+             (setf ,setting-name ,actual-value)
+             (error 'invalid-datum-error :place (quote ,setting-name) :value ,actual-value))
+         (error 'config-not-found-error
+           :place (quote ,setting-name)
+           :alternatives (%find-possible-settings (quote ,setting-name) *config-vars*))))))
+
+(defmacro set-config (&rest settings)
+  "Set the given configuration variables to the given values. Used like setf"
+  (assert (= (mod (length settings) 2) 0))
+  (let ((accumulate (list 'progn)))
+    (do ((cur settings (cddr cur)))
+        ((not cur))
+      (push (list '%set-configuration (first cur) (second cur)) accumulate))
+    (nreverse accumulate)))
+
+(defmacro reset-config (&rest settings)
+  "Reset the list of settings to their default values"
+  (let ((accumulate (list)))
+    ;; add everything backwards, as the list is built in reverse
+    (dolist (setting-name settings)
+      (check-type setting-name symbol)
+      (push `(config-info-default (get-configuration-info (quote ,setting-name))) accumulate)
+      (push setting-name accumulate))
+    (push 'setf accumulate)
+    accumulate))
+
+(defun %make-storage-pair (symbol)
+  (declare (type symbol symbol))
+  (cons (gensym (symbol-name symbol)) symbol))
+
+(defmacro with-atomic-update (settings &body body)
+  "If an error occurs during the execution of BODY, reset the provided variables to their original value"
+  (let ((setting-pairs (mapcar #'%make-storage-pair settings)))
+    `(let ,(let ((settings-list (list)))
+             (dolist (item setting-pairs (nreverse settings-list))
+               (push (list (car item) (cdr item)) settings-list)))
+       (handler-case
+           (progn
+             ,@body)
+         (warning (w)
+           (warn w))
+         (error (condition)
+           (setf ,@(loop for pair in setting-pairs
+                         append (list (cdr pair) (car pair))))
+           (error condition))
+         (t (c)
+           (signal c))))))
+
+(defmacro set-config-atomic (&rest settings)
+  "Set the listed settings to the provided values. If an error signal is raised during execution,
+all of the settings are set back to their original value"
+  (assert (= (mod (length settings) 2) 0))
+  (let ((setting-vars (do ((cur settings (cddr cur))
+                           (vars (list)))
+                          ((not cur) (nreverse vars))
+                        (push (first cur) vars))))
+    `(with-atomic-update ,setting-vars
+       (set-configuration ,@settings))))

--- a/package.lisp
+++ b/package.lisp
@@ -17,6 +17,29 @@
 ;; along with this software; see the file COPYING.  If not, see
 ;; <http://www.gnu.org/licenses/>.
 
+(defpackage #:config-system
+  (:use :cl #:alexandria)
+  (:export config-info
+           config-info-name
+           config-info-validator
+           config-info-default
+           config-info-doc
+           config-info-value
+           describe-all-config-info
+           describe-config-info
+           config-error
+           config-not-found-error
+           invalid-datum-error
+           define-config-enum
+           define-config-parameter
+           define-config-var
+           list-all-configurations
+           get-configuration-info
+           set-configuration
+           set-configuration-atomic
+           reset-configuration
+           with-atomic-update))
+
 (defpackage :stumpwm
   (:use :cl
         #:alexandria)

--- a/stumpwm-tests.asd
+++ b/stumpwm-tests.asd
@@ -2,10 +2,12 @@
   :name "StumpWM tests"
   :serial t
   :depends-on ("stumpwm"
-               "fiasco")
+               "fiasco"
+               "alexandria")
   :pathname "tests/"
   :components ((:file "package")
                (:file "kmap")
-               (:file "pathnames"))
+               (:file "pathnames")
+               (:file "config-system"))
   :perform (test-op (o c)
-             (uiop/package:symbol-call "FIASCO" "RUN-TESTS" 'stumpwm-tests)))
+             (uiop/package:symbol-call "FIASCO" "ALL-TESTS")))

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -18,6 +18,7 @@
                #:sb-posix
                #:sb-introspect)
   :components ((:file "package")
+               (:file "config-system")
                (:file "debug")
                (:file "primitives")
                (:file "wrappers")

--- a/tests/config-system.lisp
+++ b/tests/config-system.lisp
@@ -1,0 +1,129 @@
+(in-package #:config-system-tests)
+
+(defmacro defconfig-test (name lambda-list before &body body)
+  (multiple-value-bind (forms declarations docstring) (parse-body body :documentation t)
+    `(let* ((config-system::*config-vars* (make-hash-table))
+            (table config-system::*config-vars*))
+       ,@before
+       ,(if docstring
+            `(fiasco:deftest ,name ,lambda-list
+               ,docstring
+               ,@declarations
+               (let ((config-system::*config-vars* table))
+                 ,@forms))
+            `(fiasco:deftest ,name ,lambda-list
+               ,@declarations
+               (let ((config-system::*config-vars* table))
+                 ,@forms))))))
+
+(defvar *foo* "test variable")
+(defvar *bar* "test variable")
+
+(defconfig-test define-config-var-stores-info ()
+  ((let ((default "1")
+         (validator #'stringp))
+     (define-config-var *foo* default validator "documentation")))
+  (let ((info (gethash '*foo* config-system::*config-vars*))
+        (default "1")
+        (validator #'stringp))
+    (is info)
+    (is (config-info-default info) default)
+    (is (config-info-name info) '*foo*)
+    (is (config-info-doc info) "documentation")
+    (is (config-info-validator info) validator)))
+
+(defconfig-test define-config-parameter-stores-info ()
+  ((let ((default "1")
+         (validator #'stringp))
+     (define-config-parameter *foo* default validator "documentation")))
+  (let ((info (gethash '*foo* config-system::*config-vars*)))
+    (is info)
+    (is (config-info-default info) "1")
+    (is (config-info-name info) '*foo*)
+    (is (config-info-doc info) "documentation")
+    (is (config-info-validator info) #'stringp)))
+
+(defconfig-test get-configuration-info-finds-info ()
+    ((let ((default "1")
+           (validator #'stringp))
+       (define-config-parameter *foo* default validator "documentation")))
+  (let ((info (get-configuration-info '*foo*))
+        (default "1")
+        (validator #'stringp))
+    (is info)
+    (is (config-info-default info) default)
+    (is (config-info-name info) '*foo*)
+    (is (config-info-doc info) "documentation")
+    (is (config-info-validator info) validator)))
+
+(defconfig-test list-all-configurations-shows-all ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "11" validator "documentation")
+       (define-config-parameter *bar* "21" validator "documentation")))
+  (let ((configs (list-all-configurations)))
+    (is (length configs) 2)
+    (is (member (get-configuration-info '*foo*) configs :test #'eql))
+    (is (member (get-configuration-info '*bar*) configs :test #'eql))))
+
+(defconfig-test list-all-configurations-gets-correct-values ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "11" validator "documentation")
+       (define-config-parameter *bar* "21" validator "documentation")))
+  (let ((configs (list-all-configurations)))
+    (is (length configs) 2)
+    (let ((foo (find (get-configuration-info '*foo*) configs :test #'eql))
+          (bar (find (get-configuration-info '*bar*) configs :test #'eql)))
+      (is foo)
+      (is bar)
+      (is (config-info-value foo) "11")
+      (is (config-info-value bar) "21"))))
+
+(defconfig-test set-configuration-throws-on-not-found ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "11" validator "documentation")))
+  (signals config-not-found-error (set-configuration *bar* "asdf")))
+
+(defconfig-test set-configuration-throws-on-invalid ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "11" validator "documentation")))
+  (signals invalid-datum-error (set-configuration *foo* 111)))
+
+(defconfig-test set-configuration-checks-arg-length ()
+    ()
+  (signals error (macroexpand '(set-configuration *foo* 111 *bar*))))
+
+(defconfig-test set-configuration-sets-valid ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "11" validator "documentation")))
+  (set-configuration *foo* "12")
+  (is *foo* "12"))
+
+(defconfig-test reset-configuration-works ()
+    ((define-config-parameter *foo* "11" #'stringp "documentation")
+     (define-config-parameter *bar* "22" #'stringp "documentation"))
+  (set-configuration *foo* "asdf"
+                     *bar* "qwerty")
+  (reset-configuration *foo* *bar*)
+  (is *foo* "11")
+  (is *bar* "22"))
+
+(defconfig-test with-atomic-update-restores-values ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "qwerty" validator "documentation")
+       (define-config-parameter *bar* "asdf" validator "documentation")))
+  (ignore-errors
+    (with-atomic-update (*foo* *bar*)
+      (set-configuration *foo* "set")
+      (set-configuration *bar* 11)))
+  (is *foo* "qwerty")
+  (is *bar* "asdf"))
+
+(defconfig-test set-configuration-atomic-restores-values ()
+    ((let ((validator #'stringp))
+       (define-config-parameter *foo* "qwerty" validator "documentation")
+       (define-config-parameter *bar* "asdf" validator "documentation")))
+  (ignore-errors
+    (set-configuration-atomic *foo* "set"
+                              *bar* 11))
+  (is *foo* "qwerty")
+  (is *bar* "asdf"))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,2 +1,5 @@
 (fiasco:define-test-package #:stumpwm-tests
   (:use #:stumpwm))
+
+(fiasco:define-test-package #:config-system-tests
+  (:use #:config-system #:alexandria))


### PR DESCRIPTION
This PR adds a basic configuration utility package that covers all of the essential elements of a configuration system as described in #838. Before merging this commit, look at https://github.com/szos/defcustom/tree/functionize, which @szos is writting to solve the same problem. Comparing the two, it looks like szos's version has many more features and nice-to-haves, while the code here just meets the minimal requirements and is much simpler.

## Features

This PR adds the macros `define-config-parameter` and `define-config-var` for declaring variables that are meant to be modified by the system users. These macros register the variables and declare them using `defparameter` and `defvar` respectively. A validation function is given to this macro that is used for checking that the variable's value conforms to specific requirements. `define-config-enum` is also present, which works the same way as `define-config-parameter` except the the validation function is generated automatically.

To set configuration variables, you can use the `set-config` and `set-config-atomic` macros. These macros follow the same form as `setf` and verify that the values the variables are being set to are correct using the provided validation function. If the values aren't valid, an `invalid-datum-error` condition is raised. The difference between these two functions are that if an error condition is raised while `set-configuration-atomic` is being executed, all of the variables in form are reset to their values from before the form was executed.

You can retrieve information about a specific configuration variable by using the `get-configuration-info` function, and get a list of all of the known configuration variables with `all-config-info`. You can print information about individual variables or variables matching a pattern to a stream using `describe-config-info` and `describe-all-config-info`, respectively.

A `with-atomic-update` macro is also provided, which resets a given set of variables to their values before the form was executed if a condition was raised while the form was executing.

Since the code uses `defparameter` and `defvar` under the hood, it is completely backwards compatible with existing code.