### PR TITLE
Check for nil value before calling `window-parent` within `geometry-hints`

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -120,9 +120,10 @@ than the root window's width and height."
                y (frame-y head)
                width (frame-width head)
                height (frame-height head)
-               (xlib:window-priority (window-parent win)
-                                     (window-parent (group-raised-window win-group))) :above
-               (group-raised-window (window-group win)) win))
+               (group-raised-window (window-group win)) win)
+         (when (group-raised-window win-group)
+           (setf (xlib:window-priority (window-parent win)
+                                       (window-parent (group-raised-window win-group))) :above)))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))


### PR DESCRIPTION
While testing #851 we found a bug where if a fullscreen window is moved to a group that has never had a window in it, StumpWM tries to call `window-parent` on `nil`. This is due to the way the function `geometry-hints` handles fullscreen windows. This pull request moves the offending code into a `when` statement dependent upon `group-raised-window` being truthy.  