### PR TITLE
patch dynamic-group-resize-head to not map over window

### DIFF
--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -722,7 +722,7 @@ floating windows onto the stack."
                    (push window previous-floats)
                    (dynamic-mixins:replace-class window 'dynamic-window))
                  (dynamic-group-place-window group head window)
-              finally (map nil #'sync-minor-modes window))
+              finally (sync-minor-modes window))
         (focus-frame group (window-frame master-window))))))
 
 ;;; Handle overflow of both heads and groups


### PR DESCRIPTION
change one line to not attempt to map over a window. fixes issues with retiling heads in a dynamic group. 