### PR TITLE
stumpwm.asd: Bump :version to 24.11

### DIFF
--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -7,7 +7,7 @@
 (defsystem :stumpwm
   :name "StumpWM"
   :author "Shawn Betts <sabetts@vcn.bc.ca>"
-  :version "23.11"
+  :version "24.11"
   :maintainer "David Bjergaard <dbjergaard@gmail.com>"
   ;; :license "GNU General Public License"
   :description "A tiling, keyboard driven window manager"


### PR DESCRIPTION
This was apparently forgotten when tagging 24.11 which means the `version` command would still show `23.11` when not building from git (as is the case with the nixpkgs package).

Is there some script / task for tagging releases, perhaps? Then we could automate the bump to prevent it from happening again in the future.