### PR TITLE
Fix crash when autoenabling minor mode thats already enabled

### DIFF
--- a/minor-modes.lisp
+++ b/minor-modes.lisp
@@ -339,7 +339,8 @@ current objects if MINOR-MODE is global"
 (defun sync-minor-modes (object)
   "Sync the globally active minor modes in the object"
   (loop for class in *active-global-minor-modes*
-        when (typep object (scope-type (minor-mode-scope class)))
+        when (and (not (typep object class)) ; Dont autoenable if already enabled
+                  (typep object (scope-type (minor-mode-scope class))))
           do (autoenable-minor-mode class object)))
 
 (defun sync-all-minor-modes ()
@@ -607,9 +608,10 @@ ROOT-MAP-SPEC."
   (defun define-enable-methods (mode scope)
     (let ((optarg (get-scope scope)))
       `((defmethod autoenable-minor-mode ((mode (eql ',mode)) (obj ,mode))
-          (signal 'minor-mode-enable-error :mode ',mode
-                                           :object obj
-                                           :reason 'already-enabled))
+          (with-simple-restart (continue "Ignore enable error for ~A" ',mode)
+            (signal 'minor-mode-enable-error :mode ',mode
+                                             :object obj
+                                             :reason 'already-enabled)))
         (defmethod autoenable-minor-mode ((mode (eql ',mode)) (obj ,(car optarg)))
           (when (and ,@(unless (eql (third optarg) (first optarg))
                          ;; Check if the filter type is the same as the class

--- a/replace-class.lisp
+++ b/replace-class.lisp
@@ -73,7 +73,13 @@
 
 (defmethod replace-class :around (object new &rest rest)
   (restart-case (progn
-                  (call-next-method)
+                  (handler-bind ((error
+                                   (lambda (c)
+                                     (let ((r1 (find-restart 'continue c))
+                                           (r2 (find-restart 'stumpwm::continue c)))
+                                       (cond (r1 (invoke-restart r1))
+                                             (r2 (invoke-restart r2)))))))
+                    (call-next-method))
                   (unless (typep object new)
                     (error "Failed to change class ~A ~A" object new)))
     (force-change ()


### PR DESCRIPTION
Currently when creating a new object which should have minor modes enabled in it there comes an error of type minor-mode-autoenable-error. This causes a hard crash. To reproduce the crash define a new minor mode scoped to `:window`, with the option `(:global t)`. Enable the minor mode, causing it to be enabled in all window objects. Then create a new window, triggering the crash. 

This patch addresses this by A) establishing a restart around the autoenable error signalled in the autoenable-minor-mode method to ignore the error, B) binding a handler to invoke this restart in the replace-class around method specializing on (t t), and C) explicitly checking if an object already has a minor mode enabled in it when syncing minor modes for an object.