### PR TITLE
Use non-canonical paths when resolving default data dir

### DIFF
--- a/primitives.lisp
+++ b/primitives.lisp
@@ -1544,9 +1544,12 @@ sync-all-frame-windows to see the change.")
 (defun default-data-dir ()
   "Return the default data dir pathname based on the loaded StumpWM configuration file."
   (let ((rc-file (or
-                  (probe-file (merge-pathnames #p".stumpwmrc" (user-homedir-pathname)))
-                  (probe-file (merge-pathnames #p".stumpwm.d/init.lisp" (user-homedir-pathname)))
-                  (probe-file (uiop:xdg-config-home #p"stumpwm/config")))))
+                  (let ((pathspec (merge-pathnames #p".stumpwmrc" (user-homedir-pathname))))
+                    (and (probe-file pathspec) pathspec))
+                  (let ((pathspec (merge-pathnames #p".stumpwm.d/init.lisp" (user-homedir-pathname))))
+                    (and (probe-file pathspec) pathspec))
+                  (let ((pathspec (uiop:xdg-config-home #p"stumpwm/config")))
+                    (and (probe-file pathspec) pathspec)))))
     (if rc-file
         (make-pathname :name nil :type nil :defaults rc-file)
         (merge-pathnames ".stumpwm.d/" (user-homedir-pathname)))))


### PR DESCRIPTION
Resolving the data dir path based on probe-file's canonical path lookup of pathspec breaks users that manage their StumpWM configuration through symlinked dotfiles. The data dir would incorrectly be set to wherever the root of the symlinked file is located on the file system. This may be a read only location on e.g. systems such as Guix and NixOS, or just some random location in the case of stow. StumpWM would then incorrectly treat this random location as its data directory. This patch ensures we operate on the pathspec argument and not the truename result from probe-file.

Fixes #1225