### PR TITLE
remove unnecessary uses of multiple-value-list

### DIFF
--- a/color.lisp
+++ b/color.lisp
@@ -195,7 +195,7 @@ If COLOR isn't a colorcode a list containing COLOR is returned."
                     (screen-color-map-bright screen)
                     (screen-color-map-normal screen))
                 color))
-        (t (first (multiple-value-list (alloc-color screen color))))))
+        (t (nth-value 0 (alloc-color screen color)))))
 
 (defun find-font (cc specified-font &aux (font (or specified-font 0)))
   (if (integerp font)

--- a/command.lisp
+++ b/command.lisp
@@ -385,8 +385,7 @@ then describes the symbol."
           ;; read a key sequence from the user
           (with-focus (screen-key-window (current-screen))
             (message "~a" prompt)
-            (nreverse (second (multiple-value-list
-                               (read-from-keymap (top-maps) #'update)))))))))
+            (nreverse (nth-value 1 (read-from-keymap (top-maps) #'update))))))))
 
 (define-stumpwm-type :window-number (input prompt)
   (when-let ((n (or (argument-pop input)

--- a/timers.lisp
+++ b/timers.lisp
@@ -42,9 +42,8 @@
 (defun idle-time (screen)
   "Returns the time in seconds since idle according to the root window
 of the `screen'."
-  (/ (first (multiple-value-list
-             (xlib:screen-saver-get-idle
-              *display* (screen-root screen))))
+  (/ (xlib:screen-saver-get-idle
+      *display* (screen-root screen))
      1000.0))
 
 (defun run-with-timer (secs repeat function &rest args)


### PR DESCRIPTION
`cl:nth-value` can be used to access an nth return value. The `(first (multiple-value-list ...))` in `timers.lisp` is not needed since functions like `/` ignore additional return values by default.