### PR TITLE
Add a type declamation for *TOP-LEVEL-ERROR-ACTION*

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -532,6 +532,7 @@ are valid values.
 (defvar *maxsize-gravity* :center)
 (defvar *transient-gravity* :center)
 
+(declaim (type (member :message :break :abort) *top-level-error-action*))
 (defvar *top-level-error-action* :abort
   "If an error is encountered at the top level, in
 STUMPWM-INTERNAL-LOOP, then this variable decides what action


### PR DESCRIPTION
The compiler will now ensure that *TOP-LEVEL-ERROR-ACTION* will only be one of the prescribed values. This is useful because toplevel errors are handled in an ECASE expression, so if *TOP-LEVEL-ERROR-ACTION* contains an unexpected value at the time of a toplevel error, the expression will cause another, more cryptic error to be signaled.