### PR TITLE
patch copy-frame-tree to not expect a structure

### DIFF
--- a/tile-group.lisp
+++ b/tile-group.lisp
@@ -475,7 +475,7 @@ T (default) then also focus the frame."
   "Return a copy of the frame tree."
   (cond ((null tree) tree)
         ((typep tree 'frame)
-         (copy-structure tree))
+         (copy-frame tree))
         (t
          (mapcar #'copy-frame-tree tree))))
 


### PR DESCRIPTION
To make minor modes function with frames as a scope object, they had to be implemented as classes and not structures. The function copy-frame-tree calls copy-structure on a frame and was overlooked when this change was made, in part because no other part of stumpwm appears to call this function and so it has no impact on uncustomized stumpwm. This patch addresses this and changes the call to copy-frame instead of copy-structure. 