### PR TITLE
Minor mode updates

### DIFF
--- a/minor-modes.lisp
+++ b/minor-modes.lisp
@@ -51,6 +51,8 @@
           minor-mode-global-p
           enable-minor-mode
           disable-minor-mode
+          autoenable-minor-mode
+          autodisable-minor-mode
           minor-mode-keymap
           minor-mode-lighter
 

--- a/minor-modes.lisp
+++ b/minor-modes.lisp
@@ -178,6 +178,10 @@ object.")
   (:method (minor-mode) nil)
   (:documentation "Return a string of minor mode lighters."))
 
+(defgeneric lighter-on-click (minor-mode-symbol)
+  (:method (minor-mode) nil)
+  (:documentation "Return the on-click function defined for MINOR-MODE-SYMBOL"))
+
 (defgeneric minor-mode-enable-hook (minor-mode-symbol)
   (:documentation
    "Returns the minor mode enable hook for a given minor mode symbol. This hook is
@@ -448,6 +452,22 @@ modes."
          (mapcar #'minor-mode-keymap
                  (list-current-mode-objects :screen (group-screen group)))))
 
+;;; Lighter on click
+
+(flet ((ml-on-click-minor-mode (code minor-mode &rest rest)
+         (declare (ignore rest))
+         (let ((fn (lighter-on-click minor-mode)))
+           (if fn
+               (funcall fn code)
+               (let ((svar
+                       (read-one-line (current-screen)
+                                      (format nil
+                                              "Disable minor mode ~A? [Yes/no] "
+                                              minor-mode))))
+                 (when (string-equal "yes" svar)
+                   (disable-minor-mode minor-mode)))))))
+  (register-ml-on-click-id :ml-on-click-minor-mode #'ml-on-click-minor-mode))
+
 ;;; Helper Functions
 
 (defun generate-keymap (keymap-spec &optional
@@ -572,6 +592,7 @@ ROOT-MAP-SPEC."
               (:global                 . 1)
               (:lighter-make-clickable . 1)
               (:lighter                . 1)
+              (:lighter-on-click       . 1)
               (:expose-keymaps         . 1)
               (:rebind                 . 1)
               (:root-map               . 1)
@@ -953,7 +974,14 @@ it is called with the mode object as its only argument.
 (:LIGHTER-MAKE-CLICKABLE (OR T NIL))@*
 When :LIGHTER-MAKE-CLICKABLE is T then the :LIGHTER is wrapped in a call to
 FORMAT-WITH-ON-CLICK-ID, called with the id :ML-ON-CLICK-MINOR-MODE and the mode
-as a quoted symbol. 
+as a quoted symbol.
+
+@item
+(:LIGHTER-ON-CLICK FUNCTION)@*
+When :LIGHTER-ON-CLICK is provided it must be a function of arity one, which
+will be called whenever the minor modes lighter is clicked, with the button code
+of the click as its only argument. If this is provided then
+:LIGHTER-MAKE-CLICKABLE is implied to be T.
 
 @item
 (:INTERACTIVE (OR SYMBOL T NIL))@*
@@ -1011,12 +1039,14 @@ Example:
   (multiple-value-bind (mm-opts other-opts)
       (parse-minor-mode-options options)
     (destructuring-bind (&key top-map root-map (expose-keymaps t) rebind
-                           lighter lighter-make-clickable
+                           lighter lighter-make-clickable lighter-on-click
                            (scope :unscoped) interactive global
                            (enable-when nil ewpp) 
                            (make-hooks t) (define-command-definer t)
                            default-initargs)
         mm-opts
+      (when lighter-on-click
+        (setf lighter-make-clickable t))
       (with-gensyms (gmode gkeymap)
         `(progn
            ;; Ensure that the superclasses are valid for a minor mode. 
@@ -1062,6 +1092,11 @@ Example:
                                              nil '((eql ,mode))))))
                    (when method
                      (remove-method #'minor-mode-global-p method))))
+
+           (let ((fn ,(when lighter-on-click
+                        lighter-on-click)))
+             (defmethod lighter-on-click ((,gmode (eql ',mode)))
+               fn))
 
            (defmethod minor-mode-lighter ((,gmode ,mode))
              (cons

--- a/minor-modes.lisp
+++ b/minor-modes.lisp
@@ -607,9 +607,9 @@ ROOT-MAP-SPEC."
   (defun define-enable-methods (mode scope)
     (let ((optarg (get-scope scope)))
       `((defmethod autoenable-minor-mode ((mode (eql ',mode)) (obj ,mode))
-          (signal 'minor-mode-enable-error :mode ',mode
-                                           :object obj
-                                           :reason 'already-enabled))
+          (signal 'minor-mode-autoenable-error :mode ',mode
+                                               :object obj
+                                               :reason 'already-enabled))
         (defmethod autoenable-minor-mode ((mode (eql ',mode)) (obj ,(car optarg)))
           (when (and ,@(unless (eql (third optarg) (first optarg))
                          ;; Check if the filter type is the same as the class

--- a/mode-line-formatters.lisp
+++ b/mode-line-formatters.lisp
@@ -150,29 +150,31 @@ fmt-highlight. Any non-visible windows are colored the
   (declare (ignore ml))
   (time-format *time-modeline-string*))
 
+(defun format-minor-modes-for-mode-line (mode-objects)
+  (with-output-to-string (s)
+    (loop for modes on mode-objects
+          for list = (minor-mode-lighter (car modes))
+          do (loop for text in list
+                   unless (string= text "")
+                     do (write-string " " s)
+                        (write-string text s)))))
+
 (add-screen-mode-line-formatter #\m 'fmt-minor-modes)
 (defun fmt-minor-modes (ml)
-  (subseq (with-output-to-string (s)
-            (loop for modes on (list-current-mode-objects
-                                :screen (mode-line-screen ml))
-                  for list = (minor-mode-lighter (car modes))
-                  do (loop for text in list
-                           unless (string= text "")
-                             do (write-string " " s)
-                                (write-string text s))))
-          1))
+  (let ((total-string
+          (format-minor-modes-for-mode-line (list-current-mode-objects
+                                             :screen (mode-line-screen ml)))))
+    (if (string= "" total-string)
+        total-string
+        (subseq total-string 1))))
 
 (add-screen-mode-line-formatter #\M 'fmt-all-minor-modes)
 (defun fmt-all-minor-modes (ml)
   (declare (ignore ml))
-  (subseq (with-output-to-string (s)
-            (loop for text in (remove-duplicates (mapcan #'minor-mode-lighter
-                                                         (list-mode-objects nil))
-                                                 :test #'string-equal)
-                  unless (string= text "")
-                    do (write-string " " s)
-                       (write-string text s)))
-          1))
+  (let ((total-string (format-minor-modes-for-mode-line (list-mode-objects nil))))
+    (if (string= "" total-string)
+        total-string
+        (subseq total-string 1))))
 
 (defvar *bar-med-color* "^B")
 (defvar *bar-hi-color* "^B^3*")

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -713,13 +713,14 @@ one."
                      (remove-frame sib leaf))
                    tree))))
 
-(defun sync-frame-windows (group frame)
-  "synchronize windows attached to FRAME."
-  (mapc (lambda (w)
-          (when (eq (window-frame w) frame)
-            (dformat 3 "maximizing ~S~%" w)
-            (maximize-window w)))
-        (group-tile-windows group)))
+(defgeneric sync-frame-windows (group frame)
+  (:documentation "synchronize windows attached to FRAME.")
+  (:method (group frame)
+    (mapc (lambda (w)
+            (when (eq (window-frame w) frame)
+              (dformat 3 "maximizing ~S~%" w)
+              (maximize-window w)))
+          (group-tile-windows group))))
 
 (defun sync-all-frame-windows (group)
   "synchronize all frames in GROUP."


### PR DESCRIPTION
Update various things related to minor modes: 

- change a condition type
- update the minor mode mode line formatters
- export autoenable and autodisable generic functions to allow ease when defining methods for them
- make the functions `sync-frame-windows` and `geometry-hints` generic to allow specialization by minor modes. 
- added on-click option for minor modes and setup the default on-click behavior