### PR TITLE
Work around button-presses not working for decoration windows

### DIFF
--- a/events.lisp
+++ b/events.lisp
@@ -649,7 +649,13 @@ the window in it's frame."
       ((setf win (find-window-by-parent window (top-windows)))
        ;; The click happened on the parent window, so the coordinates are
        ;; correct.
-       ))
+       )
+      ((and child (setf win (find-window-by-parent child (top-windows))))
+       ;; The click happened on the parent window but was received by
+       ;; the root window, since the parent window does not grab
+       ;; buttons (see commit d5230923 for details).
+       (setf x (- x (xlib:drawable-x child))
+             y (- y (xlib:drawable-y child)))))
     (cond
       ((and screen (not child))
        (group-button-press (screen-current-group screen) button x y :root)


### PR DESCRIPTION
Commit d5230923 fixed a Chromium bug by changing StumpWM's window grabs to be on the managed window instead of the parent window, but that had the side-effect of StumpWM not responding to button-presses on the decoration window itself, a rather critical functionality for floating groups.

This pull-request "fixes" that problem by instead responding to the event when it propagates up to the root window (where the `child` event key indicates the actual decoration window that was clicked) and translates the click coordinates as appropriate (hopefully).

I really want to make it clear that I'm not nearly conversant enough in X11 conventions to know if this is the proper fix, though. It seems like an ugly workaround to me. d5230923 states that it brings StumpWM more in line with other window managers, which makes me wonder how those other window managers deal with the same problem. I find it somewhat difficult to believe that this is the standard way of dealing with it. Could it be that they're using a separate child window for decorations inside the same parent window as the managed window, or something? And if so, is that something StumpWM should emulate?

I also looked through the bug list briefly, and I think issue #1034 describes the same problem.