### PR TITLE
Patch dynamic group resize head

### DIFF
--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -722,7 +722,7 @@ floating windows onto the stack."
                    (push window previous-floats)
                    (dynamic-mixins:replace-class window 'dynamic-window))
                  (dynamic-group-place-window group head window)
-              finally (map nil #'sync-minor-modes window))
+              finally (sync-minor-modes window))
         (focus-frame group (window-frame master-window))))))
 
 ;;; Handle overflow of both heads and groups

--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -721,8 +721,8 @@ floating windows onto the stack."
               do (when (float-window-p window)
                    (push window previous-floats)
                    (dynamic-mixins:replace-class window 'dynamic-window))
-                 (dynamic-group-place-window group head window)
-              finally (sync-minor-modes window))
+                 (dynamic-group-place-window group head window))
+        (map nil 'sync-minor-modes windows)
         (focus-frame group (window-frame master-window))))))
 
 ;;; Handle overflow of both heads and groups


### PR DESCRIPTION
Correct a misspelling of a variable, no longer attempting to map over a window but instead map over a list of windows. 