### PR TITLE
decrement autoconf version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.59])
 AC_INIT([Stump Window Manager],esyscmd(grep :version stumpwm.asd | cut -d\" -f2 | tr -d \\n),[dbjergaard@gmail.com])
 
 AC_SUBST(MODULE_DIR)


### PR DESCRIPTION
In commit ec07aba the autoconf version was incremented from 2.59 to 2.71. This has caused all CI builds to fail (for me at least, and a quick glance at the commit logs seem to confirm this for others) due to the autoconf requirement not being satisfied. I am unfamiliar with autoconf and the github builds feature, so this solution may not be appropriate, but decrementing the version of autoconf back to 2.59 allows building again for the CI. 