### PR TITLE
Fix fullscreen frame

### DIFF
--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -128,7 +128,7 @@ than the root window's width and height."
              (setf x (frame-x frame-to-fill)
                    y (frame-y frame-to-fill)
                    width (frame-width frame-to-fill)
-                   height (frame-height frame-to-fill)))
+                   height (frame-height frame-to-fill))))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -116,20 +116,19 @@ than the root window's width and height."
        (let* ((win-group (window-group win))
               (fs-in-frame (fullscreen-in-frame-p win))
               (head (frame-head win-group f))
-              (frame-to-fill (if fs-in-frame f head))
-              (ml (head-mode-line head))
-              (adjust-by (if (and fs-in-frame
-                                  (or (eq :stump (mode-line-mode ml))
-                                      (eq :visible (mode-line-mode ml))))
-                             (mode-line-height ml)
-                             0)))
-         ;; determine if the window should be fullscreened in the frame or the
-         ;; head. When fullscreen-in-frame-p returns true, use the current frame
-         ;; and adjust for mode line size. 
-         (setf x (frame-x frame-to-fill)
-               y (+ (frame-y frame-to-fill) adjust-by)
-               width (frame-width frame-to-fill)
-               height (- (frame-height frame-to-fill) adjust-by)))
+              (frame-to-fill (if fs-in-frame f head)))
+         ;; Determine if the window should be fullscreened in the frame or the
+         ;; head. If fullscreening a frame, use the frame-display functions on
+         ;; y axis to account for the modeline.
+         (if fs-in-frame
+             (setf x (frame-x frame-to-fill)
+                   y (frame-display-y win-group frame-to-fill)
+                   width (frame-width frame-to-fill)
+                   height (frame-display-height win-group frame-to-fill))
+             (setf x (frame-x frame-to-fill)
+                   y (frame-y frame-to-fill)
+                   width (frame-width frame-to-fill)
+                   height (frame-height frame-to-fill)))
        (return-from geometry-hints (values x y 0 0 width height 0 t)))
       ;; Adjust the defaults if the window is a transient_for window.
       ((find (window-type win) '(:transient :dialog))


### PR DESCRIPTION
hey, i wrote a big wall of text here, but wonderful firefox browser crashed the tab with no survivors, so forgive me if this is not complete or it sounds bad

i tried out the code in #974, and it didn't really work well for me, it left space at the top when i fullscreened a frame. probably has to do with the fact that @szos has the modeline at the top, and i have it at the bottom. i modified the code so that there's no manual checking of the modeline height and stuff, since there are frame-display functions to handle all that. there was also a comment saying there is a check on whether we are fullscreening a frame or head, but there was no such check, so i added it. the code should probably be changed a bit or something, i don't know lisp so i don't know what is good style/performant.

also, do you think it would be possible to decouple the frame fullscreening functionality from the head fullscreening? for example, if you wanted all the frames to be fullscreened by default, the only way i can currently think of is creating a predicate that always returns true, but this makes it impossible to make a window fullscreened for the head
