### PR TITLE
patch interactive function for `eval-command-error` restart in function `eval-command`

### DIFF
--- a/command.lisp
+++ b/command.lisp
@@ -576,7 +576,9 @@ user aborted."
                                                             (backtrace-string) ""))))))
               (parse-and-run-command cmd))
           (eval-command-error (err-text)
-            :interactive (lambda () nil)
+            :interactive (lambda ()
+                           (format nil "^B^1*Error In Command '^b~a^B'"
+                                   cmd))
             (values err-text t)))
       ;; interactive commands update the modeline
       (update-all-mode-lines)

--- a/command.lisp
+++ b/command.lisp
@@ -579,6 +579,8 @@ user aborted."
             :interactive (lambda ()
                            (list (format nil "^B^1*Error In Command '^b~a^B'"
                                          cmd)))
+            :report (lambda (s)
+                      (format s "Exit command ~S" cmd))
             (values err-text t)))
       ;; interactive commands update the modeline
       (update-all-mode-lines)

--- a/command.lisp
+++ b/command.lisp
@@ -577,8 +577,8 @@ user aborted."
               (parse-and-run-command cmd))
           (eval-command-error (err-text)
             :interactive (lambda ()
-                           (format nil "^B^1*Error In Command '^b~a^B'"
-                                   cmd))
+                           (list (format nil "^B^1*Error In Command '^b~a^B'"
+                                         cmd)))
             (values err-text t)))
       ;; interactive commands update the modeline
       (update-all-mode-lines)


### PR DESCRIPTION
The interactive function for the restart EVAL-COMMAND-ERROR returns an argument list of zero arguments while the restart takes one argument. This PR makes it return a single format string similar to what would be passed if this restart were invoked via the handler established within the restart-case form. 