### PR TITLE
Bug fix: Avoid "... is not a string designator" error in format-expand.

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1075,7 +1075,7 @@ Does not trim if `TRIM-COUNT' is nil, and returns the empty string if it is zero
                     ;; If that fails, /then/ you have an error.
                     (etypecase result
                       (string result)
-                      (atom (string result))
+                      (atom (write-to-string result :escape nil))
                       (list (apply #'uiop:strcat result))))
                   trim-count trim-end-p)))
              ;; Separated so it can be run in the initially clause.


### PR DESCRIPTION
This patch avoids the "(number) is not a string designator" error that the current version of `format-expand` gives when formatting a number.

This happens, for example, when invoking the `info` command (display information about the current window) because the standard value "%wx%h %n (%t)" of `*window-info-format*` contains the numeric options %w and %h.