### PR TITLE
Use `fiasco:all-tests` to run tests instead of run-package-tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ MAKEINFO=@MAKEINFO@
 
 sbcl_BUILDOPTS=--load ./make-image.lisp
 sbcl_INFOOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
-sbcl_TESTOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(in-package :stumpwm-tests)" --eval "(if (run-package-tests) (uiop:quit 0) (uiop:quit 1))"
+sbcl_TESTOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(if (fiasco:all-tests) (uiop:quit 0) (uiop:quit 1))"
 
 datarootdir = @datarootdir@
 prefix=@prefix@

--- a/stumpwm-tests.asd
+++ b/stumpwm-tests.asd
@@ -8,4 +8,4 @@
                (:file "kmap")
                (:file "pathnames"))
   :perform (test-op (o c)
-             (uiop/package:symbol-call "FIASCO" "RUN-TESTS" 'stumpwm-tests)))
+             (uiop/package:symbol-call "FIASCO" "ALL-TESTS" 'stumpwm-tests)))


### PR DESCRIPTION
This change will cause all of the test packages known by fiasco to run. Since only test packages that we care about should be loaded, no unneeded work should be done, but it will allow us to break up our tests into multiple packages if needed. Currently, only tests in the `:stumpwm-tests` are ran.

Note that these changes are also present in #839, but since that PR probably isn't going to be merged, I'm submitting this separately.