### PR TITLE
Fix window head selection on full screen

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -79,9 +79,9 @@
         (heads (screen-heads (group-screen (window-group window)))))
     (flet ((within-frame-p (y x head)
              (and (>= x (frame-x head))
-                  (< x (+ (frame-x head) (frame-width head)))
+                  (< x (+ (frame-x head) (1- (frame-width head))))
                   (>= y (frame-y head))
-                  (< y (+ (frame-y head) (frame-height head))))))
+                  (< y (+ (frame-y head) (1- (frame-height head)))))))
       (or (find-if (lambda (head)
                      (or (within-frame-p top left head)
                          (within-frame-p top right head)
@@ -246,7 +246,7 @@
        (* 2 *normal-border-width*)
        *float-window-border*
        *float-window-title-height*)))
-  
+
 (defun maximize-float (window &key horizontal vertical)
   (let* ((head (window-head window))
          (ml (head-mode-line head))
@@ -257,7 +257,7 @@
                (* 2 *float-window-border*)))
          (h (window-display-height window)))
     (when horizontal
-      (float-window-move-resize window :width w)) 
+      (float-window-move-resize window :width w))
     (when vertical
       (float-window-move-resize window :y hy :height h))
     (when (and horizontal vertical)
@@ -273,7 +273,7 @@
         (xwin (window-xwin window)))
     (when (member *mouse-focus-policy* '(:click :sloppy))
       (group-focus-window group window))
-    
+
     ;; When in border
     (multiple-value-bind (relx rely same-screen-p child state-mask)
         (xlib:query-pointer (window-parent window))
@@ -293,12 +293,12 @@
                  (win-focused-p (eq window (screen-focus screen))))
             (setf *last-click-time* current-time)
             (when (< delta-t 0.25)
-              (cond ((and (not (eq (window-height window) 
-                                   (window-display-height window))) 
-                          win-focused-p) 
+              (cond ((and (not (eq (window-height window)
+                                   (window-display-height window)))
+                          win-focused-p)
                      (maximize-float window :vertical t))
                     (win-focused-p (maximize-float window :vertical t :horizontal t))
-                    (t (focus-window window t))))))  
+                    (t (focus-window window t))))))
 
         (multiple-value-bind (relx rely same-screen-p child state-mask)
             (xlib:query-pointer (window-parent window))


### PR DESCRIPTION
When a window is maximized it can move to the wrong head, depending on whether left/top is matched or right/bottom is matched first in the list of heads. This patch makes it choose the same head independent of the head list order.