### PR TITLE
remove number zero from group number map

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -771,7 +771,7 @@ exist, in which case they go into the current group.")
 (defvar *window-number-map* "0123456789"
   "Set this to a string to remap the window numbers to something more convenient.")
 
-(defvar *group-number-map* "1234567890"
+(defvar *group-number-map* "123456789"
   "Set this to a string to remap the group numbers to something more convenient.")
 
 (defvar *frame-number-map* "0123456789abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
This fixes issue #1180. 

StumpWM expects group numbers to grow incrementally and for their numbers to match the *group-number-map*. However because group numbers start from one the tenth group created gets the group number ten, while the *group-number-map* and associated function group-map-number report its number as zero, because zero is the tenth character in that string. Removing the zero from the string removes this inconsistency, as any group-map-number that isnt present in the string is returned via princ-to-string.