### PR TITLE
Add [vh]split-uniformly, deprecate [hv]split-equally.

### DIFF
--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -448,6 +448,8 @@ class hierarchy.")
       "vsplit"
       "hsplit-equally"
       "vsplit-equally"
+      "hsplit-uniformly"
+      "vsplit-uniformly"
       "remove-split"
       "remove"
       "only"

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1865,7 +1865,9 @@ window pool, where windows and frames are not so tightly connected.
 !!! hsplit
 !!! vsplit
 !!! hsplit-equally
+!!! vsplit-uniformly
 !!! vsplit-equally
+!!! hsplit-uniformly
 !!! remove-split
 !!! only
 !!! curframe

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1029,10 +1029,20 @@ windows used to draw the numbers in. The caller must destroy them."
 
 (defcommand (hsplit-equally tile-group) (amt)
     ((:number "Enter the number of frames: "))
+"Deprecated. Use `vsplit-uniformly' instead."
+  (split-frame-eql-parts (current-group) :row amt))
+
+(defcommand (vsplit-uniformly tile-group) (amt)
+    ((:number "Enter the number of frames: "))
 "Split current frame in n rows of equal size."
   (split-frame-eql-parts (current-group) :row amt))
 
 (defcommand (vsplit-equally tile-group) (amt)
+    ((:number "Enter the number of frames: "))
+"Deprecated. Use `hsplit-uniformly' instead."
+  (split-frame-eql-parts (current-group) :column amt))
+
+(defcommand (hsplit-uniformly tile-group) (amt)
     ((:number "Enter the number of frames: "))
 "Split current frame in n columns of equal size."
   (split-frame-eql-parts (current-group) :column amt))


### PR DESCRIPTION
- Add command `vsplit-uniformly' with the same behavior as
  `hsplit-equally'.
- Deprecate `hsplit-equally' in favor of `vsplit-uniformly'.
- Add command `hsplit-uniformly' with the same behavior as
  `vsplit-equally'.
- Deprecate `vsplit-equally' in favor of `hsplit-uniformly'.

This fixes #854.