### PR TITLE
Make find-mode-line-by-window find mode-lines with matching xwin ids

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -143,7 +143,10 @@ timer.")
   (find head *mode-lines* :key #'mode-line-head))
 
 (defun find-mode-line-by-window (xwin)
-  (find xwin *mode-lines* :key #'mode-line-window))
+  (find (xlib:window-id xwin) *mode-lines*
+        :key (lambda (ml)
+               (when-let ((win (mode-line-window ml)))
+                 (xlib:window-id win)))))
 
 (defun mode-line-gc (ml)
   (ccontext-gc (mode-line-cc ml)))


### PR DESCRIPTION
See https://github.com/polybar/polybar/issues/1853

The :destroy-notify handler is meant to destroy mode-line windows if the event applies to one. However, find-mode-line-by-window searched for a window object matching with eql rather than a window id. Since the event window would not eql the mode-line-window, find returned nil regardless of whether the window ids match, meaning that the mode-line window would not be destroyed.

This change uses window id as the key for find and searches for the id of the given window.

---

I've tested this change with polybar and a project of mine slothbar. Without it, manually calling `(destroy-mode-line (car *mode-lines*))` will have the same effect since it does what the event handler is trying to achieve.

Also, I haven't tried to check whether this is in any way related to https://github.com/stumpwm/stumpwm/issues/1212. I will look into it if I find time.