### PR TITLE
Add an alpha channel to some allocated colors

### DIFF
--- a/color.lisp
+++ b/color.lisp
@@ -106,9 +106,10 @@ then call (update-color-map).")
                           color))))
 
 (defun alloc-color (screen color)
-  (xlib:alloc-color 
-   (xlib:screen-default-colormap (screen-number screen))
-   (lookup-color screen color)))
+  ;; We add an alpha channel to the color returned by xlib:alloc-color
+  (logior (xlib:alloc-color (xlib:screen-default-colormap (screen-number screen))
+                            (lookup-color screen color))
+          (ash #xff 24)))
 
 ;; Normal colors are dimmed and bright colors are intensified in order
 ;; to more closely resemble the VGA pallet.

--- a/screen.lisp
+++ b/screen.lisp
@@ -387,7 +387,11 @@ FOCUS-WINDOW is an extra window used for _NET_SUPPORTING_WM_CHECK."
   (xlib:display-finish-output *display*)
   ;; Initialize the screen structure
   (labels ((ac (color)
-             (xlib:alloc-color (xlib:screen-default-colormap screen-number) color)))
+             ;; We add an alpha channel to the color returned by
+             ;; xlib:alloc-color. This is normally done by stumpwm:alloc-color,
+             ;; but that requires a screen instance.
+             (logior (xlib:alloc-color (xlib:screen-default-colormap screen-number) color)
+                     (ash #xff 24))))
     (let* ((default-colormap (xlib:screen-default-colormap screen-number))
            (screen-root (xlib:screen-root screen-number))
            (fg-color (ac +default-foreground-color+))


### PR DESCRIPTION
This is a hacky, partial fix for #669, also experienced by elais[m] on IRC, in which enabling a compositor turns the StumpWM window background color transparent. It's based on [a similar fix](https://github.com/herbstluftwm/herbstluftwm/pull/1178) in herbstluftwm.

Since this patch changes the result of a call to `xlib:alloc-color`, which involves a request to X, I suspect it to break on systems that don't use 24-bit colors. I'm not sure how to properly test that.

It would probably be better to either do this in our `alloc-color` or to somehow fix this in CLX.