### PR TITLE
Support float groups with expose command

### DIFF
--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -1045,6 +1045,9 @@ window. "
           (dynamic-group-add-window group head window)
           (sync-minor-modes window)))))
 
+(defmethod invoke-expose ((group dynamic-group))
+  (declare (ignore group))
+  (message "Expose is not supported for dynamic groups"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Dynamic Group Commands ;;;

--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -42,12 +42,13 @@ area."
       (only))
     (recursive-tile (min *expose-n-max* num-win) group)))
 
+(defgeneric invoke-expose (group))
 
-(defcommand expose () ()
-  "Automagically tile all windows and let the user select one, make
-that window the focus. Set the variable `*expose-auto-tile-fn*' to another
-tiling function if a different layout is desired. Set `*expose-n-max*' to the
-maximum number of windows to be displayed for choosing."
+(defmethod invoke-expose ((group dynamic-group))
+  (declare (ignore group))
+  (message "Expose is not supported for dynamic groups"))
+
+(defmethod invoke-expose ((group tile-group))
   (funcall *expose-auto-tile-fn* nil
            (current-group (current-screen)))
   ;; have the user select a window
@@ -55,3 +56,91 @@ maximum number of windows to be displayed for choosing."
     (run-commands "fselect"))
   ;; maximize that window
   (only))
+
+(defmethod invoke-expose ((group float-group))
+  (let ((curwin (group-current-window group))
+        (wincount (length (group-windows group)))
+        (width (head-width (group-current-head group)))
+        (height (head-height (group-current-head group)))
+        (old-win-positions nil))
+    (labels ((collect-x-y (wincount)
+               (let ((factors (loop for i from 1 to (1+ wincount)
+                                    when (= (mod wincount i) 0)
+                                      collect i)))
+                 (cond ((= (length factors) 1) ; prime number
+                        (collect-x-y (1+ wincount)))
+                       ((= (length factors) 2)
+                        (collect-x-y (1+ wincount)))
+                       (t (nthcdr (floor (length factors) 2) factors))))))
+      (unless (= wincount 1)
+        (destructuring-bind (ycount xcount &rest ignore)
+            (let ((f (collect-x-y wincount)))
+              (let* ((x (car f))
+                     (y (ceiling wincount x)))
+                (list y x)))
+          (declare (ignore ignore))
+          (block done
+            (let ((w (floor width xcount))
+                  (h (floor height ycount))
+                  (y 0)
+                  (x 0)
+                  (wins (group-windows group)))
+              (dotimes (i ycount)
+                (setf y (* i h))
+                (dotimes (j xcount)
+                  (setf x (* j w))
+                  (let ((win (pop wins)))
+                    (if win 
+                        (progn
+                          (push (list win :x (window-x win)
+                                          :y (window-y win)
+                                          :width (window-width win)
+                                          :height (window-height win))
+                                old-win-positions)
+                          (float-window-move-resize win :x x
+                                                        :y y
+                                                        :width w
+                                                        :height h))
+                        (return-from done nil)))))))
+          (let* ((ws (draw-window-numbers group))
+                 (focuswin
+                   (or (unwind-protect
+                            (multiple-value-bind (has-click ch x y)
+                                (read-one-char-or-click group)
+                              (if has-click
+                                  (let ((winner))
+                                    (dolist (f (group-windows group))
+                                      (when (and (> x (window-x f))
+                                                 (> y (window-y f)))
+                                        (if winner
+                                            (when (or (> (window-x f)
+                                                         (window-x winner))
+                                                      (> (window-y f)
+                                                         (window-y winner)))
+                                              (setf winner f))
+                                            (setf winner f))))
+                                    (ungrab-pointer)
+                                    winner)
+                                  (when ch
+                                    (let ((num
+                                            (read-from-string (string ch) nil nil)))
+                                      (dformat 3 "read ~S ~S~%" ch num)
+                                      (find num (group-windows group)
+                                            :test #'=
+                                            :key 'window-number)))))
+                         (mapc #'xlib:destroy-window ws)
+                         (mapc (lambda (spec)
+                                 (apply #'float-window-move-resize spec))
+                               old-win-positions)
+                         (xlib:display-finish-output *display*))
+                       curwin)))
+            (when focuswin
+              (focus-all focuswin))))))))
+
+(defcommand expose () ()
+  "Automagically lay out all windows in a grid and let the user select one, making
+that window the focused window. Set the variable `*expose-auto-tile-fn*' to
+another tiling function if a different layout is desired for tile groups. Set
+`*expose-n-max*' to the maximum number of windows to be displayed for choosing
+when in a tile group."
+  (invoke-expose (current-group (current-screen))))

--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -63,9 +63,8 @@ area."
                (let ((factors (loop for i from 1 to (1+ wincount)
                                     when (= (mod wincount i) 0)
                                       collect i)))
-                 (cond ((= (length factors) 1) ; prime number
-                        (collect-x-y (1+ wincount)))
-                       ((= (length factors) 2)
+                 (cond ((or (= (length factors) 1) ; prime number
+                            (= (length factors) 2)) 
                         (collect-x-y (1+ wincount)))
                        (t (nthcdr (floor (length factors) 2) factors))))))
       (unless (= wincount 1)

--- a/dynamic-window.lisp
+++ b/dynamic-window.lisp
@@ -44,10 +44,6 @@ area."
 
 (defgeneric invoke-expose (group))
 
-(defmethod invoke-expose ((group dynamic-group))
-  (declare (ignore group))
-  (message "Expose is not supported for dynamic groups"))
-
 (defmethod invoke-expose ((group tile-group))
   (funcall *expose-auto-tile-fn* nil
            (current-group (current-screen)))

--- a/window.lisp
+++ b/window.lisp
@@ -649,6 +649,31 @@ and bottom_end_x."
   "Return a free window number for GROUP."
   (find-free-number (mapcar 'window-number (group-windows group))))
 
+(defun draw-window-numbers (group)
+  "Draw window numbers over every window at the coordinates (0 . 0)."
+  (let ((screen (group-screen group)))
+    (mapcar (lambda (f)
+              (let ((w (xlib:create-window
+                        :parent (screen-root screen)
+                        :x (window-x f)
+                        :y (window-y  f)
+                        :width 1
+                        :height 1
+                        :background (screen-fg-color screen)
+                        :border (screen-border-color screen)
+                        :border-width 1
+                        :event-mask '())))
+                (xlib:map-window w)
+                (setf (xlib:window-priority w) :above)
+                (echo-in-window w (screen-font screen)
+                                (screen-fg-color screen)
+                                (screen-bg-color screen)
+                                (string (format nil "~A" (window-number f))))
+                (xlib:display-finish-output *display*)
+                (dformat 3 "mapped ~S~%" (window-number f))
+                w))
+            (group-windows group))))
+
 (defun reparent-window (screen window)
   ;; apparently we need to grab the server so the client doesn't get
   ;; the mapnotify event before the reparent event. that's what fvwm


### PR DESCRIPTION
This PR modifies the expose command to function with both floating and tiling groups, and adds an additional safety measure to prevent it from destroying the state of dynamic groups. 

All logic has been moved from the expose command to a generic function specializing upon the group type, however the way tile groups are expose-ed was preserved. 

This addresses issue #1057. 