### PR TITLE
Update stumpwm.texi.in

### DIFF
--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -162,6 +162,7 @@ Windows
 * Programming With Windows::
 * Rule Based Window Placement::
 * Window Selection Expressions::
+
 Frames
 
 * Interactively Resizing Frames::


### PR DESCRIPTION
Add blank line before `Frames` so that the generated documentation properly separates sections 6 (Windows) and 7 (Frames).