### PR TITLE
Typo fix: match-properties-or-function -> match-properties-and-function

### DIFF
--- a/window-placement.lisp
+++ b/window-placement.lisp
@@ -80,7 +80,7 @@
             (match-properties-or-function
              (or properties-matched (funcall match-properties-or-function w)))
             (match-properties-and-function
-             (and properties-matched (funcall match-properties-or-function w)))
+             (and properties-matched (funcall match-properties-and-function w)))
             (t properties-matched)))))
 
 (defun rule-matching-window (window)


### PR DESCRIPTION
The `match-properties-or-function` value was incorrectly used.