### PR TITLE
Patch window placement rules

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1151,11 +1151,13 @@ The windows title must not match @var{title-not}.
 
 @item match-properties-and-function
 A function that, if provided, must return true alongside the provided properties
-in order for the rule to match. This function takes one argument, the window.
+in order for the rule to match. This function takes one argument, the window. 
+Must be an unquoted symbol to be looked up at runtime. 
 
 @item match-properties-or-function
 A function that, if provided and returning true, will cause the rule to match
 regardless of whether the window properties match. Takes one argument, the window.
+Must be an unquoted symbol to be looked up at runtime. 
 @end table"
   (let ((x (gensym "X")))
     `(dolist (,x ',frame-rules)

--- a/window-placement.lisp
+++ b/window-placement.lisp
@@ -80,7 +80,7 @@
             (match-properties-or-function
              (or properties-matched (funcall match-properties-or-function w)))
             (match-properties-and-function
-             (and properties-matched (funcall match-properties-or-function w)))
+             (and properties-matched (funcall match-properties-and-function w)))
             (t properties-matched)))))
 
 (defun rule-matching-window (window)


### PR DESCRIPTION
* Fix typo causing hard crash

when using `match-properties-and-function` alone a typo was causing it to funcall `match-properties-or-function` instead, which caused a hard crash from which one cannot recover.

* update docstring

Update docstring for `define-frame-preference` to accurately reflect the acceptable values for `match-properties-[and|or]-function` key arguments.