### PR TITLE
Add the sterling pound to keytrans

### DIFF
--- a/keytrans.lisp
+++ b/keytrans.lisp
@@ -69,6 +69,7 @@ calling KEYSYM->KEYSYM-NAME."
 (define-keysym-name "!" "exclam")
 (define-keysym-name "\"" "quotedbl")
 (define-keysym-name "$" "dollar")
+(define-keysym-name "£" "sterling")
 (define-keysym-name "%" "percent")
 (define-keysym-name "&" "ampersand")
 (define-keysym-name "'" "quoteright")   ;deprecated


### PR DESCRIPTION
I notice that the symbol £ wasn't included in the keytrans file, for people that use the english UK layout it maybe useful.