### PR TITLE
Ignore `XLIB:DRAWABLE-ERROR` in `UPDATE-CONFIGURATION`

### DIFF
--- a/window.lisp
+++ b/window.lisp
@@ -354,12 +354,15 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
 (defun update-configuration (win)
   ;; Send a synthetic configure-notify event so that the window
   ;; knows where it is onscreen.
-  (xwin-send-configuration-notify (window-xwin win)
-                                  (+ (xlib:drawable-x (window-parent win))
-                                     (xlib:drawable-x (window-xwin win)))
-                                  (+ (xlib:drawable-y (window-parent win))
-                                     (xlib:drawable-y (window-xwin win)))
-                                  (window-width win) (window-height win) 0))
+  (handler-case
+      (xwin-send-configuration-notify (window-xwin win)
+                                      (+ (xlib:drawable-x (window-parent win))
+                                         (xlib:drawable-x (window-xwin win)))
+                                      (+ (xlib:drawable-y (window-parent win))
+                                         (xlib:drawable-y (window-xwin win)))
+                                      (window-width win) (window-height win) 0)
+    (xlib:drawable-error (c)
+      (dformat 4 "ignore ~S in ~S on ~S" c 'update-configuration win))))
 
 ;; FIXME: should we raise the window or its parent?
 (defmethod raise-window (win)


### PR DESCRIPTION
I encountered a problem where GnuCash windows don't get any StumpWM keybindings, effectively disabling window management while a GnuCash window was focused. Debugging it turned out what appears to be that GnuCash's splash-screen window goes away before the map-request of the main window has completed processing, and when updating the group and remaximizing all windows in it, `UPDATE-CONFIGURATION` gets into trouble because of that, unwinding back to `HANDLE-EVENT`, leaving the main window in a state of only being half-setup.

I can't say I'm sure that just ignoring those errors is the right way to solve this problem, but I at least don't think it should cause any problems, since a dead window shouldn't need any configuration notifications.