### PR TITLE
Allow specifying bright and dark colors separately

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -3084,6 +3084,17 @@ following:
 
 Of course, you can change all the colors if you like.
 
+Additionally, both the normal and bright versions of a color can be
+specified by using a list of the form @code{(normal-color bright-color)},
+for instance:
+
+@example
+(setf *colors* (append *colors*
+                       (list (list "PeachPuff" "PapayaWhip")
+                             (list "DarkGoldenRod3" "PaleGoldenrod"))))
+(update-color-map (current-screen))
+@end example
+
 @@@ parse-color-string
 @@@ uncolorify
 ### *colors*


### PR DESCRIPTION
I have been having difficulty reading some of the messages (especially from the `eval` command) because the colors are too dark. By default, the current implementation of `update-color-map` subtracts 25% brightness to create the normal colors and adds 25% brightness to create the bright colors. With this approach, no "normal" color can ever be brighter than #BFBFBF, even though those colors are often used by default by various components of the window manager and may be too dark to read easily.

This pull request adds the ability to use color specifications of the form `(dark-color light-color)` in `*colors*`. This allows the user to pick any two colors for the dark and light colors, while maintaining compatibility with older configuration files.

Another possibility would be to update the color-adjusting code, but the current documentation says that the code is meant to emulate VGA colors, which do have rather muddy normal colors by default, and doing so would also change the look of StumpWM for all users, which may not be desirable.

I am not sure how to update the manual, but it would also need to reflect this new possibility for color specifications.