### PR TITLE
Add in frame fullscreen functionality

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1179,6 +1179,44 @@ Must be an unquoted symbol to be looked up at runtime.
   "Clear all window placement rules."
   (setf *window-placement-rules* nil))
 
+(defvar *fullscreen-in-frame-p-window-functions* nil
+  "A alist of predicate functions for determining if a window should be
+fullscreen in frame.")
+
+(defun fullscreen-in-frame-p (win)
+  (some (lambda (r)
+          (let ((res (funcall (cdr r) win)))
+            (when res
+              (dformat 3 "Fullscreen in frame selector ~A matches window ~A"
+                       (car r) win))
+            res))
+        *fullscreen-in-frame-p-window-functions*))
+
+(defun add-fullscreen-in-frame-rule (name function &key shadow)
+  "Add a function to the fullscreen-in-frame window rules alist.  If NAME already
+exists as a key in the alist and SHADOW is nil, then FUNCTION replaces the
+existing value.  Otherwise NAME and FUNCTION are pushed onto the alist."
+  (let ((present (assoc name *fullscreen-in-frame-p-window-functions*)))
+    (if (and present (not shadow))
+        (setf (cdr present) function)
+        (push (cons name function) *fullscreen-in-frame-p-window-functions*))))
+
+(defun remove-fullscreen-in-frame-rule (name &key count)
+  "Remove rules named NAME from the fullscreen-in-frame window rules alist.  If
+COUNT is NIL then all matching rules are removed, otherwise only the first COUNT
+rules are removed."
+  (setf *fullscreen-in-frame-p-window-functions*
+        (remove name *fullscreen-in-frame-p-window-functions*
+                :key #'car :count count)))
+
+(defmacro define-fullscreen-in-frame-rule (name (window-argument) &body body)
+  "Define a rule for a window to be fullscreened within the frame.  Each rule is a
+function which will be called when a window is made fullscreen.  If the rule
+returns NIL then the fullscreen window takes up the entire head, otherwise it
+takes up only its frame."
+  `(flet ((,name (,window-argument) ,@body))
+     (add-fullscreen-in-frame-rule ',name #',name)))
+
 (defvar *mouse-focus-policy* :ignore
   "The mouse focus policy decides how the mouse affects input
 focus. Possible values are :ignore, :sloppy, and :click. :ignore means

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1193,18 +1193,19 @@ fullscreen in frame.")
         *fullscreen-in-frame-p-window-functions*))
 
 (defun add-fullscreen-in-frame-rule (name function &key shadow)
-  "Add a function to the fullscreen-in-frame window rules alist.  If NAME already
-exists as a key in the alist and SHADOW is nil, then FUNCTION replaces the
-existing value.  Otherwise NAME and FUNCTION are pushed onto the alist."
+  "Add a function to the fullscreen-in-frame window rules alist.  If @var{NAME}
+already exists as a key in the alist and @var{SHADOW} is nil, then
+@var{FUNCTION} replaces the existing value.  Otherwise @var{NAME} and
+@var{FUNCTION} are pushed onto the alist."
   (let ((present (assoc name *fullscreen-in-frame-p-window-functions*)))
     (if (and present (not shadow))
         (setf (cdr present) function)
         (push (cons name function) *fullscreen-in-frame-p-window-functions*))))
 
 (defun remove-fullscreen-in-frame-rule (name &key count)
-  "Remove rules named NAME from the fullscreen-in-frame window rules alist.  If
-COUNT is NIL then all matching rules are removed, otherwise only the first COUNT
-rules are removed."
+  "Remove rules named @var{NAME} from the fullscreen-in-frame window rules alist.
+If @var{COUNT} is NIL then all matching rules are removed, otherwise only the
+first @var{COUNT} rules are removed."
   (setf *fullscreen-in-frame-p-window-functions*
         (remove name *fullscreen-in-frame-p-window-functions*
                 :key #'car :count count)))
@@ -1213,7 +1214,8 @@ rules are removed."
   "Define a rule for a window to be fullscreened within the frame.  Each rule is a
 function which will be called when a window is made fullscreen.  If the rule
 returns NIL then the fullscreen window takes up the entire head, otherwise it
-takes up only its frame."
+takes up only its frame. Within the body of the rule @var{WINDOW-ARGUMENT} is
+bound to the window being processed."
   `(flet ((,name (,window-argument) ,@body))
      (add-fullscreen-in-frame-rule ',name #',name)))
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -1706,6 +1706,14 @@ An input function takes 2 arguments: the input structure and the key pressed.
 ### *hidden-window-color*
 
 ### *honor-window-moves*
+
+
+%%% define-fullscreen-in-frame-rule
+@@@ add-fullscreen-in-frame-rule
+@@@ remove-fullscreen-in-frame-rule
+### *fullscreen-in-frame-p-window-functions*
+
+
 @menu
 * Window Marks::
 * Customizing Window Appearance::

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -114,11 +114,27 @@ than the root window's width and height."
       ;; handle specially fullscreen windows.
       ((window-fullscreen win)
        (let* ((win-group (window-group win))
-              (head (frame-head win-group f)))
-         (setf x (frame-x head)
-               y (frame-y head)
-               width (frame-width head)
-               height (frame-height head)))
+              (fs-in-frame (fullscreen-in-frame-p win))
+              (head (frame-head win-group f))
+              (frame-to-fill (if fs-in-frame f head))
+              (ml (head-mode-line head)))
+         ;; determine if the window should be fullscreened in the frame or the
+         ;; head. When fullscreen-in-frame-p returns true, use the current frame
+         ;; and adjust for mode line size. 
+         (setf x (frame-x frame-to-fill)
+               y (+ (frame-y frame-to-fill)
+                    (if (and fs-in-frame 
+                             (or (eq :stump (mode-line-mode ml))
+                                 (eq :visible (mode-line-mode ml))))
+                        (mode-line-height ml)
+                        0))
+               width (frame-width frame-to-fill)
+               height (- (frame-height frame-to-fill)
+                         (if (and fs-in-frame 
+                                  (or (eq :stump (mode-line-mode ml))
+                                      (eq :visible (mode-line-mode ml))))
+                             (mode-line-height ml)
+                             0))))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -117,24 +117,19 @@ than the root window's width and height."
               (fs-in-frame (fullscreen-in-frame-p win))
               (head (frame-head win-group f))
               (frame-to-fill (if fs-in-frame f head))
-              (ml (head-mode-line head)))
+              (ml (head-mode-line head))
+              (adjust-by (if (and fs-in-frame
+                                  (or (eq :stump (mode-line-mode ml))
+                                      (eq :visible (mode-line-mode ml))))
+                             (mode-line-height ml)
+                             0)))
          ;; determine if the window should be fullscreened in the frame or the
          ;; head. When fullscreen-in-frame-p returns true, use the current frame
          ;; and adjust for mode line size. 
          (setf x (frame-x frame-to-fill)
-               y (+ (frame-y frame-to-fill)
-                    (if (and fs-in-frame 
-                             (or (eq :stump (mode-line-mode ml))
-                                 (eq :visible (mode-line-mode ml))))
-                        (mode-line-height ml)
-                        0))
+               y (+ (frame-y frame-to-fill) adjust-by)
                width (frame-width frame-to-fill)
-               height (- (frame-height frame-to-fill)
-                         (if (and fs-in-frame 
-                                  (or (eq :stump (mode-line-mode ml))
-                                      (eq :visible (mode-line-mode ml))))
-                             (mode-line-height ml)
-                             0))))
+               height (- (frame-height frame-to-fill) adjust-by)))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))


### PR DESCRIPTION
This PR allows for windows to be made fullscreen within their frame instead of their head. By default all windows will fill the head when being made fullscreen, it is only by defining a rule that they are made fullscreen within the window. The rule add/remove functionality was placed in `primitives.lisp` along with the rule defining macro, as this is where `define-frame-preference` is defined, but if there is a better location they can be moved there. This would address issue #971.

This PR doesnt change the default behavior, and windows fullscreened within their frame can coexist with normal fullscreen windows (tested with firefox and vlc). The usage of keys in an alist allow for temporarily overriding a rule, or adding rules that run only once; users could define a macro such as: 

```lisp
(defmacro fullscreen-in-frame-only-once ((win &key keep-until-matched) &body body)
  (with-gensyms (g l)
    `(define-fullscreen-in-frame-rule ,g (,win)
       (let ((,l (progn ,@body)))
         ,(if keep-until-matched
              `(when ,l (remove-fullscreen-in-frame-rule ',g))
              `(remove-fullscreen-in-frame-rule ',g))
         ,l))))
```

Here is a screenshot of multiple fullscreen-in-frame firefox instances: 

![2022-05-19-145336_1366x768_scrot](https://user-images.githubusercontent.com/39150985/169298375-fc701e8a-878d-4de1-a88c-fff41a23aceb.png)

And here is the rule used to fullscreen these windows specifically (helper functions not included): 

```lisp
(define-fullscreen-in-frame-rule firefox-rule (win)
  (when (classed-p win "Firefox")
    (youtube-url-p (get-firefox-url win))))
```

