### PR TITLE
get rid of CFFI dependency by using rewriting set-signal-handler to use SBCL's Foreign Function Interface directly

### DIFF
--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -16,8 +16,7 @@
                #:cl-ppcre
                #:clx
                #:sb-posix
-               #:sb-introspect
-               #:cffi)
+               #:sb-introspect)
   :components ((:file "package")
                (:file "primitives")
                (:file "wrappers")


### PR DESCRIPTION
see discussion in https://github.com/stumpwm/stumpwm/pull/774