### PR TITLE
Prevent windows from being left set to abandoned frames after xrandr events

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -248,6 +248,12 @@
 (defmethod group-sync-head ((group float-group) head)
   (declare (ignore head)))
 
+(defmethod group-adopt-orphaned-windows ((group float-group) &optional (screen (current-screen)))
+  (let ((orphaned-frames (orphaned-frames screen)))
+    (loop for window in (list-windows screen)
+          when (member (window-frame window) orphaned-frames)
+          do (group-add-window group window))))
+
 (defvar *last-click-time* 0
   "Time since the last click occurred")
 

--- a/group.lisp
+++ b/group.lisp
@@ -104,6 +104,10 @@ called. When the modeline size changes, this is called."))
 (defgeneric group-repack-frame-numbers (group)
   (:documentation "Repack frame numbers to range from zero to the number of 
 frames such that there are no numerical gaps."))
+(defgeneric group-adopt-orphaned-windows (group &optional screen)
+  (:documentation "Adopts window that have been orphaned (such as being in a frame
+that no longer belongs to any group) into the given group, defaults to searching
+the current screen"))
 
 (define-swm-class group ()
   ((screen :initarg :screen :accessor group-screen)

--- a/head.lisp
+++ b/head.lisp
@@ -95,13 +95,15 @@
                (<= y (+ (head-y head) (head-height head))))
       (return head))))
 
-;; Determining a frame's head based on position probably won't
-;; work with overlapping heads. Would it be better to walk
-;; up the frame tree?
-(defun frame-head (group frame)
-  (let ((center-x (+ (frame-x frame) (ash (frame-width frame) -1)))
-        (center-y (+ (frame-y frame) (ash (frame-height frame) -1))))
-    (find-head-by-position (group-screen group) center-x center-y)))
+(defgeneric frame-head (group frame)
+  (:documentation "Return the head frame is on")
+  (:method (group frame)
+    "As a fallback, use the frame's position on the screen to return a head
+ in the same position. This can be out of sync with stump's state if was
+ moved by something else, such as X11 during an external monitor change"
+    (let ((center-x (+ (frame-x frame) (ash (frame-width frame) -1)))
+          (center-y (+ (frame-y frame) (ash (frame-height frame) -1))))
+      (find-head-by-position (group-screen group) center-x center-y))))
 
 (defun group-heads (group)
   (screen-heads (group-screen group)))
@@ -191,7 +193,12 @@
       (dolist (head (intersection heads old-heads :test '= :key 'head-number))
               (let ((new-head (find (head-number head) heads  :test '= :key 'head-number))
                     (old-head (find (head-number head) old-heads :test '= :key 'head-number)))
-                (scale-head screen old-head new-head))))))
+                (scale-head screen old-head new-head))))
+    (when-let ((orphaned-frames (orphaned-frames screen)))
+      (let ((group (current-group)))
+        (dformat 1 "Orphaned frames ~A found on screen ~A! Adopting into group ~A"
+                 orphaned-frames screen group)
+        (group-adopt-orphaned-windows group screen)))))
 
 (defun head-force-refresh (screen new-heads)
   (scale-screen screen new-heads)
@@ -203,3 +210,10 @@
   "Refresh screens in case a monitor was connected, but a
   ConfigureNotify event was snarfed by another program."
   (head-force-refresh screen (make-screen-heads screen (screen-root screen))))
+
+(defun orphaned-frames (screen)
+  "Returns a list of frames on a screen not associated with any group.
+  These shouldn't exist."
+  (let ((adopted-frames (loop for group in (screen-groups screen)
+                              append (group-frames group))))
+    (set-difference (screen-frames screen) adopted-frames)))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -267,6 +267,28 @@
 (defun (setf tile-group-frame-head) (frame group head)
   (setf (elt (tile-group-frame-tree group) (position head (group-heads group))) frame))
 
+(defun current-frame ()
+  (window-frame (current-window)))
+
+(defmethod frame-head ((group tile-group) frame)
+  "Walks the group's frame tree to determine the \"head-frame\" that is this
+  group's parent, and then looks up the corresponding head from its position
+  in the group's head-list"
+  (labels ((frame-head-helper (group frame group-frame-tree)
+                     (if frame
+                         (let ((parent-tree (tree-parent group-frame-tree frame)))
+                           (if (eq group-frame-tree parent-tree)
+                               (elt (group-heads group)
+                                    (position frame parent-tree))
+                               (frame-head-helper group parent-tree group-frame-tree)))
+                         (error "Could not find a head for frame ~A !" frame))))
+    (let ((group-frame-tree (tile-group-frame-tree group)))
+      (if (member frame (group-heads group))
+          frame
+          (if-let ((head-position (position frame group-frame-tree)))
+            (elt (group-heads group) head-position)
+            (frame-head-helper group frame group-frame-tree))))))
+
 (defgeneric populate-frames (group)
   (:documentation "Try to fill empty frames in GROUP with hidden windows")
   (:method (group)
@@ -333,6 +355,8 @@
            (ml (head-mode-line head))
            (head-y (frame-y head))
            (rel-frame-y (- (frame-y frame) head-y)))
+      (when (> (frame-y frame) (frame-height head))
+        (error "Frame ~A is below head ~A" frame head))
       (if (and ml (not (eq (mode-line-mode ml) :hidden)))
           (case (mode-line-position ml)
             (:top
@@ -344,13 +368,21 @@
           (frame-y frame)))))
 
 (defgeneric frame-display-height (group frame)
-  (:documentation "Return a HEIGHT for frame that doesn't overlap the mode-line.")
+  (:documentation "Return a HEIGHT for frame that fits within its head and doesn't overlap the mode-line.")
   (:method (group frame)
     (let* ((head (frame-head group frame))
-           (ml (head-mode-line head)))
+           (ml (head-mode-line head))
+           (valid-frame-height (min (frame-height frame)
+                                    (frame-height head))))
       (if (and ml (not (eq (mode-line-mode ml) :hidden)))
-          (round (* (frame-height frame) (mode-line-factor ml)))
-          (frame-height frame)))))
+          (round (* valid-frame-height (mode-line-factor ml)))
+          valid-frame-height))))
+
+(defgeneric frame-display-width (group frame)
+  (:documentation "Return a WIDTH for frame that fits within its head")
+  (:method (group frame)
+    (min (frame-width frame)
+         (frame-width (frame-head group frame)))))
 
 (defun frame-intersect (f1 f2)
   "Return a new frame representing (only) the intersection of F1 and F2. WIDTH and HEIGHT will be <= 0 if there is no overlap"
@@ -434,6 +466,31 @@ T (default) then also focus the frame."
 
 (defun head-frames (group head)
   (tree-accum-fn (tile-group-frame-head group head) 'nconc 'list))
+
+(defun screen-frames (screen)
+  "Returns a list of all frames associated with any window in a screen"
+  (remove-duplicates (mapcar #'(lambda (window) (window-frame window))
+                             (list-windows screen))))
+
+(defun orphaned-frames (screen)
+  "Returns a list of frames on a screen not associated with any group.
+  These shouldn't exist."
+  (let ((adopted-frames (loop for group in (screen-groups screen)
+                              append (group-frames group))))
+    (set-difference (screen-frames screen) adopted-frames)))
+
+(defmethod group-adopt-orphaned-windows ((group tile-group) &optional (screen (current-screen)))
+  "Picks an arbitray frame in the given group and moves
+  any windows in frames without a group thereinto"
+  (let ((orphaned-frames (orphaned-frames screen))
+        (foster-frame (tree-leaf (tile-group-frame-tree group))))
+    (unless foster-frame
+      (error "Could not find a valid frame in group ~A to adopt windows
+  with group-less frames ~A on screen ~A"
+             group orphaned-frames screen))
+    (loop for window in (list-windows screen)
+          when (member (window-frame window) orphaned-frames)
+          do (setf (window-frame window) foster-frame))))
 
 (defun find-free-frame-number (group)
   (find-free-number (mapcar 'frame-number (group-frames group))))

--- a/tile-window.lisp
+++ b/tile-window.lisp
@@ -94,7 +94,7 @@ than the root window's width and height.")
                            (= (length (group-frames (window-group win))) 1))
                        0
                        (default-border-width-for-type win)))
-           (fwidth (- (frame-width f) (* 2 border)))
+           (fwidth (- (frame-display-width (window-group win) f) (* 2 border)))
            (fheight (- (frame-display-height (window-group win) f)
                        (* 2 border)))
            (width fwidth)


### PR DESCRIPTION
Follow up to #1008 

Resolves the remaining issues mentioned in #763 . When a head with unhidden windows is removed, X11 will automatically relocate those windows to a valid head. Unfortunately, this means that when `group-remove-head` would use `head-window` to lookup which windows belonged to frames on the removed head (in order to reassign them to a frame that should exist, and remove the final references to frames that should not exist), the old `frame-head` function would miss the moved windows, because it looked up by actual coordinates (and the frame has already been moved into "valid" space, on the new head). This PR makes 'frame-head' a generic function, leaves the old behavior in place as a default method and adds a faster, correct, method for `tile-groups` (walking up the group's tile tree). This resolves the bug

I also added various checks/fix-ups/better errors in case if something else brings stump into a similar state.