### PR TITLE
Don't raise fullscreen windows in GEOMETRY-HINTS

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -118,11 +118,7 @@ than the root window's width and height."
          (setf x (frame-x head)
                y (frame-y head)
                width (frame-width head)
-               height (frame-height head))
-         (when (group-raised-window win-group)
-           (setf (xlib:window-priority (window-parent win)
-                                       (window-parent (group-raised-window win-group))) :above))
-         (setf (group-raised-window win-group) win))
+               height (frame-height head)))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))


### PR DESCRIPTION
Raising fullscreen windows in `geometry-hints` causes problems when new windows are created in a group which has an unfocused fullscreen window open. Also, it does not seem like a very good idea to be changing window orders in a function meant to get properties, as earlier discussed [here](https://github.com/stumpwm/stumpwm/issues/632#issuecomment-521786107).

If anyone knows if there is a good reason the function was written to raise fullscreen windows, I can write a patch which still respects that, but for now this seems like the solution to this issue.