### PR TITLE
Add ability to ignore color formatters

### DIFF
--- a/color.lisp
+++ b/color.lisp
@@ -204,6 +204,11 @@ If COLOR isn't a colorcode a list containing COLOR is returned."
 
 (defgeneric apply-color (ccontext modifier &rest arguments))
 
+(defmethod apply-color :around ((cc ccontext) modifier &rest arguments)
+  (declare (ignorable ccontext modifier arguments))
+  (when *draw-in-color*
+    (call-next-method)))
+
 (defmethod apply-color ((cc ccontext) (modifier (eql :fg)) &rest args)
   (setf (ccontext-fg cc) (first args))
   (let* ((gcontext (ccontext-gc cc))

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -393,6 +393,9 @@ with 1 argument: the menu.")
 (defvar *text-color* "white"
   "The color of message text.")
 
+(defvar *draw-in-color* t
+  "When NIL color formatters are ignored.")
+
 (defvar *menu-maximum-height* nil
   "Defines the maxium number of lines to display in the menu before enabling
    scrolling. If NIL scrolling is disabled.")

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -3082,6 +3082,7 @@ sending them as one.
 ### *suppress-frame-indicator*
 ### *suppress-window-placement-indicator*
 ### *text-color*
+### *draw-in-color*
 ### *timeout-frame-indicator-wait*
 ### *top-level-error-action*
 


### PR DESCRIPTION
This PR adds the ability to ignore color formatters (such as `^(:fg "red")`). While likely not a big deal for many, I find it useful to suppress color formatters, such as when displaying notifications through StumpWM. 

Edit: apologies, I tried using githubs fetch upstream functionality, and it seems to have added an additional commit. I will remove this. 