### PR TITLE
Allow forking from within the ~/.stumpwmrc

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -42,6 +42,7 @@
           *destroy-window-hook*
           *focus-window-hook*
           *place-window-hook*
+          *pre-thread-hook*
           *start-hook*
           *restart-hook*
           *quit-hook*
@@ -270,6 +271,9 @@ arguments: the current window and the last window (could be nil).")
 (defvar *place-window-hook* '()
   "A hook called whenever a window is placed by rule. Arguments are
 window group and frame")
+
+(defvar *pre-thread-hook* '()
+  "A hook called before any threads are started. Useful if you need to fork.")
 
 (defvar *start-hook* '()
   "A hook called when stumpwm starts.")

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -26,7 +26,8 @@
           stumpwm
           call-in-main-thread
           in-main-thread-p
-          push-event))
+          push-event
+          close-resources))
 
 (defvar *in-main-thread* nil
   "Dynamically bound to T during the execution of the main stumpwm function.")
@@ -228,6 +229,10 @@ further up. "
 (defun data-dir ()
   (merge-pathnames ".stumpwm.d/" (user-homedir-pathname)))
 
+(defun close-resources ()
+  (xlib:close-display *display*)
+  (close-log))
+
 (defun stumpwm-internal (display-str)
   (multiple-value-bind (host display screen protocol) (parse-display-string display-str)
     (declare (ignore screen))
@@ -285,9 +290,7 @@ further up. "
              (let ((*package* (find-package *default-package*)))
                (run-hook *start-hook*)
                (stumpwm-internal-loop)))
-        (progn
-          (xlib:close-display *display*)
-          (close-log)))))
+        (close-resources))))
   ;; what should the top level loop do?
   :quit)
 

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -240,9 +240,6 @@ further up. "
              (let ((*initializing* t))
                (ensure-data-dir)
                (open-log)
-               ;; Start hashing the user's PATH so completion is quick
-               ;; the first time they try to run a command.
-               (sb-thread:make-thread #'rehash)
                
                ;; we need to do this first because init-screen grabs
                ;; keys
@@ -277,6 +274,13 @@ further up. "
                    (when (and netwm-id (< netwm-id (length (screen-groups s))))
                      (switch-to-group (elt (sort-groups s) netwm-id))))
                  (redraw-current-message (current-screen))))
+
+             (run-hook *pre-thread-hook*)
+
+             ;; Start hashing the user's PATH so completion is quick
+             ;; the first time they try to run a command.
+             (sb-thread:make-thread #'rehash)
+
              ;; Let's manage.
              (let ((*package* (find-package *default-package*)))
                (run-hook *start-hook*)


### PR DESCRIPTION
This PR is offering 2 commits:

- The first one exposes a new hook that runs before any threads have been spawned, as SBCL requires an application to have no threads for sb-posix:fork to work
- The second one exposes a new function to close all the resources in a child process; I had a lot of weird sessions until I realized I should close the X display in the child :)