### PR TITLE
Fix frame splitting calculation

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -564,7 +564,7 @@ T (default) then also focus the frame."
 If ratio is an integer return the number of pixel desired."
   (if (integerp ratio)
       ratio
-      (* length ratio)))
+      (round (* length ratio))))
 
 (defun funcall-on-leaf (tree leaf fn)
   "Return a new tree with LEAF replaced with the result of calling FN on LEAF."


### PR DESCRIPTION
When splitting frames on certain resolutions the frame is not split to a natural number:

![split-error](https://github.com/stumpwm/stumpwm/assets/86064861/ebde9fa8-94b5-421c-802d-233061be0150)

When a new window is created in the "bugged" split, stumpwm crashes.

To solve this i round the ratio multiplication done in the `ratio-or-pixel` function that is called when this happens. For me this seems to solve the problem.