### PR TITLE
Add refresh-colors-for-modeline to mode-line.lisp

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -354,11 +354,14 @@ timer.")
 (defun refresh-colors-for-modeline (screen head)
   "Set the colors for the modeline to the currently set values then redraw"
   (let* ((ml (head-mode-line head))
-         (cc (mode-line-cc ml)))
+         (cc (mode-line-cc ml))
+         (win (mode-line-window ml)))
     (setf (ccontext-default-bg cc)
           (alloc-color screen *mode-line-background-color*))
     (setf (ccontext-default-fg cc)
           (alloc-color screen *mode-line-foreground-color*))
+    (setf (xlib:window-background win)
+          (alloc-color screen *mode-line-background-color*))
     (redraw-mode-line ml t)))
 
 ;;; Registering mode line clickable areas

--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -351,6 +351,16 @@ timer.")
   "Update all mode lines."
   (mapc 'redraw-mode-line *mode-lines*))
 
+(defun refresh-colors-for-modeline (screen head)
+  "Set the colors for the modeline to the currently set values then redraw"
+  (let* ((ml (head-mode-line head))
+         (cc (mode-line-cc ml)))
+    (setf (ccontext-default-bg cc)
+          (alloc-color screen *mode-line-background-color*))
+    (setf (ccontext-default-fg cc)
+          (alloc-color screen *mode-line-foreground-color*))
+    (redraw-mode-line ml t)))
+
 ;;; Registering mode line clickable areas
 
 (defvar *mode-line-on-click-functions* nil


### PR DESCRIPTION
I wrote this in order to update the colors of the modeline without having to toggle it on and off, which creates an ugly visual jump when done that way.