### PR TITLE
Fix the ioloop timeout

### DIFF
--- a/ioloop.lisp
+++ b/ioloop.lisp
@@ -290,15 +290,16 @@
                                   (values nil nil))))
                        ;; Actually block for events
                        (multiple-value-bind (rval errno)
-                           (sb-unix:unix-fast-select (1+ maxfd)
-                                                     (sb-alien:addr rfds)
-                                                     (sb-alien:addr wfds)
-                                                     (sb-alien:addr efds)
-                                                     (compute-timeout)
-                                                     nil)
+                           (multiple-value-call #'sb-unix:unix-fast-select
+                                                (1+ maxfd)
+                                                (sb-alien:addr rfds)
+                                                (sb-alien:addr wfds)
+                                                (sb-alien:addr efds)
+                                                (compute-timeout))
+                         (declare (ignore rval))
                          (cond ((and errno (plusp errno))
                                 (unless (eql errno sb-unix:eintr)
-                                  (dformat 5
+                                  (dformat 1
                                            "Unexpected ~S error: ~A~%"
                                            'sb-unix:unix-fast-select
                                            (sb-int:strerror errno))))


### PR DESCRIPTION
1451b05 fixed the issues with unix-fast-select returning nil, however,
it replace a call to `multiple-value-call` to one with
`multiple-value-bind` to get the the errno. However, (compute-timeouts)
returns multiple values: seconds and milliseconds remanining in the
timeout. 1451b05 passed the seconds value, and set the milliseconds to
nil, resulting in waiting for 0 seconds and 0 milliseconds whenever
the timeout was supposed to be less than a second

I also made the syscall-level errors from this debug level 1 instead
of 5