### PR TITLE
Add an idle delay to which-key-mode

### DIFF
--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -16,7 +16,9 @@
                #:cl-ppcre
                #:clx
                #:sb-posix
-               #:sb-introspect)
+               #:sb-introspect
+               #:trivial-timers
+               #:bordeaux-threads)
   :components ((:file "package")
                (:file "debug")
                (:file "primitives")


### PR DESCRIPTION
This changeset makes which-key-mode more similar to emacs. Instead of popping up
immediately upon a keypress, `*which-key-idle-delay*`can be specified to delay
presentation of the which-key window. In addition, `*which-key-secondary-idle-delay*`
can be used to specify the delay for additional presentations of the which-key window
when it is already showing e.g. when navigating into another keymap.

This changeset also adds some light customization of the keybindings presentation. The
`*display-bindings-formatter*` parameter can be set to change presentation of
keybindings in the help window. By default, the keybindings are left unsorted to
maintain backwards compatible behavior. Two other formatting functions,
`alphabetical-command-bindings-formatter` and `alphabetical-key-bindings-formatter`
can be used to sort keybindings by command name or key sequence respectively. An
additional parameter, `*which-key-bindings-formatter*` can be used to adjust the
which-key keybindings format independently of the C-h format.

trivial-timers and bordeaux-threads have been added for portable versions of the timer 
functionality in sb-ext and threading in sb-thread. Threading was needed for the same
reason as https://github.com/stumpwm/stumpwm/issues/606, which is that key-sequences block the main thread and so stumpwm's 
timers don't run. Instead we use threaded timers and a mutex around displaying messages 
to achieve thread safety.

I've been running this for a few days now without errors, but it's all been manual testing.
I also understand if we don't want to bring in more dependencies (though timers and 
threads seems sensible) -- let me know if you think this belongs in stumpwm-contrib rather
than stumpwm.

FWIW, I've been running with this config:

```lisp
(setf *which-key-idle-delay* 0.5)
(setf *which-key-secondary-idle-delay* 0.0)
(setf *which-key-bindings-formatter* #'alphabetical-command-bindings-formatter)
(setf *display-bindings-formatter* #'alphabetical-command-bindings-formatter)

(which-key-mode)
```