### PR TITLE
Update contribution guidelines and add issue references

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ that your contribution gets merged in a timely manner:
   * Export symbols from packages that aren't widely useful (many times
     a little more thought will reveal how to implement your internal
     change without having to export/break encapsulation)
-  * Make stylistic changes that suit your coding style/way of thinking 
+  * Make stylistic changes that suit your coding style/way of thinking
+  * Include OS or system-specific code (See [#1251](https://github.com/stumpwm/stumpwm/issues/1252)).
 
 If you aren't a lisp hacker, you can contribute in the form of
 documenting and organizing the wiki. There's a lot of information
@@ -180,7 +181,7 @@ StumpWM universe (in no particular order):
 * Wallpapers! (support pulling from remote sources, changing based on
   timers, and other hacky features)
 * Shutdown, restart, suspend, and hibernate functions that don't
-  require root access
+  require root access. See [#1252](https://github.com/stumpwm/stumpwm/issues/1252), [#1251](https://github.com/stumpwm/stumpwm/issues/1251)
 * Revamped, mouse-friendly mode-line. 
   * Dynamically trim window titles to fit them all on the mode-line
   * Split the mode-line into multiple cells for containing different information


### PR DESCRIPTION
Mention that system-specific code isn't allowed, and add links to related issues.

Adding these should prevent things like the discussion in #1241 from being iterated on again; we don't want new contributors to find their code being rejected because of a rule they didn't know.