### PR TITLE
Autoconf autoupdate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.71])
-AC_INIT([Stump Window Manager],[esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n)],[dbjergaard@gmail.com])
+AC_INIT([Stump Window Manager],esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n),[dbjergaard@gmail.com])
 
 AC_SUBST(MODULE_DIR)
 AC_SUBST(LISP_PROGRAM)

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.59)
-AC_INIT(Stump Window Manager, esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n), dbjergaard@gmail.com)
+AC_PREREQ([2.71])
+AC_INIT([Stump Window Manager],[esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n)],[dbjergaard@gmail.com])
 
 AC_SUBST(MODULE_DIR)
 AC_SUBST(LISP_PROGRAM)
@@ -57,6 +57,9 @@ to build the manuals. Please install makeinfo for the manual.])
 fi
 
 AC_SUBST([MAKEINFO])
-AC_OUTPUT(Makefile)
-AC_OUTPUT(make-image.lisp)
-AC_OUTPUT(load-stumpwm.lisp)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+AC_CONFIG_FILES([make-image.lisp])
+AC_OUTPUT
+AC_CONFIG_FILES([load-stumpwm.lisp])
+AC_OUTPUT


### PR DESCRIPTION
Sorry about the double commits in this pull request, and I'm not really sure if this is something I should have made a PR for, or if it's just expected that individuals figure out how to use autotools. This is also my first PR to a public entity, so let me know how I can do better in the future.

Anyhow...

`44f4015e993e6445d68e4f9b47265c056ac6b75d` covers the following warnings I was getting when running `./autogen.sh`:

```
configure.ac:60: warning: AC_OUTPUT should be used without arguments.
configure.ac:60: You should run autoupdate.
configure.ac:61: warning: AC_OUTPUT should be used without arguments.
configure.ac:61: You should run autoupdate.
configure.ac:62: warning: AC_OUTPUT should be used without arguments.
configure.ac:62: You should run autoupdate.
```

`db2ffc96a8c59d33e517b3b03a621449fa9b0fca` removes the following warning, which is the result of running `autoupdate` as suggested by the above warnings:

```
configure.ac:5: warning: AC_INIT: not a literal: "esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n)"
```