### PR TITLE
Fix moving last window of floating group to another group

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -148,9 +148,10 @@
     (add-float-window group window)))
 
 (defun %float-focus-next (group)
-  (if (group-windows group)
-      (group-focus-window group (first (group-windows group)))
-      (no-focus group nil)))
+  (let ((windows (remove-if 'window-hidden-p (group-windows group))))
+    (if windows
+        (group-focus-window group (first windows))
+        (no-focus group nil))))
 
 (defmethod group-delete-window ((group float-group) (window float-window))
   (declare (ignore window))


### PR DESCRIPTION
When moving the window from a group to another, the window is marked as hidden, then it is actually
hidden, and group is asked to process lost focus. For float groups, the window focus lost function
picks up the next window in the group, even when it is hidden.

This patch doesn't allow a hidden window to gain focus.

As a side effect, `hide-window` now works for the last window of a floating group (need to verify that it wasn't working).