### PR TITLE
Reset uiop/asdf after load an image

### DIFF
--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -50,6 +50,16 @@
     (uiop:symbol-call '#:asdf '#:register-immutable-system system-name)))
 
 (sb-ext:save-lisp-and-die "stumpwm" :toplevel (lambda ()
+                                                ;; stumpwm migth be build in fake enviroment, so use uiop:restore-image
+                                                ;; to compute real uiop:*user-cache* on that user
+                                                (uiop:restore-image)
+                                                ;; and clean asdf configuration to avoid some cached paths as well
+                                                (asdf:clear-configuration)
+                                                (asdf:clear-output-translations)
+                                                (asdf:initialize-output-translations
+                                                 '(:output-translations
+                                                   :enable-user-cache
+                                                   :ignore-inherited-configuration))
                                                 ;; asdf requires sbcl_home to be set, so set it to the value when the image was built
                                                 (alexandria:when-let ((home #.(sb-ext:posix-getenv "SBCL_HOME")))
                                                   (sb-posix:putenv (format nil "SBCL_HOME=~A" home)))

--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -50,17 +50,17 @@
     (uiop:symbol-call '#:asdf '#:register-immutable-system system-name)))
 
 (sb-ext:save-lisp-and-die "stumpwm" :toplevel (lambda ()
-                                                ;; stumpwm migth be build in fake enviroment, so use uiop:restore-image
-                                                ;; to compute real uiop:*user-cache* on that user
+                                                ;; stumpwm might be built in a fake enviroment, so use uiop:restore-image
+                                                ;; to compute the real uiop:*user-cache* for that user
                                                 (uiop:restore-image)
-                                                ;; and clean asdf configuration to avoid some cached paths as well
+                                                ;; and clean the asdf configuration to avoid some cached paths as well
                                                 (asdf:clear-configuration)
                                                 (asdf:clear-output-translations)
                                                 (asdf:initialize-output-translations
                                                  '(:output-translations
                                                    :enable-user-cache
                                                    :ignore-inherited-configuration))
-                                                ;; asdf requires sbcl_home to be set, so set it to the value when the image was built
+                                                ;; asdf requires SBCL_HOME to be set, so set it to the value when the image was built
                                                 (alexandria:when-let ((home #.(sb-ext:posix-getenv "SBCL_HOME")))
                                                   (sb-posix:putenv (format nil "SBCL_HOME=~A" home)))
                                                 (stumpwm:stumpwm)


### PR DESCRIPTION
When stumpwm is built in some sort of fake environment the resulted image contains cached path to that fake enviroment which migth broke quicklisp.

Here I call a standard callback which is used by uiop for :toplevel function, and, additionally clear asdf configuration from build system and reset it.