### PR TITLE
Some floating group fixes for gmove

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -138,14 +138,15 @@
 
 (defmethod group-startup ((group float-group)))
 
-(flet ((add-float-window (group window)
+(flet ((add-float-window (group window raise)
          (change-class window 'float-window)
          (float-window-align window)
-         (group-focus-window group window)))
-  (defmethod group-add-window ((group float-group) window &key &allow-other-keys)
-    (add-float-window group window))
-  (defmethod group-add-window (group (window float-window) &key &allow-other-keys)
-    (add-float-window group window)))
+         (when raise
+           (group-focus-window group window))))
+  (defmethod group-add-window ((group float-group) window &key raise &allow-other-keys)
+    (add-float-window group window raise))
+  (defmethod group-add-window (group (window float-window) &key raise &allow-other-keys)
+    (add-float-window group window raise)))
 
 (defun %float-focus-next (group)
   (if (group-windows group)

--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -139,10 +139,13 @@
 (defmethod group-startup ((group float-group)))
 
 (flet ((add-float-window (group window raise)
-         (change-class window 'float-window)
-         (float-window-align window)
-         (when raise
-           (group-focus-window group window))))
+         (let ((fullscreen-p (window-fullscreen window)))
+           (change-class window 'float-window)
+           (float-window-align window)
+           (when fullscreen-p
+             (activate-fullscreen window))
+           (when raise
+             (group-focus-window group window)))))
   (defmethod group-add-window ((group float-group) window &key raise &allow-other-keys)
     (add-float-window group window raise))
   (defmethod group-add-window (group (window float-window) &key raise &allow-other-keys)


### PR DESCRIPTION
This pull request addresses two issues when moving a window to a float group:

1. The group was unconditionally selected after a gmove - as if gmove-and-select was used
2. Full screen windows got back to normal size after moving.

