### PR TITLE
Replace unnecessary time helper function.

### DIFF
--- a/debug.lisp
+++ b/debug.lisp
@@ -37,7 +37,7 @@ output directly to a file.")
 
 (defun dformat (level fmt &rest args)
   (when (>= *debug-level* level)
-    (multiple-value-bind (sec m h) (get-decoded-system-time)
+    (multiple-value-bind (sec m h) (get-decoded-time)
       (format *debug-stream* "~2,'0d:~2,'0d:~2,'0d ~2,' d " h m sec level))
     ;; strip out non base-char chars quick-n-dirty like
     (write-string (map 'string (lambda (ch)

--- a/time.lisp
+++ b/time.lisp
@@ -123,13 +123,9 @@ run this command to make StumpWM notice the change."
 ;;; Helper functions
 ;;; ------------------------------------------------------------------
 
-(defun get-decoded-system-time ()
-  (decode-universal-time (+ (encode-universal-time 0 0 0 1 1 1970 0)
-                            (sb-posix:time))))
-
 (defun time-plist (&optional time)
   (multiple-value-bind (sec min hour dom mon year dow dstp tz)
-      (or time (get-decoded-system-time))
+      (or time (get-decoded-time))
     (list :second sec :minute min :hour hour :dom dom :month mon
           :year year :dow dow :dlsavings-p dstp :tz tz)))
 


### PR DESCRIPTION
In time.lisp, there is a function `get-decoded-system-time` that is equivalent to `(decode-universal-time (get-universal-time))`, but [such a function already exists in Common Lisp](http://clhs.lisp.se/Body/f_get_un.htm#get-decoded-time). 

I looked at every instance of `get-decoded-system-time` and replaced it with `get-decoded-time`. If you do the math, the helper function is unnecessarily complicated.