### PR TITLE
Add preliminary altgr support

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -225,6 +225,7 @@ Available completion styles include
       (= (xlib:keycode->keysym *display* keycode 0) 0)))
 
 (defun register-altgr-as-modifier ()
+  "Register the keysym(s) for ISO_Level3_Shift as modifiers."
   (setf *all-modifiers*
         (append (multiple-value-list
                  (xlib:keysym->keycodes *display*

--- a/input.lisp
+++ b/input.lisp
@@ -223,6 +223,13 @@ Available completion styles include
       ;; Treat No Symbol keys as modifiers (and therefore ignorable)
       (= (xlib:keycode->keysym *display* keycode 0) 0)))
 
+(defun register-altgr-as-modifier ()
+  (setf *all-modifiers*
+        (append (multiple-value-list
+                 (xlib:keysym->keycodes *display*
+                                        (keysym-name->keysym "ISO_Level3_Shift")))
+                *all-modifiers*)))
+
 (defun keycode->character (code mods)
   (let ((idx (if (member :shift mods) 1 0)))
     (xlib:keysym->character *display* (xlib:keycode->keysym *display* code idx) 0)))
@@ -535,7 +542,7 @@ match with an element of the completions."
   (let* ((mods    (xlib:make-state-keys state))
          (shift-p (and (find :shift mods) t))
          (altgr-p (and (intersection (modifiers-altgr *modifiers*) mods) t))
-         (base    (if altgr-p 2 0))
+         (base    (if altgr-p *altgr-offset* 0))
          (sym     (xlib:keycode->keysym *display* code base))
          (upsym   (xlib:keycode->keysym *display* code (+ base 1))))
     ;; If a keysym has a shift modifier, then use the uppercase keysym
@@ -548,7 +555,8 @@ match with an element of the completions."
               :meta (and (intersection mods (modifiers-meta *modifiers*)) t)
               :alt (and (intersection mods (modifiers-alt *modifiers*)) t)
               :hyper (and (intersection mods (modifiers-hyper *modifiers*)) t)
-              :super (and (intersection mods (modifiers-super *modifiers*)) t))))
+              :super (and (intersection mods (modifiers-super *modifiers*)) t)
+              :altgr altgr-p)))
 
 
 ;;; input string utility functions

--- a/input.lisp
+++ b/input.lisp
@@ -28,6 +28,7 @@
           *input-completion-style*
           *input-map*
           *numpad-map*
+          register-altgr-as-modifier
           completing-read
           input-delete-region
           input-goto-char

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -48,7 +48,7 @@
 keybinding in the which-key window.")
 
 (defstruct key
-  keysym shift control meta alt hyper super)
+  keysym shift control meta alt hyper super altgr)
 
 (defstruct kmap
   bindings)
@@ -135,13 +135,33 @@ for passing as the last argument to (apply #'make-key ...)"
                 (#\S (list :shift t))
                 (t (error 'kbd-parse-error :string mods)))))
 
+(defvar *altgr-offset* 2
+  "The offset of altgr keysyms. Often 2 or 4, but always an even number.")
+
+(defun keysym-requires-altgr (keysym)
+  (unless (and (xlib:keysym->keycodes *display* keysym) t)
+    (let* ((min (xlib:display-min-keycode *display*))
+           (max (xlib:display-max-keycode *display*))
+           (map (xlib::display-keyboard-mapping *display*))
+           (size (array-dimension map 1)))
+      (when (> *altgr-offset* size)
+        (error "Cant locate keysym ~A" keysym))
+      (do ((i min (1+ i)))
+          ((> i max) nil)
+        (when (or (= keysym (aref map i *altgr-offset*))
+                  (= keysym (aref map i (1+ *altgr-offset*))))
+          (return-from keysym-requires-altgr t))))))
+
 (defun parse-key (string)
   "Parse STRING and return a key structure. Raise an error of type
 kbd-parse if the key failed to parse."
   (let* ((p (when (> (length string) 2)
               (position #\- string :from-end t :end (- (length string) 1))))
-         (mods (parse-mods string (if p (1+ p) 0)))
-         (keysym (stumpwm-name->keysym (subseq string (if p (1+ p) 0)))))
+         (%mods (parse-mods string (if p (1+ p) 0)))
+         (keysym (stumpwm-name->keysym (subseq string (if p (1+ p) 0))))
+         (mods (if (keysym-requires-altgr keysym)
+                   (append '(:altgr t) %mods)
+                   %mods)))
     (if keysym
         (apply 'make-key :keysym keysym mods)
         (error 'kbd-parse-error :string string))))

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -27,6 +27,7 @@
 (export '(*top-map*
           *root-map*
           *key-seq-color*
+          *altgr-offset*
           define-key
           kbd
           lookup-command
@@ -139,18 +140,19 @@ for passing as the last argument to (apply #'make-key ...)"
   "The offset of altgr keysyms. Often 2 or 4, but always an even number.")
 
 (defun keysym-requires-altgr (keysym)
-  (unless (and (xlib:keysym->keycodes *display* keysym) t)
-    (let* ((min (xlib:display-min-keycode *display*))
-           (max (xlib:display-max-keycode *display*))
-           (map (xlib::display-keyboard-mapping *display*))
-           (size (array-dimension map 1)))
-      (when (> *altgr-offset* size)
-        (error "Cant locate keysym ~A" keysym))
-      (do ((i min (1+ i)))
-          ((> i max) nil)
-        (when (or (= keysym (aref map i *altgr-offset*))
-                  (= keysym (aref map i (1+ *altgr-offset*))))
-          (return-from keysym-requires-altgr t))))))
+  (when *display*
+    (unless (and (xlib:keysym->keycodes *display* keysym) t)
+      (let* ((min (xlib:display-min-keycode *display*))
+             (max (xlib:display-max-keycode *display*))
+             (map (xlib::display-keyboard-mapping *display*))
+             (size (array-dimension map 1)))
+        (when (> *altgr-offset* size)
+          (error "Cant locate keysym ~A" keysym))
+        (do ((i min (1+ i)))
+            ((> i max) nil)
+          (when (or (= keysym (aref map i *altgr-offset*))
+                    (= keysym (aref map i (1+ *altgr-offset*))))
+            (return-from keysym-requires-altgr t)))))))
 
 (defun parse-key (string)
   "Parse STRING and return a key structure. Raise an error of type

--- a/kmap.lisp
+++ b/kmap.lisp
@@ -147,7 +147,7 @@ for passing as the last argument to (apply #'make-key ...)"
              (map (xlib::display-keyboard-mapping *display*))
              (size (array-dimension map 1)))
         (when (> *altgr-offset* size)
-          (error "Cant locate keysym ~A" keysym))
+          (error "AltGr offset is larger than the available offsets"))
         (do ((i min (1+ i)))
             ((> i max) nil)
           (when (or (= keysym (aref map i *altgr-offset*))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -707,6 +707,7 @@ mimics GNU Screen's keyboard handling. StumpWM's default prefix key is
 * List of Default Keybindings::
 * Binding Keys::
 * Modifiers::
+* AltGr Keys::
 * Remapped Keys::
 @end menu
 
@@ -944,7 +945,7 @@ Describe the specified command.
 ### *editor-bindings*
 ### *numpad-map*
 
-@node Modifiers, Remapped Keys, Binding Keys, Key Bindings
+@node Modifiers, AltGr Keys, Binding Keys, Key Bindings
 @section Modifiers
 
 Many users have had some difficulty with setting up modifiers for
@@ -1082,7 +1083,43 @@ commands to the @var{*top-map*}.
 ### *all-modifiers*
 ### *modifiers*
 
-@node Remapped Keys, , Modifiers, Key Bindings
+@node AltGr Keys, Remapped Keys, Modifiers, Key Bindings
+@section AltGr Keys
+
+StumpWM uses the CLX client library for X11, which doesnt support the
+XKB extension. As such support for Alt Graph must be handled
+specially.
+
+Preliminary support for Alt Graph in StumpWM is done by registering
+AltGr as a modifier key and specially handling it when it is a member of
+a key press' state. By default StumpWM treats AltGr key presses as a
+normal key and not a modifier, and this behavior should not be changed
+unless necessary. To enable treating AltGr as a modifier, the user must
+place the following in their stumpwmrc:
+
+@example
+(register-altgr-as-modifier)
+@end example
+
+Additionally, the variable @var{*altgr-offset*} defaults to 2, which may
+be appropriate for the users keyboard layout, or may not. Some users may
+have an AltGr offset of 4, or potentially 6. If, after calling
+@code{register-altgr-as-modifier}, keys on AltGr aren't being registered
+properly, then the offset may need to be changed. The user can check
+this explicitly by finding a keysym that requires AltGr and passing it
+to @code{keysym-requires-altgr}. As an example, some layouts have @kbd{ł} on
+@kbd{AltGr+l}. In such a case, the following example would return true
+when @var{*altgr-offset*} is correct:
+
+@example
+(stumpwm::keysym-requires-altgr
+  (stumpwm::stumpwm-name->keysym "lstroke"))
+@end example
+
+@@@ register-altgr-as-modifier
+### *altgr-offset*
+
+@node Remapped Keys, , AltGr Keys, Key Bindings
 @section Remapped Keys
 
 StumpWM may be configured to translate certain familiar top level


### PR DESCRIPTION
This PR implements preliminary support for altgr key bindings. This wont allow all keys to be input in the input bar, but it will allow binding to keys that can only be pressed with altgr. For example, the `[` key lies on altgr+8 when using the no layout, and this allows entering that key in the input bar, as well as binding commands and keymaps to it. 

While this is 100% a problem that should be solved in CLX instead of here, there has been little progress on it and it seems unlikely to be implemented soon, so this is presented as a workaround to address issues such as #936. 

Certain characters fail to be looked up properly, but I'm unsure if this is an issue specific to my own setup or not. For example, while `lstroke` gets registered properly for binding keys, the keysym that it gets parsed into when entering into the input bar is 435, which doesnt return a character when passed to `xlib:keysym->character`. This may be related to many characters not being present in `xlib::*keysym->character-map*`. 

If this is best maintained as a set of personal patches I'll keep them in a diff to apply myself. 


EDIT: To be very clear, I have not tested this on multiple keyboard layouts outside of `no` and `us`, and I'm unsure how it will function on multiple keyboard layouts that make use of altgr. It will likely fail if the altgr offset is not correct, though this will just put the user back in the position of not having altgr bindings (or modifying the altgr offset when they change layouts).