### PR TITLE
Better default data dir

### DIFF
--- a/debug.lisp
+++ b/debug.lisp
@@ -68,20 +68,3 @@ do:
         *standard-output* *redirect-stream*
         *trace-output*    *redirect-stream*
         *debug-stream*    *redirect-stream*))
-
-(defun rotate-log ()
-  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*))
-        (bkp-log-filename (merge-pathnames "stumpwm.log.1" *data-dir*)))
-    (when (probe-file log-filename)
-      (rename-file log-filename bkp-log-filename))))
-
-(defun open-log ()
-  (rotate-log)
-  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*)))
-    (setf *debug-stream* (open log-filename :direction :output
-                                            :if-exists :supersede
-                                            :if-does-not-exist :create))))
-(defun close-log ()
-  (when (boundp '*debug-stream*)
-    (close *debug-stream*)
-    (makunbound '*debug-stream*)))

--- a/debug.lisp
+++ b/debug.lisp
@@ -70,17 +70,14 @@ do:
         *debug-stream*    *redirect-stream*))
 
 (defun rotate-log ()
-  (let ((log-filename (merge-pathnames "stumpwm.log"
-                                      (data-dir)))
-        (bkp-log-filename (merge-pathnames "stumpwm.log.1"
-                                          (data-dir))))
+  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*))
+        (bkp-log-filename (merge-pathnames "stumpwm.log.1" *data-dir*)))
     (when (probe-file log-filename)
       (rename-file log-filename bkp-log-filename))))
 
 (defun open-log ()
   (rotate-log)
-  (let ((log-filename (merge-pathnames "stumpwm.log"
-                                      (data-dir))))
+  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*)))
     (setf *debug-stream* (open log-filename :direction :output
                                             :if-exists :supersede
                                             :if-does-not-exist :create))))

--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1566,7 +1566,24 @@ of :error."
      (ensure-data-dir)
      (with-open-file (,s ,(merge-pathnames file *data-dir*)
                          ,@keys)
-       ,@body)))
+                     ,@body)))
+
+(defun rotate-log ()
+  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*))
+        (bkp-log-filename (merge-pathnames "stumpwm.log.1" *data-dir*)))
+    (when (probe-file log-filename)
+      (rename-file log-filename bkp-log-filename))))
+
+(defun open-log ()
+  (rotate-log)
+  (let ((log-filename (merge-pathnames "stumpwm.log" *data-dir*)))
+    (setf *debug-stream* (open log-filename :direction :output
+                                            :if-exists :supersede
+                                            :if-does-not-exist :create))))
+(defun close-log ()
+  (when (boundp '*debug-stream*)
+    (close *debug-stream*)
+    (makunbound '*debug-stream*)))
 
 (defmacro move-to-head (list elt)
    "Move the specified element in in LIST to the head of the list."

--- a/stumpwm.lisp
+++ b/stumpwm.lisp
@@ -223,12 +223,6 @@ further up. "
             :local)
            (t :internet)))))
 
-(defun ensure-data-dir ()
-  (ensure-directories-exist (data-dir) :mode #o700))
-
-(defun data-dir ()
-  (merge-pathnames ".stumpwm.d/" (user-homedir-pathname)))
-
 (defun close-resources ()
   (xlib:close-display *display*)
   (close-log))
@@ -322,9 +316,7 @@ further up. "
     (dformat 0 "SIGHUP received: forcing immediate restart of stumpwm~%") ;; debug level 0 to "force" logging
     (force-stumpwm-restart))
   (let ((*in-main-thread* t))
-    (setf *data-dir*
-          (make-pathname :directory (append (pathname-directory (user-homedir-pathname))
-                                            (list ".stumpwm.d"))))
+    (setf *data-dir* (default-data-dir))
     (init-load-path *module-dir*)
     (loop
       (let ((ret (catch :top-level


### PR DESCRIPTION
Set the *data-dir* to directory where the user configuration file is instead of always using "~/.stumpwm.d". 