### PR TITLE
Export `*input-refine-candidates-fn*` for consistency.

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -25,6 +25,7 @@
 
 (export '(*input-history-ignore-duplicates*
           *input-candidate-selected-hook*
+          *input-refine-candidates-fn*
           *input-completion-style*
           *input-map*
           *numpad-map*


### PR DESCRIPTION
I was searching for a function to fuzzy-match my inputs in commands/completions and found `*input-refine-candidates-fn*`. But it is weird that it's unexported, especially given that the functions intended for it—`input-refine-prefix` and `input-refine-regexp`—are exported. This patch exports the variable so that it's usable in configs without the need for alarming `::`.