### PR TITLE
Fix crash when switching between disjoint sets of monitors

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -185,9 +185,12 @@
     ;; Try to put something in the new frame and give it an unused number
     (let ((frame (tile-group-frame-head group head)))
       (setf (frame-number frame) new-frame-num)
-        (choose-new-frame-window frame group)
-        (when (frame-window frame)
-          (unhide-window (frame-window frame))))))
+      (choose-new-frame-window frame group)
+      (when (frame-window frame)
+        (unhide-window (frame-window frame)))
+      ;; try to fix the current-frame nil issue
+      (unless (tile-group-current-frame group)
+        (setf (tile-group-current-frame group) frame)))))
 
 ;; TODO: This method has not been updated for floating windows
 (defmethod group-remove-head ((group tile-group) head)

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -185,12 +185,12 @@
     ;; Try to put something in the new frame and give it an unused number
     (let ((frame (tile-group-frame-head group head)))
       (setf (frame-number frame) new-frame-num)
-      (choose-new-frame-window frame group)
-      (when (frame-window frame)
-        (unhide-window (frame-window frame)))
       ;; try to fix the current-frame nil issue
       (unless (tile-group-current-frame group)
-        (setf (tile-group-current-frame group) frame)))))
+        (setf (tile-group-current-frame group) frame))
+      (choose-new-frame-window frame group)
+      (when (frame-window frame)
+        (unhide-window (frame-window frame))))))
 
 ;; TODO: This method has not been updated for floating windows
 (defmethod group-remove-head ((group tile-group) head)


### PR DESCRIPTION
This is an attempt at a fix to #995.

That bug only appears when switching between two disjoint sets of monitors, e.g. plugging an external monitor into a laptop and disabling the built-in display. The crash listed in #995 appears in `show-frame-outline`, but several other crashes can also occur in this situation. The fundamental problem appears to be that the current group's `tile-group-current-frame` gets set to `nil`, and a fair amount of code around the codebase can't handle this condition.

I haven't traced the code paths completely, but I suspect what is happening is that each head in the group gets removed via `group-remove-head`, and only then do the new heads get added via `group-add-head`. This means that for some time, there are no heads (and thus no frames) in the group. At some point here, `tile-group-current-frame` gets set to `nil`, though I'm not clear where -- the invocation in `group-remove-head` looks like a reasonable candidate, but in theory that should be checked by the error handler at 206.

This patch just puts a new check in `group-add-head`, that checks if `tile-group-current-frame` is `nil` and, if so, sets it to the new head's frame. I don't know if this is actually the correct way to do this, but I've verified that it does fix the crash.