### PR TITLE
Revert "Supporting reproducible builds."

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AC_SUBST(MODULE_DIR)
 AC_SUBST(LISP_PROGRAM)
 AC_SUBST(LISP)
 AC_SUBST(COMPRESSION)
-AC_SUBST(REPRODUCIBLE)
 AC_SUBST(STUMPWM_ASDF_DIR)
 
 # Checks for programs.
@@ -22,11 +21,6 @@ AC_ARG_ENABLE(compression,
               [  --enable-compression    use SBCL's core compression feature if available],
               COMPRESSION="t",
               COMPRESSION="nil")
-
-AC_ARG_ENABLE(reproducible,
-              [  --enable-reproducible   create a reproducible build (doesn't include compilation date and time)],
-              REPRODUCIBLE="t",
-              REPRODUCIBLE="nil")
 
 STUMPWM_ASDF_DIR="`pwd`"
 
@@ -68,6 +62,4 @@ AC_OUTPUT
 AC_CONFIG_FILES([make-image.lisp])
 AC_OUTPUT
 AC_CONFIG_FILES([load-stumpwm.lisp])
-AC_OUTPUT
-AC_CONFIG_FILES([version.lisp])
 AC_OUTPUT

--- a/version.lisp
+++ b/version.lisp
@@ -27,18 +27,18 @@
 (export '(*version* version))
 
 (defparameter *version*
-  #.(let* ((sys (asdf:find-system :stumpwm))
-           (git-dir (probe-path (asdf:system-relative-pathname sys ".git")))
-           (ver (if git-dir
-                  (string-trim '(#\Newline)
-                    (run-shell-command
-                      (format nil "GIT_DIR=~a git describe --tags" git-dir) t))
-                  (asdf:component-version sys))))
-      (if @REPRODUCIBLE@
-        (concatenate 'string ver " Reproducible Build")
-        (concatenate 'string ver " Compiled On " (format-expand
-                                                   *time-format-string-alist*
-                                                   *time-format-string-default*)))))
+  #.(concatenate
+     'string
+     (let* ((sys (asdf:find-system :stumpwm))
+            (git-dir (probe-path (asdf:system-relative-pathname sys ".git"))))
+       (if git-dir
+           (string-trim '(#\Newline)
+                        (run-shell-command
+                         (format nil "GIT_DIR=~a git describe --tags" git-dir) t))
+           (asdf:component-version sys)))
+  " Compiled On "
+  (format-expand *time-format-string-alist*
+                 *time-format-string-default*)))
 
 (defcommand version () ()
 "Print version information and compilation date."


### PR DESCRIPTION
Reverts stumpwm/stumpwm#1199

Need to re-work version.lisp so quicklisp can load without requiring version.lisp to be built.