### PR TITLE
Fix select-from-menu crashing X

### DIFF
--- a/menu-declarations.lisp
+++ b/menu-declarations.lisp
@@ -56,6 +56,9 @@
 (defvar *batch-menu-map* nil
   "The keymap used by batch-menu menus in addition to *menu-map*")
 
+(defvar *menu-maximum-height* 50
+  "The default maximum amount of entries displayed in a menu.")
+
 (defclass menu-entry ()
   ((label :initarg :label
           :reader menu-entry-label)

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2820,7 +2820,8 @@ Abort the menu.
 
 In addition, you can customize the number of items shown at a time (a
 page) with the @var{*menu-maximum-height*} variable. The default
-value, @code{nil}, means that there is no limit to the page size.
+value, @code{50}, limits the menu size to 50 items to avoid crashing
+the X server when a menu has a large amount of entries.
 
 ### *menu-map*
 @@@ menu-page-up

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2820,8 +2820,10 @@ Abort the menu.
 
 In addition, you can customize the number of items shown at a time (a
 page) with the @var{*menu-maximum-height*} variable. The default
-value, @code{50}, limits the menu size to 50 items to avoid crashing
-the X server when a menu has a large amount of entries.
+value, @code{50}, limits the menu size to 50 items. Setting it to
+@code{nil} will remove the limit on how many menu entries are shown
+(be careful, this can crash X11 when attempting to display a large
+amount of items).
 
 ### *menu-map*
 @@@ menu-page-up


### PR DESCRIPTION
Set default *menu-maximum-height to prevent crashing if displaying a large amount of items in a menu. Fixes #1028