### PR TITLE
Fix crash when switching screens with floating groups

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -240,6 +240,9 @@
 (defmethod group-remove-head ((group float-group) head)
   (declare (ignore head)))
 
+(defmethod group-replace-head (screen (group float-group) old-head new-head)
+  (declare (ignore screen old-head new-head)))
+
 (defmethod group-resize-head ((group float-group) oh nh)
   (declare (ignore oh nh)))
 


### PR DESCRIPTION
Fixes #1041.

If the number of screens drops to zero (e.g. when turning off the monitor, or when unplugging an external screen from a laptop before re-enabling a disabled built-in display) and floating groups exist, the window manager will crash.  This is a regression introduced in 7fa64230 - a very helpful new generic function was added to preserve the layout of tiling groups when switching screens, but no default implementation was given for floating groups.