### PR TITLE
Update SBCL options in the Makefile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,3 +76,4 @@ Andrin Bertschi     hi at abertschi dot ch
 Spenser Max Truex   web ate spensertruex.com
 Toby Worland        toby dot worland at gmail.com
 Tomasz Jeneralczyk  silicius at schwi dot pl
+Jeremiah LaRocco    jeremiah_larocco at fastmail com

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,9 +1,9 @@
 LISP=@LISP_PROGRAM@
 MAKEINFO=@MAKEINFO@
 
-sbcl_BUILDOPTS=--load ./make-image.lisp
-sbcl_INFOOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
-sbcl_TESTOPTS=--eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(if (fiasco:all-tests) (uiop:quit 0) (uiop:quit 1))"
+sbcl_BUILDOPTS=--non-interactive --eval "(setf sb-impl::*default-external-format* :UTF-8)" --load ./make-image.lisp
+sbcl_INFOOPTS=--non-interactive --eval "(setf sb-impl::*default-external-format* :UTF-8)" --eval "(progn (load \"load-stumpwm.lisp\") (load \"manual.lisp\"))" --eval "(progn (stumpwm::generate-manual) (sb-ext:quit))"
+sbcl_TESTOPTS=--non-interactive --eval "(setf sb-impl::*default-external-format* :UTF-8)" --eval "(progn (load \"load-stumpwm.lisp\") (asdf:load-system :stumpwm-tests))" --eval "(if (fiasco:all-tests) (uiop:quit 0) (uiop:quit 1))"
 
 datarootdir = @datarootdir@
 prefix=@prefix@


### PR DESCRIPTION
* Use --non-interactive so that build failures exit with a non-zero error code
* Set sb-impl::*default-external-format* to :UTF-8 based on this StackOverflow:
  https://stackoverflow.com/questions/22822793/running-utf-8-encoded-scripts-with-steel-bank-common-lisp

This should fix issues 1012 and 1013 and fix the pipeline build for PR 1011