### PR TITLE
Update window decorations when a tiled window is floated

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1401,6 +1401,7 @@ direction. The following are valid directions:
   (let ((frame (tile-group-current-frame group)))
     (change-class window 'float-window)
     (float-window-align window)
+    (update-decoration window)
     (funcall-on-node (tile-group-frame-tree group)
                      (lambda (f) (setf (slot-value f 'window) nil))
                      (lambda (f) (eq frame f)))))


### PR DESCRIPTION
Quick one-liner to cause tile-group-float-window to update the window decorations. As it stands, each floated window uses the default decoration settings and doesn't follow the user's settings until it loses or regains focus.