### PR TITLE
Remove mention of dynamic tiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ StumpWM universe (in no particular order):
     implement the above features, then export the data back to stumpwm
     and let stumpwm perform the appropriate actions 
 * Emacs' completing-read-multiple function
-* Dynamic tiling
 * Lock Screen (with support for leaving notes, bonus points if emacs
   is involved)
 * Wallpapers! (support pulling from remote sources, changing based on


### PR DESCRIPTION
Dynamic tiling is already implemented so let's remove it from the wishlist.

> [23:08:36](irc:///%23stumpwm?timestamp=2023-03-15T04%3A08%3A36.000Z) <[podiki[m]](irc:///podiki%5Bm%5D,isuser)> there is dynamic tiling already, do you mean further improvements?