### PR TITLE
Typo fix: group -> new-group

### DIFF
--- a/window-placement.lisp
+++ b/window-placement.lisp
@@ -125,7 +125,7 @@
                      (values new-group
                              (if (eq frame :float)
                                  frame
-                                 (frame-by-number group frame))
+                                 (frame-by-number new-group frame))
                              raise)))
                   ((not group-name)
                    (values (current-group)


### PR DESCRIPTION
Fixed typo introduced in 5c077c7e94abf7079d187f8ccb9274144ea4cf83