### PR TITLE
Allow absolute paths when dumping and restoring dumps

### DIFF
--- a/fdump.lisp
+++ b/fdump.lisp
@@ -97,10 +97,18 @@
   (make-ddump :screens (mapcar 'dump-screen *screen-list*)
               :current (screen-id (current-screen))))
 
+(defun dump-pathname (name)
+  "Convert NAME to a pathname for dump data. If NAME is an absolute path, then it will
+be used as is. Otherwise, defaults to writing to \"FILE.dump\" in the XDG_DATA_HOME 
+location."
+  (if (uiop:absolute-pathname-p name)
+      name
+      (merge-pathnames (ensure-directories-exist (uiop:xdg-data-home #p"stumpwm/"))
+                       (make-pathname :type "dump"
+                                      :name name))))
+
 (defun dump-to-file (foo name)
-  (with-open-file (fp (merge-pathnames (ensure-directories-exist (uiop:xdg-data-home #p"stumpwm/"))
-                                       (make-pathname :type "dump"
-                                                      :name name))
+  (with-open-file (fp (dump-pathname name)
                       :direction :output
                       :if-exists :supersede
                       :if-does-not-exist :create)
@@ -110,21 +118,27 @@
         (prin1 foo fp)))))
 
 (defcommand dump-group-to-file (file) ((:rest "Dump To File: "))
-  "Dumps the frames of the current group of the current screen to the named file."
+  "Dumps the frames of the current group of the current screen to the named file.
+If FILE is an absolute path, then the dump will be read written there.
+Otherwise, defaults to writing to \"FILE.dump\" in the XDG_DATA_HOME location."
   (dump-to-file (dump-group (current-group)) file)
   (message "Group dumped."))
 
 (defcommand-alias dump-group dump-group-to-file)
 
 (defcommand dump-screen-to-file (file) ((:rest "Dump To File: "))
-  "Dumps the frames of all groups of the current screen to the named file"
+  "Dumps the frames of all groups of the current screen to the named file.
+If FILE is an absolute path, then the dump will be read written there.
+Otherwise, defaults to writing to \"FILE.dump\" in the XDG_DATA_HOME location."
   (dump-to-file (dump-screen (current-screen)) file)
   (message "Screen dumped."))
 
 (defcommand-alias dump-screen dump-screen-to-file)
 
 (defcommand dump-desktop-to-file (file) ((:rest "Dump To File: "))
-  "Dumps the frames of all groups of all screens to the named file"
+  "Dumps the frames of all groups of all screens to the named file.
+If FILE is an absolute path, then the dump will be read written there.
+Otherwise, defaults to writing to \"FILE.dump\" in the XDG_DATA_HOME location."
   (dump-to-file (dump-desktop) file)
   (message "Desktop dumped."))
 
@@ -209,11 +223,10 @@
 
 (defcommand restore-from-file (file) ((:rest "Restore From File: "))
   "Restores screen, groups, or frames from named file, depending on file's
-contents. Defaults to the XDG_DATA_HOME location with .dump file types."
+contents. If FILE is an absolute path, then the dump will be read from there.
+Otherwise, defaults to reading from \"FILE.dump\" in the XDG_DATA_HOME location."
   (let ((dump (read-dump-from-file
-               (merge-pathnames (uiop:xdg-data-home #p"stumpwm/")
-                                (make-pathname :name file
-                                               :type "dump")))))
+               (dump-pathname file))))
     (typecase dump
       (gdump
        (restore-group (current-group) dump)


### PR DESCRIPTION
If the name passed into various dump commands is an absolute path, it will be used as
is. Otherwise, it will default to XDG_DATA_HOME/stumpwm/NAME.dump, as previously
implemented to resolve #746. The prior behavior also broke winner-mode, which
dumps in /tmp/.

Tested:

* winner-mode works as expected (absolute path)
* Interactively dumping with `dump-group` and `restore-group` with a name works as expected

Fixes:

* https://github.com/stumpwm/stumpwm-contrib/issues/189
* https://github.com/stumpwm/stumpwm/issues/746