### PR TITLE
Supporting reproducible builds (another attempt).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_SUBST(MODULE_DIR)
 AC_SUBST(LISP_PROGRAM)
 AC_SUBST(LISP)
 AC_SUBST(COMPRESSION)
+AC_SUBST(REPRODUCIBLE)
 AC_SUBST(STUMPWM_ASDF_DIR)
 
 # Checks for programs.
@@ -21,6 +22,11 @@ AC_ARG_ENABLE(compression,
               [  --enable-compression    use SBCL's core compression feature if available],
               COMPRESSION="t",
               COMPRESSION="nil")
+
+AC_ARG_ENABLE(reproducible,
+              [  --enable-reproducible   create a reproducible build (doesn't include compilation date and time)],
+              REPRODUCIBLE="t",
+              REPRODUCIBLE="nil")
 
 STUMPWM_ASDF_DIR="`pwd`"
 

--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -42,6 +42,18 @@
 
 (stumpwm:set-module-dir "@MODULE_DIR@")
 
+;; To support reproducible (compiled) builds we modify the version string
+;; to exclude the timestamp. This could be done in version.lisp as well but
+;; it hinders StumpWM users who do not compile the manager.
+
+(when @REPRODUCIBLE@
+  (let* ((ver stumpwm:*version*)
+         (idx (search "compiled on" ver :test #'char-equal)))
+    (setf stumpwm:*version* (concatenate
+                              'string
+                              (subseq ver 0 idx)
+                              "Reproducible Build"))))
+
 (when (uiop:version<= "3.1.5" (asdf:asdf-version))
   ;; We register StumpWM and its dependencies as immutable, to stop ASDF from
   ;; looking for their source code when loading modules.


### PR DESCRIPTION
This one doesn't turn `version.lisp` into a template.

Addresses #1215, #1211. 