### PR TITLE
Call group-focus-window only when requested

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -138,14 +138,15 @@
 
 (defmethod group-startup ((group float-group)))
 
-(flet ((add-float-window (group window)
+(flet ((add-float-window (group window raise)
          (change-class window 'float-window)
          (float-window-align window)
-         (group-focus-window group window)))
-  (defmethod group-add-window ((group float-group) window &key &allow-other-keys)
-    (add-float-window group window))
-  (defmethod group-add-window (group (window float-window) &key &allow-other-keys)
-    (add-float-window group window)))
+         (when raise
+           (group-focus-window group window))))
+  (defmethod group-add-window ((group float-group) window &key raise &allow-other-keys)
+    (add-float-window group window raise))
+  (defmethod group-add-window (group (window float-window) &key raise &allow-other-keys)
+    (add-float-window group window raise)))
 
 (defun %float-focus-next (group)
   (let ((windows (remove-if 'window-hidden-p (group-windows group))))


### PR DESCRIPTION
For float groups, when moving window to another group, the target group was selected automatically.

This patch fixes this by adding the raise parameter - similar to tiling and dynamic groups.