### PR TITLE
Ignore the hidden (dot-prefixed) executables in PATH.

### DIFF
--- a/user.lisp
+++ b/user.lisp
@@ -118,7 +118,8 @@ seperated by a colon."
            nconc (loop for file in (directory (merge-pathnames (make-pathname :name :wild :type :wild) dir)
                                               :resolve-symlinks nil)
                        for namestring = (file-namestring file)
-                       when (pathname-is-executable-p file)
+                       when (and (pathname-is-executable-p file)
+                                 (not (uiop:string-prefix-p #\. namestring)))
                          collect (if full-path
                                      (namestring file)
                                      namestring))))


### PR DESCRIPTION
This makes the `.`-prefixed executables hidden in `run-shell-command`/`exec`. Guix (I'm sure, among many other package managers) generates dot-prefixed executables when wrapping things into proper environments. So there are lots of `.program-real` types of executables that `exec` lists. 

This patch ignores the hidden executables by checking if they are prefixed with a dot. Makes things much clearer, at least on Guix.