### PR TITLE
patch group-forward-with-window to focus window

### DIFF
--- a/group.lisp
+++ b/group.lisp
@@ -409,7 +409,7 @@ current window of the current group to the new one."
   (when-let ((next (group-forward current list))
              (win (group-current-window current)))
     (move-window-to-group win next)
-    (really-raise-window win)))
+    (focus-all win)))
 
 (defcommand gnew (name) ((:string "Group name: "))
   "Create a new group with the specified name. The new group becomes the


### PR DESCRIPTION
Currently the commands `gprev-with-window` and `gnext-with-window` only raise the window, and dont focus it. While this works with tile groups, it falls short with float groups. This patch fixes that. 

Steps to reproduce the bug: 
1. open a window in a tile group
2. run `gnewbg-float flt`
3. run `gnext-with-window`
4. run `info` and see that there is no current window.