### PR TITLE
No hardcoded keybindings colors and which-key format

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -24,11 +24,22 @@
 
 (in-package #:stumpwm)
 
-(export '(*help-max-height* *message-max-width*))
+(export '(*help-max-height*
+          *message-max-width*
+          *which-key-format*))
+
 (defvar *message-max-width* 80
   "The maximum width of a message before it wraps.")
 (defvar *help-max-height* 10
   "Maximum number of lines for help to display.")
+(defvar *which-key-format* (concat *key-seq-color* "*5a^n ~a")
+  "The format string that decides how keybindings will show up in the
+which-key window. Two arguments will be passed to this formatter:
+
+@table @asis
+@item the keybind itself
+@item the associated command
+@end talbe")
 
 (defun columnize (list columns &key col-aligns (pad 1) (char #\Space) (align :left))
   ;; only somewhat nasty
@@ -59,7 +70,7 @@
          (data (mapcan (lambda (map)
                          (mapcar (lambda (b)
                                    (let ((bound-to (binding-command b)))
-                                     (format nil "^5*~5a^n ~a"
+                                     (format nil *which-key-format*
                                              (print-key (binding-key b))
                                              (cond ((or (symbolp bound-to)
                                                         (stringp bound-to))

--- a/help.lisp
+++ b/help.lisp
@@ -39,7 +39,7 @@ which-key window. Two arguments will be passed to this formatter:
 @table @asis
 @item the keybind itself
 @item the associated command
-@end talbe")
+@end table")
 
 (defun columnize (list columns &key col-aligns (pad 1) (char #\Space) (align :left))
   ;; only somewhat nasty

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -26,6 +26,7 @@
 
 (export '(*top-map*
           *root-map*
+          *key-seq-color*
           define-key
           kbd
           lookup-command
@@ -41,6 +42,10 @@
   "This is the keymap by default bound to @kbd{C-t} (along with 
  *group-root-map* and either *tile-group-root-map*, *float-group-root-map*,
  or *dynamic-group-map*). It is known as the @dfn{prefix map}.")
+
+(defvar *key-seq-color* "^5"
+  "Color of a keybinding when displayed in windows such as the prefix
+keybinding in the which-key window.")
 
 (defstruct key
   keysym shift control meta alt hyper super)
@@ -177,7 +182,9 @@ others."
           (keysym->stumpwm-name (key-keysym key))))
 
 (defun print-key-seq (seq)
-  (format nil "^5*~{~a~^ ~}^n" (mapcar 'print-key seq)))
+  (format nil
+          (concat *key-seq-color* "*~{~a~^ ~}^n")
+          (mapcar 'print-key seq)))
 
 (defun define-key (map key command)
   "Add a keybinding mapping for the key, @var{key}, to the command,

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -950,6 +950,7 @@ Describe the specified command.
 ### *groups-map*
 ### *group-top-maps*
 ### *exchange-window-map*
+### *key-seq-color*
 
 !!! bind
 !!! unbind
@@ -1536,6 +1537,7 @@ return a ``nil'' value in those cases, and let the command handle that.
 @@@ wrap
 ### *message-max-width*
 ### *help-max-height*
+### *which-key-format*
 !!! colon
 
 %%% with-restarts-menu


### PR DESCRIPTION
This commit adds two new customizable variables:
- \*key-seq-color\*
- \*which-key-format\*

The former modifies the color of keybindings color as shown in the
prefix string in the which-key-mode windows.

The latter modifies how keybinds are displayed in the which-key-mode
windows.
Although \*which-key-format\* relies on \*key-seq-color\* when
initializing its value, if the latter is updated, it will be necessary
to also update the former.