### PR TITLE
be more stringent about string inputs to "y or n" prompts

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -340,7 +340,11 @@ then describes the symbol."
 (define-stumpwm-type :y-or-n (input prompt)
   (let ((s (or (argument-pop input)
                (read-one-line (current-screen) (concat prompt "(y/n): ")))))
-    (equal s "y")))
+    (if (equal s "y")
+        t
+        (if (equal s "n")
+            nil
+            (throw 'error (format nil "Invalid (y/n) input: ~A" s))))))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?

--- a/command.lisp
+++ b/command.lisp
@@ -338,18 +338,10 @@ then describes the symbol."
       ,@body)))
 
 (define-stumpwm-type :y-or-n (input prompt)
-  (let* ((valid '(("y" . t)
-                  ("Y" . t)
-                  (t . t)
-                  ("n" . nil)
-                  ("N" . nil)
-                  (nil . nil)))
+  (let* ((valid '("y" "Y" t))
          (s (or (argument-pop input)
                 (read-one-line (current-screen) (concat prompt "(y/n): "))))
-         (out (assoc s valid :test 'equal)))
-    (if out
-        (cdr out)
-        (throw 'error (format nil "Invalid (y/n) input: ~A" s)))))
+         (member s valid :test #'equal))))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?

--- a/command.lisp
+++ b/command.lisp
@@ -338,13 +338,18 @@ then describes the symbol."
       ,@body)))
 
 (define-stumpwm-type :y-or-n (input prompt)
-  (let ((s (or (argument-pop input)
-               (read-one-line (current-screen) (concat prompt "(y/n): ")))))
-    (if (equal s "y")
-        t
-        (if (equal s "n")
-            nil
-            (throw 'error (format nil "Invalid (y/n) input: ~A" s))))))
+  (let* ((valid '(("y" . t)
+                  ("Y" . t)
+                  (t . t)
+                  ("n" . nil)
+                  ("N" . nil)
+                  (nil . nil)))
+         (s (or (argument-pop input)
+                (read-one-line (current-screen) (concat prompt "(y/n): "))))
+         (out (assoc s valid :test 'equal)))
+    (if out
+        (cdr out)
+        (throw 'error (format nil "Invalid (y/n) input: ~A" s)))))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?

--- a/command.lisp
+++ b/command.lisp
@@ -338,10 +338,10 @@ then describes the symbol."
       ,@body)))
 
 (define-stumpwm-type :y-or-n (input prompt)
-  (let* ((valid '("y" "Y" t))
+  (let* ((positive-responses '("y" t))
          (s (or (argument-pop input)
                 (read-one-line (current-screen) (concat prompt "(y/n): "))))
-         (member s valid :test #'equal))))
+         (member s positive-responses :test #'equalp))))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?


### PR DESCRIPTION
I kept trying to call commands with arguments like `t`, which `:y-or-n` evaluates to `nil`, which confused me. So i made `:y-or-n` throw an error if the argument isn't `"y"` or `"n"`

alternatively, we could create a list of arguments that evaluates to `t`, i would propose `t`, `"t"`, and `"Y"`

let me know what you think!