### PR TITLE
allow `unmaximize` command to accept a window as its argument

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -456,11 +456,10 @@ frame. Possible values are:
                                                 (window-height-inc window)))))
       (maximize-window window)))))
 
-(defcommand (unmaximize tile-group) () ()
+(defcommand (unmaximize tile-group) (&optional (window (current-window))) (:rest)
   "Use the size the program requested for current window (if any) instead of maximizing it."
-  (let* ((window (current-window))
-         (status (not (window-normal-size window)))
-         (hints (window-normal-hints window)))
+  (let ((status (not (window-normal-size window)))
+        (hints (window-normal-hints window)))
     (if (and (xlib:wm-size-hints-width hints)
              (xlib:wm-size-hints-height hints))
         (progn


### PR DESCRIPTION
`unmaximize` is a command that is useful from Lisp, not just interactively. Because it assumes the current window, it is not possible to use it from functions in `*new-window-hook*` since they are called prior to the new window being made the current one. This fixes that by allowing you to specify a window when calling it from Lisp. Interactively, it still defaults to the current one.