### PR TITLE
FIX issue #997

### DIFF
--- a/keytrans.lisp
+++ b/keytrans.lisp
@@ -102,8 +102,6 @@ calling KEYSYM->KEYSYM-NAME."
 (define-keysym-name "|" "bar")
 (define-keysym-name "}" "braceright")
 (define-keysym-name "~" "asciitilde")
-(define-keysym-name "<" "quoteleft")
-(define-keysym-name ">" "quoteright")
 (define-keysym-name "«" "guillemotleft")
 (define-keysym-name "»" "guillemotright")
 (define-keysym-name "À" "Agrave")


### PR DESCRIPTION
As far as i could find quoteleft and quoteright have no relation with the symbols < and > , the bepo layout can output ` and ’ which are already defined as grave and apostrophe.