### PR TITLE
patch the orphaned frames function to ignore float groups

### DIFF
--- a/floating-group.lisp
+++ b/floating-group.lisp
@@ -257,8 +257,9 @@
 (defmethod group-adopt-orphaned-windows ((group float-group) &optional (screen (current-screen)))
   (let ((orphaned-frames (orphaned-frames screen)))
     (loop for window in (list-windows screen)
-          when (member (window-frame window) orphaned-frames)
-          do (group-add-window group window))))
+          when (and (not (float-window-p window))
+                    (member (window-frame window) orphaned-frames))
+            do (group-add-window group window))))
 
 (defvar *last-click-time* 0
   "Time since the last click occurred")

--- a/head.lisp
+++ b/head.lisp
@@ -228,5 +228,6 @@
   "Returns a list of frames on a screen not associated with any group.
   These shouldn't exist."
   (let ((adopted-frames (loop for group in (screen-groups screen)
-                              append (group-frames group))))
+                              unless (typep group 'float-group)
+                                append (group-frames group))))
     (set-difference (screen-frames screen) adopted-frames)))

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -494,6 +494,7 @@ T (default) then also focus the frame."
   "Returns a list of frames on a screen not associated with any group.
   These shouldn't exist."
   (let ((adopted-frames (loop for group in (screen-groups screen)
+                              unless (typep group 'float-group)
                               append (group-frames group))))
     (set-difference (screen-frames screen) adopted-frames)))
 

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -490,14 +490,6 @@ T (default) then also focus the frame."
   (remove-duplicates (mapcar #'(lambda (window) (window-frame window))
                              (list-windows screen))))
 
-(defun orphaned-frames (screen)
-  "Returns a list of frames on a screen not associated with any group.
-  These shouldn't exist."
-  (let ((adopted-frames (loop for group in (screen-groups screen)
-                              unless (typep group 'float-group)
-                              append (group-frames group))))
-    (set-difference (screen-frames screen) adopted-frames)))
-
 (defmethod group-adopt-orphaned-windows ((group tile-group) &optional (screen (current-screen)))
   "Picks an arbitray frame in the given group and moves
   any windows in frames without a group thereinto"

--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -487,7 +487,9 @@ T (default) then also focus the frame."
 
 (defun screen-frames (screen)
   "Returns a list of all frames associated with any window in a screen"
-  (remove-duplicates (mapcar #'(lambda (window) (window-frame window))
+  (remove-duplicates (mapcan #'(lambda (window)
+                                 (unless (float-window-p window)
+                                   (list window)))
                              (list-windows screen))))
 
 (defmethod group-adopt-orphaned-windows ((group tile-group) &optional (screen (current-screen)))
@@ -500,7 +502,8 @@ T (default) then also focus the frame."
   with group-less frames ~A on screen ~A"
              group orphaned-frames screen))
     (loop for window in (list-windows screen)
-          when (member (window-frame window) orphaned-frames)
+          when (and (not (float-window-p window))
+                    (member (window-frame window) orphaned-frames))
           do (setf (window-frame window) foster-frame))))
 
 (defun find-free-frame-number (group)


### PR DESCRIPTION
This addresses issue #1058. The problem is in the function `orphaned-frames`, which assumes all groups in a screen are tiling groups. This PR removes that assumption and ignores floating groups. 

This PR ignores all floating windows in the function `screen-frames`. It also makes `group-adopt-orphaned-windows` ignore float windows, as it appears that floating windows can never be orphaned; orphan status seems to refer to frames that do not belong to a group and the windows which belong to those frames. 