### PR TITLE
Revised the poweroff functions from the prior PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ StumpWM universe (in no particular order):
   is involved)
 * Wallpapers! (support pulling from remote sources, changing based on
   timers, and other hacky features)
-* Shutdown, restart, suspend, and hibernate functions that don't
-  require root access
 * Revamped, mouse-friendly mode-line. 
   * Support fixed number of chars for window titles
   * Dynamically trim window titles to fit them all on the mode-line

--- a/make-image.lisp.in
+++ b/make-image.lisp.in
@@ -3,7 +3,7 @@
 (in-package #:cl-user)
 
 (let* ((expected-warnings
-        '((sb-kernel:redefinition-with-defgeneric . 1)
+        '((sb-kernel:redefinition-with-defgeneric . 2)
           (sb-kernel:redefinition-with-defun . 13)
           (sb-kernel:redefinition-with-defmethod . 1)
           (uiop/lisp-build:compile-warned-warning . 1)

--- a/poweroff.lisp
+++ b/poweroff.lisp
@@ -1,0 +1,80 @@
+(in-package :stumpwm)
+
+(export '(shutdown cancel-shutdown reboot halt suspend hibernate
+          *alternative-suspend* *alternative-hibernate*))
+
+(defun path-directories (&optional (name "PATH"))
+  (let ((path-dirs (uiop:split-string (uiop:getenv name) :separator '(#\:))))
+    (mapcar (lambda (x) (uiop:ensure-pathname x :ensure-directory t)) path-dirs)))
+
+(defun file-in-path-p (name)
+  (dolist (dir (path-directories))
+    (when (probe-file (merge-pathnames dir name))
+      (return dir))))
+
+(defcommand shutdown (&optional (now nil) (time 30)) ((:y-or-n "Now? "))
+  "Poweroff the system. If NOW is not NIL poweroff immediately, otherwise asks for a date."
+  #+(or bsd linux)
+  (let* ((time (if (and %interactivep% (not now))
+                   (read-one-line (current-screen) "When? ")
+                   (if (and %interactivep% now) "" time)))
+         (cmd (format nil "shutdown ~a ~a" time (if now "now" ""))))
+    (run-shell-command cmd)))
+
+(defcommand cancel-shutdown () ()
+  "Cancels any shutdown process."
+  #+(or bsd linux) (run-shell-command (format nil "shutdown -c")))
+
+(defcommand reboot (&optional (now nil) (time 30)) ((:y-or-n "Now? "))
+  "Reboot the system. If NOW is not NIL reboot immediately, otherwise asks for a date."
+  #+(or bsd linux)
+  (let* ((time (if (and %interactivep% (not now))
+                   (read-one-line (current-screen) "When? ")
+                   (if (and %interactivep% now) "" time)))
+         (cmd (format nil "shutdown -r ~a ~a" time (if now "now" ""))))
+    (run-shell-command cmd)))
+
+(defcommand halt (&optional (now nil) (time 30)) ((:y-or-n "Now? "))
+  "Halt the system. If NOW is not NIL halt immediately, otherwise asks for a date."
+  #+(or bsd linux)
+  (let* ((time (if (and %interactivep% (not now))
+                   (read-one-line (current-screen) "When? ")
+                   (if (and %interactivep% now) "" time)))
+         (cmd (format nil "shutdown -H ~a ~a" time (if now "now" ""))))
+    (run-shell-command cmd)))
+
+(declaim (type (or function string null) *alternative-suspend*))
+(defvar *alternative-suspend* nil
+  "Alternative shell command or function for the suspend function.")
+
+(declaim (type (or function string null) *alternative-hibernate*))
+(defvar *alternative-hibernate* nil
+  "Alternative shell command or function used for the hibernate function.")
+
+(flet ((call-alternative (alt)
+         (cond
+           ((stringp alt) (run-shell-command alt))
+           ((functionp alt) (funcall alt)))))
+
+  (defcommand suspend () ()
+    "Suspends the system. For unsupported systems set *ALTERNATIVE-SUSPEND* to a shell command or function of your choice."
+    #+linux (cond
+              (*alternative-suspend* (call-alternative *alternative-suspend*))
+              ((file-in-path-p "systemctl")
+               (run-shell-command "systemctl suspend"))
+              (t (error "Suspend is not implemented for this system.")))
+    #+bsd (if *alternative-suspend*
+              (call-alternative *alternative-suspend*)
+              (error "Suspend is not implemented for this system.")))
+
+  (defcommand hibernate () ()
+    "Hibernates the system. For unsupported systems set *ALTERNATIVE-HIBERNATE* to a shell command or function of your choice."
+    #+linux (cond
+              (*alternative-hibernate* (call-alternative *alternative-hibernate*))
+              ((file-in-path-p "systemctl")
+               (run-shell-command "systemctl hibernate"))
+              (t (error "Hibernate is not implemented for this system.")))
+    #+bsd (if *alternative-hibernate*
+              (call-alternative *alternative-hibernate*)
+              (error "Hibernate is not implemented for this system."))))
+

--- a/poweroff.lisp
+++ b/poweroff.lisp
@@ -68,7 +68,7 @@
                      (if (search "mem" (read-line state) :test #'string=)
                          (write-string "mem" state)
                          (error "Suspend is not implemented for this system.")))
-                   (error "Suspend is not implemented for this system."))))
+                   (message "^1Your StumpWM process does not have Root privileges to run suspend.^*~%Effective user id: ~A" (sb-posix:geteuid)))))
     #+bsd (if *alternative-suspend*
               (call-alternative *alternative-suspend*)
               (error "Suspend is not implemented for this system.")))
@@ -87,7 +87,7 @@
                            (write-string "platform" disk)
                            (write-string "disk" state))
                          (error "Hibernate is not implemented for this system.")))
-                   (error "Hibernate is not implemented for this system."))))
+                   (message "^1Your StumpWM process does not have Root privileges to run hibernate.^*~%Effective user id: ~A" (sb-posix:geteuid)))))
     #+bsd (if *alternative-hibernate*
               (call-alternative *alternative-hibernate*)
               (error "Hibernate is not implemented for this system."))))

--- a/poweroff.lisp
+++ b/poweroff.lisp
@@ -2,8 +2,6 @@
 
 (export '(shutdown cancel-shutdown reboot halt suspend hibernate))
 
-(import '(dbus:list-names dbus:with-introspected-object dbus:with-open-bus dbus:system-server-addresses))
-
 (defcommand shutdown (&optional (now nil) (time 30)) ((:y-or-n "Now? "))
   "Poweroff the system. If NOW is not NIL poweroff immediately, otherwise asks for a date."
   #+(or bsd linux)
@@ -39,10 +37,10 @@
 (defcommand suspend () ()
   "Suspends the system."
   #+linux
-  (with-open-bus (bus (system-server-addresses))
+  (dbus:with-open-bus (bus (dbus:system-server-addresses))
     (cond
-      ((find "org.freedesktop.login1" (list-names bus) :test #'string=)
-       (with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
+      ((find "org.freedesktop.login1" (dbus:list-names bus) :test #'string=)
+       (dbus:with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
          (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanSuspend"))
              (login "org.freedesktop.login1.Manager" "Suspend" nil)
              (message "^1ERROR:~%Suspend is not available on your system.^*"))))
@@ -54,9 +52,9 @@
       (t
        (message "^1ERROR:~%Suspend is not available on your system.^*"))))
   #+bsd
-  (with-open-bus (bus (system-server-addresses))
+  (dbus:with-open-bus (bus (dbus:system-server-addresses))
     (if (find "org.freedesktop.ConsoleKit" (list-names bus) :test #'string=)
-        (with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
+        (dbus:with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
           (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanSuspend"))
               (login "org.freedesktop.ConsoleKit.Manager" "Suspend" nil)
               (message "^1ERROR:~%Suspend is not available on your system.^*")))
@@ -65,10 +63,10 @@
 (defcommand hibernate () ()
   "Hibernates the system."
   #+linux
-  (with-open-bus (bus (system-server-addresses))
+  (dbus:with-open-bus (bus (dbus:system-server-addresses))
     (cond
-      ((find "org.freedesktop.login1" (list-names bus) :test #'string=)
-       (with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
+      ((find "org.freedesktop.login1" (dbus:list-names bus) :test #'string=)
+       (dbus:with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
          (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanHibernate"))
              (login "org.freedesktop.login1.Manager" "Hibernate" nil)
              (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
@@ -82,9 +80,9 @@
       (t
        (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
   #+bsd
-  (with-open-bus (bus (system-server-addresses))
+  (dbus:with-open-bus (bus (dbus:system-server-addresses))
     (if (find "org.freedesktop.ConsoleKit" (list-names bus) :test #'string=)
-        (with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
+        (dbus:with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
           (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanHibernate"))
               (login "org.freedesktop.ConsoleKit.Manager" "Hibernate" nil)
               (message "^1ERROR:~%Hibernate is not available on your system.^*")))

--- a/poweroff.lisp
+++ b/poweroff.lisp
@@ -1,16 +1,8 @@
 (in-package :stumpwm)
 
-(export '(shutdown cancel-shutdown reboot halt suspend hibernate
-          *alternative-suspend* *alternative-hibernate*))
+(export '(shutdown cancel-shutdown reboot halt suspend hibernate))
 
-(defun path-directories (&optional (name "PATH"))
-  (let ((path-dirs (uiop:split-string (uiop:getenv name) :separator '(#\:))))
-    (mapcar (lambda (x) (uiop:ensure-pathname x :ensure-directory t)) path-dirs)))
-
-(defun file-in-path-p (name)
-  (dolist (dir (path-directories))
-    (when (probe-file (merge-pathnames dir name))
-      (return dir))))
+(import '(dbus:list-names dbus:with-introspected-object dbus:with-open-bus dbus:system-server-addresses))
 
 (defcommand shutdown (&optional (now nil) (time 30)) ((:y-or-n "Now? "))
   "Poweroff the system. If NOW is not NIL poweroff immediately, otherwise asks for a date."
@@ -44,51 +36,57 @@
          (cmd (format nil "shutdown -H ~a ~a" time (if now "now" ""))))
     (run-shell-command cmd)))
 
-(declaim (type (or function string null) *alternative-suspend*))
-(defvar *alternative-suspend* nil
-  "Alternative shell command or function for the suspend function.")
+(defcommand suspend () ()
+  "Suspends the system."
+  #+linux
+  (with-open-bus (bus (system-server-addresses))
+    (cond
+      ((find "org.freedesktop.login1" (list-names bus) :test #'string=)
+       (with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
+         (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanSuspend"))
+             (login "org.freedesktop.login1.Manager" "Suspend" nil)
+             (message "^1ERROR:~%Suspend is not available on your system.^*"))))
+      ((= 0 (sb-posix:geteuid))
+       (with-open-file (state #P"/sys/power/state" :direction :io :if-exists :supersede)
+         (if (search "mem" (read-line state) :test #'string=)
+             (write-string "mem" state)
+             (message "^1ERROR:~%Suspend is not available on your system.^*"))))
+      (t
+       (message "^1ERROR:~%Suspend is not available on your system.^*"))))
+  #+bsd
+  (with-open-bus (bus (system-server-addresses))
+    (if (find "org.freedesktop.ConsoleKit" (list-names bus) :test #'string=)
+        (with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
+          (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanSuspend"))
+              (login "org.freedesktop.ConsoleKit.Manager" "Suspend" nil)
+              (message "^1ERROR:~%Suspend is not available on your system.^*")))
+        (message "^1ERROR:~%Suspend is not available on your system.^*"))))
 
-(declaim (type (or function string null) *alternative-hibernate*))
-(defvar *alternative-hibernate* nil
-  "Alternative shell command or function used for the hibernate function.")
-
-(flet ((call-alternative (alt)
-         (typecase alt
-           (string (run-shell-command alt))
-           (function (funcall alt)))))
-  (defcommand suspend () ()
-    "Suspends the system. For unsupported systems set *ALTERNATIVE-SUSPEND* to a shell command or function of your choice."
-    #+linux (cond
-              (*alternative-suspend* (call-alternative *alternative-suspend*))
-              ((file-in-path-p "systemctl")
-               (run-shell-command "systemctl suspend"))
-              (t
-               (if (= 0 (sb-posix:geteuid))
-                   (with-open-file (state #P"/sys/power/state" :direction :io :if-exists :supersede)
-                     (if (search "mem" (read-line state) :test #'string=)
-                         (write-string "mem" state)
-                         (error "Suspend is not implemented for this system.")))
-                   (message "^1Your StumpWM process does not have Root privileges to run suspend.^*~%Effective user id: ~A" (sb-posix:geteuid)))))
-    #+bsd (if *alternative-suspend*
-              (call-alternative *alternative-suspend*)
-              (error "Suspend is not implemented for this system.")))
-
-  (defcommand hibernate () ()
-    "Hibernates the system. For unsupported systems set *ALTERNATIVE-HIBERNATE* to a shell command or function of your choice."
-    #+linux (cond
-              (*alternative-hibernate* (call-alternative *alternative-hibernate*))
-              ((file-in-path-p "systemctl")
-               (run-shell-command "systemctl hibernate"))
-              (t
-               (if (= 0 (sb-posix:geteuid))
-                   (with-open-file (state #P"/sys/power/state" :direction :io :if-exists :supersede)
-                     (if (search "disk" (read-line state) :test #'string=)
-                         (with-open-file (disk #P"/sys/power/disk" :direction :output :if-exists :supersede)
-                           (write-string "platform" disk)
-                           (write-string "disk" state))
-                         (error "Hibernate is not implemented for this system.")))
-                   (message "^1Your StumpWM process does not have Root privileges to run hibernate.^*~%Effective user id: ~A" (sb-posix:geteuid)))))
-    #+bsd (if *alternative-hibernate*
-              (call-alternative *alternative-hibernate*)
-              (error "Hibernate is not implemented for this system."))))
+(defcommand hibernate () ()
+  "Hibernates the system."
+  #+linux
+  (with-open-bus (bus (system-server-addresses))
+    (cond
+      ((find "org.freedesktop.login1" (list-names bus) :test #'string=)
+       (with-introspected-object (login bus "/org/freedesktop/login1" "org.freedesktop.login1")
+         (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanHibernate"))
+             (login "org.freedesktop.login1.Manager" "Hibernate" nil)
+             (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
+      ((= 0 (sb-posix:geteuid))
+       (with-open-file (state #P"/sys/power/state" :direction :io :if-exists :supersede)
+         (if (search "disk" (read-line state) :test #'string=)
+             (with-open-file (disk #P"/sys/power/disk" :direction :output :if-exists :supersede)
+               (write-string "platform" disk)
+               (write-string "disk" state))
+             (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
+      (t
+       (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
+  #+bsd
+  (with-open-bus (bus (system-server-addresses))
+    (if (find "org.freedesktop.ConsoleKit" (list-names bus) :test #'string=)
+        (with-introspected-object (login bus "/org/freedesktop/ConsoleKit" "org.freedesktop.ConsoleKit")
+          (if (string= "yes" (login "org.freedesktop.login1.Manager" "CanHibernate"))
+              (login "org.freedesktop.ConsoleKit.Manager" "Hibernate" nil)
+              (message "^1ERROR:~%Hibernate is not available on your system.^*")))
+        (message "^1ERROR:~%Hibernate is not available on your system.^*"))))
 

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -66,7 +66,8 @@
                (:file "replace-class")
                ;; keep this last so it always gets recompiled if
                ;; anything changes
-               (:file "version"))
+               (:file "version")
+               (:file "poweroff"))
   :in-order-to ((test-op (test-op "stumpwm/tests"))))
 
 (defsystem "stumpwm/build"

--- a/stumpwm.asd
+++ b/stumpwm.asd
@@ -17,7 +17,8 @@
                #:clx
                #:sb-posix
                #:sb-introspect
-               #:dynamic-mixins-swm)
+               #:dynamic-mixins-swm
+               #:dbus)
   :components ((:file "package")
                (:file "debug")
                (:file "primitives")

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2860,6 +2860,8 @@ The following is a list of commands that don't really fit in any other
 @@@ shutdown
 @@@ reboot
 @@@ halt
+### *alternative-suspend*
+### *alternative-hibernate*
 @@@ suspend
 @@@ hibernate
 

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2857,6 +2857,11 @@ The following is a list of commands that don't really fit in any other
 @@@ no-focus
 ### *record-last-msg-override*
 ### *toplevel-io*
+@@@ shutdown
+@@@ reboot
+@@@ halt
+@@@ suspend
+@@@ hibernate
 
 @menu
 * Menus::

--- a/stumpwm.texi.in
+++ b/stumpwm.texi.in
@@ -2860,8 +2860,6 @@ The following is a list of commands that don't really fit in any other
 @@@ shutdown
 @@@ reboot
 @@@ halt
-### *alternative-suspend*
-### *alternative-hibernate*
 @@@ suspend
 @@@ hibernate
 

--- a/tests/integration-tests/container-scripts/install-deps
+++ b/tests/integration-tests/container-scripts/install-deps
@@ -5,7 +5,7 @@ sbcl_version=2.2.10 # Synchronize with variable expected-sbcl-version-in-ci in .
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qy update
-apt-get -qy install curl build-essential autoconf git bzip2 make farbfeld netpbm procps x11-apps x11-xserver-utils xdotool xvfb xterm
+apt-get -qy install curl build-essential autoconf git bzip2 make farbfeld netpbm procps x11-apps x11-xserver-utils xdotool xvfb xterm libfixposix3 libfixposix-dev
 rm -rf /var/lib/apt/lists/*
 
 curl -LO https://downloads.sourceforge.net/project/sbcl/sbcl/${sbcl_version}/sbcl-${sbcl_version}-x86-64-linux-binary.tar.bz2
@@ -22,4 +22,4 @@ cd ..
 
 sbcl --load quicklisp.lisp --eval "(quicklisp-quickstart:install)"
 sbcl --load "/root/quicklisp/setup.lisp"  --eval "(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))"
-sbcl --eval "(progn (ql:quickload '(clx cl-ppcre alexandria fiasco)))"
+sbcl --eval "(progn (ql:quickload '(clx cl-ppcre alexandria fiasco dbus)))"


### PR DESCRIPTION
For Linux instead of systemctl only logind is used, if either logind or elogind is available it should work fine, if neither exists the kernel interface will be used as long as stumpwm runs as root  instead, otherwise an error message will be shown.

For BSD ConsoleKit2 is used and since the interface is identical with logind the logic is the same.

This is a good compromise from my point of view but i'd appreciate more suggestions.