### PR TITLE
Set up floating group root keymap in the same manner as tiling group

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -390,13 +390,20 @@
 
 ;;; Bindings
 
-(pushnew '(float-group *float-group-top-map*) *group-top-maps*)
-(defvar *float-group-top-map* (make-sparse-keymap))
-(defvar *float-group-root-map* (make-sparse-keymap)
+(defvar *float-group-top-map* nil)
+(defvar *float-group-root-map* nil
   "Commands specific to a floating group context hang from this keymap.
 It is available as part of the @dnf{prefix map} when the active group
 is a tile group.")
 
+(fill-keymap *float-group-top-map*
+  *escape-key* '*float-group-root-map*)
+
+(fill-keymap *float-group-root-map*
+  (kbd "n")  "next"
+  (kbd "p")  "prev")
+
+(pushnew '(float-group *float-group-top-map*) *group-top-maps*)
 
 (defcommand gnew-float (name) ((:rest "Group Name: "))
   "Create a floating window group with the specified name and switch to it."

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -394,7 +394,7 @@
 (defvar *float-group-root-map* nil
   "Commands specific to a floating group context hang from this keymap.
 It is available as part of the @dnf{prefix map} when the active group
-is a tile group.")
+is a float group.")
 
 (fill-keymap *float-group-top-map*
   *escape-key* '*float-group-root-map*)


### PR DESCRIPTION
Set up `*float-group-top-map*` and `*float-group-root-map*` in the same
way as `*tile-group-top-map*` and `*tile-group-root-map*`: by initializing
them to `nil` and using `fill-keymap` to populate them with bindings.

I noticed that bindings created in `*float-group-root-map*` weren't actually being bound, and after inspecting the variable `*float-group-top-map*` I found it to be empty; `*escape-key*` wasnt bound in it the same way it is in `*tile-group-top-map*`. This ammends that by initializing the `*float-group-*-map*` variables in the same manner as the `*tile-group-*-map*` variables. 