### PR TITLE
Fix compile error: fix let binding body position

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -340,8 +340,8 @@ then describes the symbol."
 (define-stumpwm-type :y-or-n (input prompt)
   (let* ((positive-responses '("y" t))
          (s (or (argument-pop input)
-                (read-one-line (current-screen) (concat prompt "(y/n): "))))
-         (member s positive-responses :test #'equalp))))
+                (read-one-line (current-screen) (concat prompt "(y/n): ")))))
+    (member s positive-responses :test #'equalp)))
 
 (defun lookup-symbol (string)
   ;; FIXME: should we really use string-upcase?


### PR DESCRIPTION
* command.lisp (:y-or-n):
The body was placed in let varlist by mistake. I moved it out.