### PR TITLE
Update makefile to update stumpwm.texi when any lisp files change

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,7 +22,7 @@ stumpwm.info: stumpwm.texi
 	test "$(MAKEINFO)" = "no" || $(MAKEINFO) stumpwm.texi
 
 # FIXME: This rule is too hardcoded
-stumpwm.texi: stumpwm.texi.in
+stumpwm.texi: stumpwm.texi.in $(FILES)
 	$(LISP) $(@LISP@_INFOOPTS)
 
 stumpwm: $(FILES)


### PR DESCRIPTION
Currently the `stumpwm.info` target in the makefile depends on the `stumpwm.texi` target, which in turn only depends upon the file `stumpwm.texi.in`. This PR adds all files listed in the asd file to the requirements for `stumpwm.texi`. The reasoning for this is that the `stumpwm.texi` file is built from docstrings present in the `.lisp` files, and as such should be rebuilt if those docstrings have potentially changed. Currently this file is only rebuilt if `stumpwm.texi.in` is explicitly changed. 