### PR TITLE
Allow help keys to be changed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Daniel Oliveira     drdo at drdo.eu
 Panji Kusuma        epanji at gmail dot com
 Andrin Bertschi     hi at abertschi dot ch
 Spenser Max Truex   web ate spensertruex.com
+Toby Worland        toby dot worland at gmail.com

--- a/bindings.lisp
+++ b/bindings.lisp
@@ -27,12 +27,16 @@
 (export '(*groups-map*
           *group-top-maps*
           *help-map*
+          *help-keys*
           set-prefix-key))
 
 (defvar *escape-key* (kbd "C-t")
   "The escape key. Any keymap that wants to hang off the escape key
 should use this specific key struct instead of creating their own
 C-t.")
+
+(defvar *help-keys* '("?" "C-h")
+  "The list of keys used to invoke the help command.")
 
 (defvar *escape-fake-key* (kbd "t")
   "The binding that sends the fake escape key to the current window.")

--- a/events.lisp
+++ b/events.lisp
@@ -207,7 +207,8 @@ The Caller is responsible for setting up the input focus."
                (when grab (ungrab-pointer)))))
           (match
            (values match key-seq))
-          ((and (find key (mapcar #'kbd *help-keys*)
+          ((and (find key *help-keys* :key #'kbd
+                                   
                       :test 'equalp))
            (apply 'display-bindings-for-keymaps (reverse (cdr key-seq)) (dereference-kmaps kmaps))
            (values t key-seq))

--- a/events.lisp
+++ b/events.lisp
@@ -207,8 +207,7 @@ The Caller is responsible for setting up the input focus."
                (when grab (ungrab-pointer)))))
           (match
            (values match key-seq))
-          ((and (find key (list (kbd "?")
-                                (kbd "C-h"))
+          ((and (find key (mapcar #'kbd *help-keys*)
                       :test 'equalp))
            (apply 'display-bindings-for-keymaps (reverse (cdr key-seq)) (dereference-kmaps kmaps))
            (values t key-seq))

--- a/help.lisp
+++ b/help.lisp
@@ -106,7 +106,7 @@
 
 (defun help-key-p (keys)
   "If the key is for the help command."
-  (final-key-p keys '("?" "C-h")))
+  (final-key-p keys *help-keys*))
 
 (defun cancel-key-p (keys)
   "If a key is the cancelling key binding."

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -839,7 +839,7 @@ input should be valid Common Lisp.
 
 @item C-t C-h
 @itemx C-t ?
-The help. These are set using the @var{*help-keys*} variable.
+The help. These can be customized using the @var{*help-keys*} variable.
 
 @item C-t -
 Hide all frames and show the root window.

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -839,7 +839,7 @@ input should be valid Common Lisp.
 
 @item C-t C-h
 @itemx C-t ?
-The help.
+The help. These are set using the @var{*help-keys*} variable.
 
 @item C-t -
 Hide all frames and show the root window.
@@ -2465,6 +2465,7 @@ Return T if TIMER is a timer structure.
 @@@ lookup-command
 
 ### *help-map*
+### *help-keys*
 
 @node Colors, Hooks, Miscellaneous Commands, Top
 @chapter Colors


### PR DESCRIPTION
Introduce a new variable called `*help-keys*`. Which holds the keys used to invoke the help command, instead of hard coding them.
Defaults to `C-h` and `?`

Fixes #891 