### PR TITLE
Require :uiop at make-image.lisp

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -1,3 +1,5 @@
+(require :uiop)
+
 (in-package #:cl-user)
 
 (let* ((expected-warnings


### PR DESCRIPTION
`make-image.lisp` can be run via `--script` at SBCL and the last one do not load ASDF and UIOP by default on this way.

That leads to an error like:
```
Package UIOP/LISP-BUILD does not exist.
```