### PR TITLE
Add *timeout-wait-multiline*

### DIFF
--- a/message-window.lisp
+++ b/message-window.lisp
@@ -125,16 +125,16 @@ function expects to be wrapped in a with-state for win."
     (cancel-timer *frame-indicator-timer*)
     (setf *frame-indicator-timer* nil)))
 
-(defun reset-message-window-timer ()
-  "Set the message window timer to timeout in *timeout-wait* seconds."
+(defun reset-message-window-timer (timeout-wait)
+  "Set the message window timer to timeout in timeout-wait seconds."
   (unless *ignore-echo-timeout*
     (when (timer-p *message-window-timer*)
       (cancel-timer *message-window-timer*))
-    (setf *message-window-timer* (run-with-timer *timeout-wait* nil
+    (setf *message-window-timer* (run-with-timer timeout-wait nil
                                                  'unmap-all-message-windows))))
 
 (defun reset-frame-indicator-timer ()
-  "Set the message window timer to timeout in *timeout-wait* seconds."
+  "Set the message window timer to timeout in *timeout-frame-indicator-wait* seconds."
   (when (timer-p *frame-indicator-timer*)
     (cancel-timer *frame-indicator-timer*))
   (setf *frame-indicator-timer* (run-with-timer *timeout-frame-indicator-wait* nil
@@ -283,7 +283,10 @@ When NEW-ON-BOTTOM-P is non-nil, new messages are queued at the bottom."
           (when (timer-p *message-window-timer*)
             (cancel-timer *message-window-timer*)
             (setf *message-window-timer* nil))
-          (reset-message-window-timer)))
+          (reset-message-window-timer
+            (if (> (length strings) 1)
+                (or *timeout-wait-multiline* *timeout-wait*)
+                *timeout-wait*))))
     (push-last-message screen strings highlights)
     (xlib:display-finish-output *display*)
     (dformat 5 "Outputting a message:~%~{        ~a~%~}" strings)

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -29,6 +29,7 @@
           *suppress-frame-indicator*
           *suppress-window-placement-indicator*
           *timeout-wait*
+          *timeout-wait-multiline*
           *timeout-frame-indicator-wait*
           *frame-indicator-text*
           *frame-indicator-timer*
@@ -196,6 +197,10 @@
 (defvar *timeout-wait* 5
   "Specifies, in seconds, how long a message will appear for. This must
 be an integer.")
+
+(defvar *timeout-wait-multiline* nil
+  "Specifies, in seconds, how long a message will more than one line will
+appear for. This must be an integer. If falsy, default to *timeout-wait*.")
 
 (defvar *timeout-frame-indicator-wait* 1
   "The amount of time a frame indicator timeout takes.")

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1566,6 +1566,7 @@ set these color variables.
 ### *message-window-input-gravity*
 ### *message-window-timer*
 ### *timeout-wait*
+### *timeout-wait-multiline*
 ### *input-window-gravity*
 
 @node Using The Input Bar, Programming The Message Bar, Customizing The Bar, Message and Input Bar


### PR DESCRIPTION
The `*timeout-wait*` variable specifies how long a message will appear for. One might want shorter messages to disappear a lot sooner than long ones.

This PR adds makes the timeout differentiate between single- and multiline messages and adds a variable `*timeout-wait-multiline*` for the multiline ones.