### PR TITLE
Small patch to fix quicklisp loading dynamic-mixins

### DIFF
--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -76,6 +76,5 @@
   :entry-point "stumpwm:main"
   :components ((:file "main")))
 
-;;; Explicitly load the vendored dynamic mixins asd file
-(asdf:load-asd
- (asdf:system-relative-pathname "stumpwm" "dynamic-mixins/dynamic-mixins.asd"))
+;; Quicklisp prefers systems in the central registry over its own systems
+(push (asdf:system-relative-pathname "stumpwm" "dynamic-mixins/") asdf:*central-registry*)


### PR DESCRIPTION
This hopefully fixes #1079/#1080, I could compile and `make test` ran okay.

Loading the asd didn't look necessary after this, but it might be, in which case they can coexist. Otherwise, quicklisp's dynamic-mixins has a name conflict between cl's and closer-mop's standard-generic-function.