### PR TITLE
Removed call to update-configuration from maximize-window.

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -215,8 +215,7 @@ than the root window's width and height."
                                   wy
                                   (- (xlib:drawable-height (window-parent win)) height wy))
                             :cardinal 32))
-    (update-decoration win)
-    (update-configuration win)))
+    (update-decoration win)))
 
 ;;;
 


### PR DESCRIPTION
Calling update-configuration on maximize triggers an event loop for
all Reaper windows [https://reaper.fm].

Fixes #859

I have stumpwm running with this patch for a week now and did not notice any strange window behavior.