### PR TITLE
Made scale-screen add heads before removing heads

### DIFF
--- a/head.lisp
+++ b/head.lisp
@@ -169,10 +169,10 @@
           (when (= (head-number oh) (head-number nh))
             ;; Same frame number, probably the same head
             (setf (head-number nh) (head-number oh))))))
-    (dolist (h (set-difference oheads heads :test '= :key 'head-number))
-      (remove-head screen h))
     (dolist (h (set-difference heads oheads :test '= :key 'head-number))
       (add-head screen h))
+    (dolist (h (set-difference oheads heads :test '= :key 'head-number))
+      (remove-head screen h))
     (dolist (h (intersection heads oheads :test '= :key 'head-number))
       (let ((nh (find (head-number h) heads  :test '= :key 'head-number))
             (oh (find (head-number h) oheads :test '= :key 'head-number)))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -200,6 +200,7 @@
     (setf (tile-group-frame-tree group) (delete frames-to-delete group-frame-tree))
     ;; Just set current frame to whatever.
     (let ((frame (first (group-frames group))))
+      (unless (frame-p frame) (error "Couldn't locate a frame in group ~A" group))
       (setf (tile-group-current-frame group) frame
             (tile-group-last-frame group) nil)
       ;; Hide its windows.

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -9,7 +9,7 @@
 like xterm and emacs.")
 
 (define-swm-class tile-window (window)
-  ((frame   :initarg :frame   :accessor window-frame)
+  ((frame   :initarg :frame   :accessor window-frame :type frame)
    (normal-size :initform nil :accessor window-normal-size)))
 
 (defmethod print-swm-object ((object tile-window) stream)


### PR DESCRIPTION
This resolves the crash in #647 and #763 . 

Ultimately, this happens because `group-remove-head` can't handle there not being any frames in a group. If you try to remove the only head, `group-remove-head` will delete its frames from the group's `tile-group-frame-tree`, leaving it empty, then it will try to grab the group's first frame `;; just set current frame to whatever.`, which will, unfortunately, be nil, and proceed to set all of the windows' window-frame to nil, causing this problem.

https://github.com/stumpwm/stumpwm/blob/master/tile-group.lisp#L196-L208

This pull request solves the problem by simply preventing there from not being any heads during normal operation: adding new heads before removing the old ones if both happen in a single `:CONFIGURE-NOTIFY ` event.

I do, however, think that stumpwm ought be able to handle not having any actual heads attached, at least temporarily, and this patch is really papering over the issues with that (and, in fact, prevents `tile-window`'s frame slots from being set to nil if you have safety turned up on sbcl).

Furthermore, it doesn't looks like frames are properly adopted and scaled when moving between heads of different resolution.