### PR TITLE
Add sorting rules for minor mode inheritance order

### DIFF
--- a/dynamic-mixins/dynamic-mixins-swm.asd
+++ b/dynamic-mixins/dynamic-mixins-swm.asd
@@ -15,4 +15,5 @@
 
   :components
   ((:file "package")
+   (:file "sorting")
    (:file "dynamic-mixins")))

--- a/dynamic-mixins/src/dynamic-mixins.lisp
+++ b/dynamic-mixins/src/dynamic-mixins.lisp
@@ -33,12 +33,16 @@ instance; further elements must be class names or classes."
                    (slot-value (class-of object-or-class) 'classes))
                   (t (list (class-of object-or-class))))))
     (make-mix-list
-     :list (remove-duplicates
-            (append (mapcar #'%find-class class-list)
-                    class0)))))
+     :list (sort (remove-duplicates
+                  (append (mapcar #'%find-class class-list)
+                          class0))
+                 'symbol-before-p
+                 :key 'class-name))))
 
 (defun mix (&rest classes)
-  (make-mix-list :list (remove-duplicates (mapcar #'%find-class classes))))
+  (make-mix-list :list (sort (remove-duplicates (mapcar #'%find-class classes))
+                             'symbol-before-p
+                             :key 'class-name)))
 
 (defun set-superclasses (class list)
   (reinitialize-instance class :direct-superclasses list))

--- a/dynamic-mixins/src/package.lisp
+++ b/dynamic-mixins/src/package.lisp
@@ -2,4 +2,5 @@
   (:use #:cl #:alexandria)
   (:export #:mixin-class #:mixin-object #:mixin-classes
            #:ensure-mix #:delete-from-mix #:mix
-           #:replace-class #:replace-class-in-mixin))
+           #:replace-class #:replace-class-in-mixin
+           #:set-rule #:*class-ordering-rules*))

--- a/dynamic-mixins/src/sorting.lisp
+++ b/dynamic-mixins/src/sorting.lisp
@@ -1,0 +1,43 @@
+(in-package :dynamic-mixins-swm)
+
+(defvar *class-ordering-rules* nil
+  "A plist of rules for how to order classes for mixing. Keys are the class
+names. Rules have the following shape:
+
+(:before ((string-1 . package-designator-1)
+          (string-2 . package-designator-2)
+          ...
+          (string-n . package-designator-n))
+ :after ((string-1 . package-designator-1)
+         (string-2 . package-designator-2)
+         ...
+         (string-n . package-designator-n)))")
+
+(defun set-rule (symbol before after)
+  "Add or replace a class ordering rule for SYMBOL."
+  (setf (getf *class-ordering-rules* symbol) (list :before before :after after)))
+
+(defun symbol-ordering-rules (symbol)
+  (getf *class-ordering-rules* symbol))
+
+(defun symbol-ordering-rules-before-list (symbol &optional rules)
+  (getf (or rules (symbol-ordering-rules symbol)) :before))
+
+(defun symbol-ordering-rules-after-list (symbol &optional rules)
+  (getf (or rules (symbol-ordering-rules symbol)) :after))
+
+(defun symbol-spec-match (symbol spec)
+  (let ((p (find-package (cdr spec))))
+    (when p
+      (eq (find-symbol (string (car spec)) p)
+          symbol))))
+
+(defun symbol-before-p (s1 s2)
+  "Return truthy if S1 should be before S2."
+  (or (find s2 (symbol-ordering-rules-before-list s1) :test #'symbol-spec-match)
+      (find s1 (symbol-ordering-rules-after-list s2) :test #'symbol-spec-match)))
+
+(defun symbol-after-p (s1 s2)
+  "Return truthy if S1 should be after S2."
+  (or (find s2 (symbol-ordering-rules-after-list s1) :test #'symbol-spec-match)
+      (find s1 (symbol-ordering-rules-before-list s2) :test #'symbol-spec-match)))


### PR DESCRIPTION
Add the options `:mix-before` and `:mix-after` to `define-minor-mode` to allow coordination between minor modes regarding what order the minor modes are mixed in. Additionally adds class sorting rules to the dynamic-mixins-swm package, contained in their own file. This allows slightly finer grained control over what order methods are called in by controlling the order of the mix list.