### PR TITLE
Add a setf function for window-property, also FIX issue #997

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,3 +78,4 @@ Toby Worland        toby dot worland at gmail.com
 Tomasz Jeneralczyk  silicius at schwi dot pl
 Jeremiah LaRocco    jeremiah_larocco at fastmail com
 Axel Svensson       mail at axelsvensson dot com
+Luminous99          ahmetakbash8 at gmail dot com

--- a/keytrans.lisp
+++ b/keytrans.lisp
@@ -102,8 +102,6 @@ calling KEYSYM->KEYSYM-NAME."
 (define-keysym-name "|" "bar")
 (define-keysym-name "}" "braceright")
 (define-keysym-name "~" "asciitilde")
-(define-keysym-name "<" "quoteleft")
-(define-keysym-name ">" "quoteright")
 (define-keysym-name "«" "guillemotleft")
 (define-keysym-name "»" "guillemotright")
 (define-keysym-name "À" "Agrave")

--- a/window.lisp
+++ b/window.lisp
@@ -39,7 +39,7 @@
     window-gravity window-group window-number window-parent window-title
     window-user-title window-class window-type window-res window-role
     window-unmap-ignores window-state window-normal-hints window-marked
-    window-plist window-fullscreen window-screen
+    window-plist window-fullscreen window-screen window-property
     ;; Window utilities
     update-configuration no-focus
     ;; Window management API
@@ -499,6 +499,15 @@ _NET_WM_STATE_DEMANDS_ATTENTION set"
 
 (defun window-property (window prop)
   (xlib:get-property (window-xwin window) prop))
+
+(defun (setf window-property) (value window property)
+  "Set the PROPERTY of WINDOW to VALUE. VALUE may be an INTEGER, a STRING or a SYMBOL."
+  (multiple-value-bind (value type format)
+      (etypecase value
+        (integer (values (list value) :integer 32))
+        (string (values (map 'vector #'char-code value) :string 8))
+        (symbol (values (map 'vector #'char-code (symbol-name value)) :string 8)))
+    (xlib:change-property (window-xwin window) property value type format)))
 
 (defun find-wm-state (xwin state)
   (find (xlib:find-atom *display* state) (xlib:get-property xwin :_NET_WM_STATE) :test #'=))


### PR DESCRIPTION
As far as i could find quoteleft and quoteright have no relation with the symbols < and > , the bepo layout can output ` and ’ which are already defined as grave and apostrophe.