### PR TITLE
Add `input-refine-fuzzy` for fuzzy matching.

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -36,6 +36,7 @@
           input-insert-string
           input-point
           input-refine-prefix
+          input-refine-fuzzy
           input-refine-regexp
           input-substring
           input-validate-region
@@ -134,6 +135,16 @@ and complete the input by mutating it."))
                         (string= str elt
                                  :end1 (length str)
                                  :end2 (length str))))
+                 candidates))
+
+(defun input-refine-fuzzy (str candidates)
+  (remove-if-not (lambda (elt)
+                   (when (listp elt)
+                     (setf elt (car elt)))
+                   (and (<= (length str) (length elt))
+                        (every (lambda (part)
+                                 (search part elt))
+                               (uiop:split-string str))))
                  candidates))
 
 (defun input-refine-regexp (str candidates)


### PR DESCRIPTION
This adds a new input completion function that's neither regexp nor prefix—something in between, rather. 