### PR TITLE
Move display-finish-output out of loops

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -1095,26 +1095,27 @@ desktop when starting."
   "Draw the number of each frame in its corner. Return the list of
 windows used to draw the numbers in. The caller must destroy them."
   (let ((screen (group-screen group)))
-    (mapcar (lambda (f)
-              (let ((w (xlib:create-window
-                        :parent (screen-root screen)
-                        :x (frame-display-x group f)
-                        :y (frame-display-y group f)
-                        :width 1 :height 1
-                        :background (screen-fg-color screen)
-                        :border (screen-border-color screen)
-                        :border-width 1
-                        :event-mask '())))
-                (xlib:map-window w)
-                (setf (xlib:window-priority w) :above)
-                (echo-in-window w (screen-font screen)
-                                (screen-fg-color screen)
-                                (screen-bg-color screen)
-                                (string (get-frame-number-translation f)))
-                (xlib:display-finish-output *display*)
-                (dformat 3 "mapped ~S~%" (frame-number f))
-                w))
-            (group-frames group))))
+    (prog1
+        (mapcar (lambda (f)
+                  (let ((w (xlib:create-window
+                            :parent (screen-root screen)
+                            :x (frame-display-x group f)
+                            :y (frame-display-y group f)
+                            :width 1 :height 1
+                            :background (screen-fg-color screen)
+                            :border (screen-border-color screen)
+                            :border-width 1
+                            :event-mask '())))
+                    (xlib:map-window w)
+                    (setf (xlib:window-priority w) :above)
+                    (echo-in-window w (screen-font screen)
+                                    (screen-fg-color screen)
+                                    (screen-bg-color screen)
+                                    (string (get-frame-number-translation f)))
+                    (dformat 3 "mapped ~S~%" (frame-number f))
+                    w))
+                (group-frames group))
+      (xlib:display-finish-output *display*))))
 
 (defmacro save-frame-excursion (&body body)
   "Execute body and then restore the current frame."

--- a/window.lisp
+++ b/window.lisp
@@ -805,12 +805,11 @@ and bottom_end_x."
   "Any time *top-map* is modified this must be called."
   (loop for i in *screen-list*
         do (xwin-ungrab-keys (screen-focus-window i))
-        do (loop for j in (screen-mapped-windows i)
+           (loop for j in (screen-mapped-windows i)
                  do (xwin-ungrab-keys j))
-        do (xlib:display-finish-output *display*)
-        do (loop for j in (screen-mapped-windows i)
+           (loop for j in (screen-mapped-windows i)
                  do (xwin-grab-keys j (window-group (find-window j))))
-        do (xwin-grab-keys (screen-focus-window i) (screen-current-group i)))
+           (xwin-grab-keys (screen-focus-window i) (screen-current-group i)))
   (when (current-window)
     (remap-keys-grab-keys (current-window)))
   (xlib:display-finish-output *display*))


### PR DESCRIPTION
I don't know if display-finish-output needs to be called repeatedly like it is, but if not, this little PR moves it out of loops
( Originally asked in the IRC )