### PR TITLE
 Fix problem input-insert-char on SBCL 2.1.7

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -607,8 +607,9 @@ second and neither excedes the bounds of the input string."
 position. @var{input} must be of type @var{input-line}. Input
 functions are passed this structure as their first argument."
   (vector-push-extend #\_ (input-line-string input))
-  (replace (input-line-string input) (input-line-string input)
-           :start2 (input-line-position input) :start1 (1+ (input-line-position input)))
+  (replace (input-line-string input) (copy-seq (input-line-string input))
+           :start1 (1+ (input-line-position input))
+           :start2 (input-line-position input))
   (setf (char (input-line-string input) (input-line-position input)) char)
   (incf (input-line-position input)))
 


### PR DESCRIPTION
In **input-insert-char** function, we use replace with same sequence in arguments. It signal an error "The value -1 is not of type SB-INT:INDEX when binding SB-VM::SRC-START". It is appear when SBCL updated to version 2.1.7 on my machine. Since replace destructively modifies SEQUENCE1, we should not used same sequence for SEQUENCE2.

It is probably the same issues:
https://github.com/stumpwm/stumpwm/issues/912
https://github.com/stumpwm/stumpwm/pull/910