### PR TITLE
Fix building without quick-lisp

### DIFF
--- a/load-stumpwm.lisp.in
+++ b/load-stumpwm.lisp.in
@@ -5,5 +5,9 @@
 
 (require 'asdf)
 
-(asdf:load-asd #p"@STUMPWM_ASDF_DIR@/stumpwm.asd")
+(asdf:initialize-source-registry
+ '(:source-registry
+   (:directory "@STUMPWM_ASDF_DIR@")
+   :inherit-configuration))
+
 (asdf:load-system "stumpwm")


### PR DESCRIPTION
Before 24.11 it was possible to build stumpwm without quick-lisp, by adding a symlink to a few .asd into it's root.

https://github.com/stumpwm/stumpwm/pull/1194 brokes it, and here I had recovered that part which is needed to make an update for OpenBSD port at least.