### PR TITLE
Display keybindings in `describe-command`

### DIFF
--- a/help.lisp
+++ b/help.lisp
@@ -278,7 +278,7 @@ FIND-BINDING-IN-KMAP."
                      lambda-list))
            (format nil "~&~a" (or (documentation name 'function) ""))
            (when (stringp com)
-             (when-let ((bindings (find-binding com)))
+             (when-let ((bindings (find-binding com :top-level-maps (top-maps))))
                (let ((organized
                        (mapcar (lambda (b)
                                  (let ((final

--- a/help.lisp
+++ b/help.lisp
@@ -302,14 +302,14 @@ FIND-BINDING-IN-KMAP."
                     (format nil "~&~a" (or (documentation name 'function) "")))
                    *message-max-width*
                    nil)))
-      (when (stringp com)
-        (let ((bindings (find-binding com :top-level-maps (top-maps))))
-          (if bindings 
-              (format stream
-                      "~A~%~%Bound to:~%~{~{~A~#[~; invoking ~:; in ~]~}~^~%~}"
-                      text
-                      (make-even-lengths bindings))
-              (format stream "~A" text)))))))
+      (let ((bindings (when (stringp com)
+                        (find-binding com :top-level-maps (top-maps)))))
+        (if bindings 
+            (format stream
+                    "~A~%~%Bound to:~%~{~{~A~#[~; invoking ~:; in ~]~}~^~%~}"
+                    text
+                    (make-even-lengths bindings))
+            (format stream "~A" text))))))
       
 (defcommand describe-command (com) ((:command "Describe Command: "))
   "Print the online help associated with the specified command."


### PR DESCRIPTION
This PR displays keybindings and keymaps in the `describe-command` message. It adds two functions, `find-binding` and `find-binding-in-kmap` which recursively look through the specified keymaps (and all sub-maps) and return a list of bindings that match the specified command. 

Here is some screenshots of `describe-command`:

![describe-frame-screenshot png](https://user-images.githubusercontent.com/39150985/148818189-1a7bd991-81d4-4130-a7e6-5edd2e972fd3.png)

![describe-frame-screenshot png png](https://user-images.githubusercontent.com/39150985/148819416-f2a88235-5ea2-43c9-811a-06874be6eb4d.png)


This improves StumpWM by improving discoverability and self-documentation capabilities. It also addresses the issue of users undefining a key in `*root-map*` when the binding they wish to remove is in `*[tile|float|dynamic]-group-root-map*` by making it clear which map it is bound in. 

I would appreciate a review of this, as the formatted table of bindings is placed outside of the `wrap` function, as that function removes extra spaces which are needed for the formatting. I dont see anything breaking by having the table outside of the `wrap` function, but I could be wrong. Additionally, it only displays bindings that are active in the current group. It may be desirable to display all bindings for all top maps, but I'm unsure what the default should be. 