### PR TITLE
Fix improper item-object in menu filter predicate

### DIFF
--- a/menu-definitions.lisp
+++ b/menu-definitions.lisp
@@ -230,7 +230,7 @@ a re-computation of the match."
           (labels ((match-p (table-item)
                      (funcall (single-menu-filter-pred menu)
                               (car table-item)
-                              (second table-item)
+                              (cdr table-item)
                               (single-menu-current-input menu))))
             (setf (menu-table menu) (remove-if-not #'match-p (single-menu-unfiltered-table menu))
                   (menu-selected menu) 0)


### PR DESCRIPTION
I found a bug in `select-from-menu` function. It tried to take a second element of menu element when my menu elements were conses.

I think that we should not force the menu elements to be lists of length 2. Instead, they should be conses where car element is a string displayed in menu and cdr is item-object.