### PR TITLE
Patch minor mode scopes

### DIFF
--- a/minor-modes.lisp
+++ b/minor-modes.lisp
@@ -761,10 +761,13 @@ DESIGNATOR in the minor mode scope hash table."
   (defun scope-current-object-function (designator)
     (cadr (get-scope designator)))
   (defun scope-all-objects-function (designator)
-    (let ((type (first (get-scope designator))))
+    (let* ((scope (get-scope designator))
+           (type (first scope))
+           (filter (third scope)))
       (lambda ()
         (loop for object in (list-mode-objects nil)
-              when (typep object type)
+              when (and (typep object type)
+                        (typep object filter))
                 collect object))))
   (defun find-active-global-minor-modes-for-scope (scope)
     (loop for mode in *active-global-minor-modes*
@@ -878,12 +881,9 @@ provided."
 (define-minor-mode-scope (:dynamic-group dynamic-group)
   (current-group))
 
-(defun %manual-tiling-group-p (g)
-  (and (typep g 'tile-group)
-       (not (typep g 'dynamic-group))))
-
-(define-minor-mode-scope (:manual-tiling-group tile-group
-                                               (satisfies %manual-tiling-group-p))
+(define-minor-mode-scope (:manual-tiling-group
+                          tile-group
+                          (and tile-group (not dynamic-group)))
   (current-group))
 
 (define-minor-mode-scope (:frame frame)
@@ -894,12 +894,8 @@ provided."
 (define-minor-mode-scope (:head head)
   (current-head))
 
-(defun %frame-but-not-head (o)
-  (and (typep o 'frame)
-       (not (typep o 'head))))
-
 (define-descended-minor-mode-scope :frame-excluding-head :frame
-  :filter-type (satisfies %frame-but-not-head))
+  :filter-type (and frame (not head)))
 
 (define-minor-mode-scope (:window window)
   (current-window))

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2542,7 +2542,7 @@ minor mode scoped to @code{:GROUP} cant be a subclass of a minor mode
 scoped to @code{:WINDOW}, for example. However there is a way to
 override this by explicitly stating that two otherwise incompatible
 scopes are compatible. This is done by defining methods for the generic
-function @code{VALIDATE-SUPERSCOPE} which dispatch upon the scope
+function @code{VALIDATE-SUPERSCOPE} which specialize upon the scope
 designators. Such methods should return at least one value, indicating
 if the superscope is a valid parent of the scope. If multiple values are
 returned, the second value must indicate whether the superscope is an
@@ -2563,6 +2563,20 @@ used to determine what minor modes should be mixed into an object when
 it is created. For this reason it is important when defining a minor
 mode or minor mode scope to understand the type hierarchy. It may also
 be in the programmers best interests to define an accompanying type.
+
+Below is an example of a minor mode scope definition that descends from
+the @code{:WINDOW} scope, and is restricted to only firefox
+windows. This would be used to implement a minor mode that only gets
+mixed in to firefox windows, for example to implement key rebinding.
+
+@verbatim
+(defun %firefox-window-p (w)
+  (and (typep w 'window)
+       (string-equal (window-class window) "Firefox")))
+
+(define-descended-minor-mode-scope :firefox-window :window
+  :filter-type (satisfies %firefox-window-p))
+@end verbatim
 
 The following scopes are predefined:
 @itemize


### PR DESCRIPTION
This PR patches minor mode scopes to utilize the filter type when returning all scope objects for a given scope. Additionally it makes changes to the manual to add an example of defining minor mode scopes.  