### PR TITLE
Expand Dynamic Groups: allow setting default values before instantiation, expand manual

### DIFF
--- a/dynamic-group.lisp
+++ b/dynamic-group.lisp
@@ -60,6 +60,18 @@
 
 (in-package :stumpwm)
 
+(export '(set-dynamic-group-initial-values
+          dynamic-group-p
+          dynamic-group-master-layout
+          dynamic-group-default-split-ratio
+          dynamic-group-head-layout
+          dynamic-group-head-split-ratio
+          dynamic-group-overflow-policy
+          dynamic-group-head-placement-policy
+          *rotation-focus-policy*
+          dyn-blacklist-command
+          dyn-unblacklist-command))
+
 (defmacro swap (a b)
   "Swap the values of A and B using PSETF."
   `(psetf ,a ,b
@@ -1173,6 +1185,7 @@ backward (counterclockwise)"
       ((:b) (rotate-stack-backward g h)))))
 
 (defcommand (swap-windows tile-group) () ()
+  "Exchange two windows"
   (let* ((f1 (progn (message "Select Window One")
                     (choose-frame-by-number (current-group))))
          (f2 (progn (message "Select Window Two")
@@ -1251,6 +1264,7 @@ backward (counterclockwise)"
           (focus-frame group next-head)))))
 
 (defcommand (hprev dynamic-group) () ()
+  "Move focus to the previous head in a dynamic group"
   (let* ((group (current-group))
          (head (current-head))
          (info-alist (reverse (dynamic-group-head-info-alist group)))
@@ -1266,10 +1280,12 @@ backward (counterclockwise)"
           (focus-frame group next-head)))))
 
 (defcommand (fnext-in-head dynamic-group) () ()
+  "Focus the next frame in the current head"
   (let ((group (current-group)))
     (focus-frame-after group (head-frames group (current-head)))))
 
 (defcommand (fprev-in-head dynamic-group) () ()
+  "Focus the previous frame in the current head"
   (let ((group (current-group)))
     (focus-frame-after group (reverse (head-frames group (current-head))))))
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -410,8 +410,77 @@ When defining commands, anything restricted to tiling groups will also be
 active in dynamic groups. To fully restrict it to tiling groups, call the
 function dyn-blacklist-command on the command in question.
 
+The head placement policy, overflow policy, master layout, and default
+split ratio of dynamic groups are special in that they can only be
+modified once a dynamic group object has been instantiated. To change
+their initial values the function @code{set-dynamic-group-initial-values}
+can be used to modify these values before instantiating a dynamic group,
+but not after. 
 
-@node Frame Basics, Window Basics, Floating Group Basics, Basic Concepts
+@menu
+* Dynamic Group Index::
+@end menu
+
+@node Dynamic Group Index, Frame Basics, Dynamic Group Basics, Dynamic Group Basics
+@subsection Dynamic Group Index
+Index of exported variables, commands, and functions defined in the
+dynamic group file.
+
+### *rotation-focus-policy*
+
+@@@ set-dynamic-group-initial-values
+
+@@@ dynamic-group-p
+
+@@@ dynamic-group-master-layout
+
+@@@ dynamic-group-head-layout
+
+@@@ dynamic-group-default-split-ratio
+
+@@@ dynamic-group-head-split-ratio
+
+@@@ dynamic-group-overflow-policy
+
+@@@ dynamic-group-head-placement-policy
+
+@@@ dyn-blacklist-command
+
+@@@ dyn-unblacklist-command
+
+!!! gnew-dynamic
+
+!!! gnewbg-dynamic
+
+!!! rotate-windows
+
+!!! rotate-stack
+
+!!! swap-windows
+
+!!! change-layout
+
+!!! change-default-layout
+
+!!! change-split-ratio
+
+!!! change-default-split-ratio
+
+!!! retile
+
+!!! select-floating-window
+
+!!! exchange-window-with-master
+
+!!! hnext
+
+!!! hprev
+
+!!! fnext-in-head
+
+!!! fprev-in-head
+
+@node Frame Basics, Window Basics, Dynamic Group Basics, Basic Concepts
 @subsection Frame Basics
 Frames are the boxes within which windows are displayed. StumpWM
 starts with a single frame per head, meaning that each monitor shows a


### PR DESCRIPTION
this PR adds the ability to modify the default initial values for dynamic groups before instantiating them. 

It also adds missing docstrings, and adds a dynamic group specific index to the manual under the dynamic groups section. 